### PR TITLE
Fix popover clipping when clicking menu bar icon

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -35,7 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Create popover
         popover = NSPopover()
-        popover.contentSize = NSSize(width: 320, height: 260)
+        popover.contentSize = NSSize(width: 320, height: 450)
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(rootView: UsageView(usageManager: usageManager))
 
@@ -813,6 +813,7 @@ struct UsageView: View {
     @State private var showingSettings: Bool = false
 
     var body: some View {
+        ScrollView {
         VStack(alignment: .leading, spacing: 16) {
             Text("Claude Usage")
                 .font(.headline)
@@ -1088,6 +1089,7 @@ struct UsageView: View {
             }
         }
         .padding()
+        }
         .frame(width: 360)
         .onAppear {
             // Load saved cookie when view appears


### PR DESCRIPTION
## Summary
- The popover's `contentSize` height (260px) was too small, causing the top of the widget to be cut off
- Increased popover height from 260 to 450 to fit default content
- Wrapped `UsageView` in a `ScrollView` so expandable sections (cookie input, settings) don't overflow

## Test plan
- [ ] Click menu bar icon — full widget should be visible including "Claude Usage" title at top
- [ ] Expand "Set Session Cookie" section — content should scroll
- [ ] Expand "Settings" section — content should scroll
- [ ] Test with both sections expanded simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)