### PR TITLE
Security: store session cookie in macOS Keychain instead of UserDefaults

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -10,7 +10,6 @@ struct KeychainHelper {
     static func save(_ value: String, forKey key: String) {
         guard let data = value.data(using: .utf8) else { return }
 
-        // Try updating an existing item first
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
@@ -20,10 +19,14 @@ struct KeychainHelper {
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
 
         if updateStatus == errSecItemNotFound {
-            // Item doesn't exist yet — add it
             var addQuery = query
             addQuery[kSecValueData] = data
-            SecItemAdd(addQuery as CFDictionary, nil)
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                NSLog("ClaudeUsage: Keychain add failed for key '\(key)': \(addStatus)")
+            }
+        } else if updateStatus != errSecSuccess {
+            NSLog("ClaudeUsage: Keychain update failed for key '\(key)': \(updateStatus)")
         }
     }
 
@@ -49,7 +52,10 @@ struct KeychainHelper {
             kSecAttrService: service,
             kSecAttrAccount: key
         ]
-        SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            NSLog("ClaudeUsage: Keychain delete failed for key '\(key)': \(status)")
+        }
     }
 }
 

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -392,8 +392,15 @@ class UsageManager: ObservableObject {
     }
 
     func loadSessionCookie() {
-        if let savedCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
-            sessionCookie = savedCookie
+        if let cookie = KeychainHelper.load(forKey: "session_cookie") {
+            sessionCookie = cookie
+        } else if let legacyCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
+            // Migrate from UserDefaults to Keychain on first launch after update
+            NSLog("ClaudeUsage: Migrating cookie from UserDefaults to Keychain")
+            KeychainHelper.save(legacyCookie, forKey: "session_cookie")
+            UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
+            UserDefaults.standard.synchronize()
+            sessionCookie = legacyCookie
         }
     }
 
@@ -424,16 +431,14 @@ class UsageManager: ObservableObject {
     func saveSessionCookie(_ cookie: String) {
         NSLog("ClaudeUsage: Saving cookie, length: \(cookie.count)")
         sessionCookie = cookie
-        UserDefaults.standard.set(cookie, forKey: "claude_session_cookie")
-        UserDefaults.standard.synchronize()
-        NSLog("ClaudeUsage: Cookie saved successfully")
+        KeychainHelper.save(cookie, forKey: "session_cookie")
+        NSLog("ClaudeUsage: Cookie saved to Keychain successfully")
     }
 
     func clearSessionCookie() {
         NSLog("ClaudeUsage: Clearing cookie")
         sessionCookie = ""
-        UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
-        UserDefaults.standard.synchronize()
+        KeychainHelper.delete(forKey: "session_cookie")
 
         // Reset all data
         sessionUsage = 0

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -23,10 +23,12 @@ struct KeychainHelper {
             addQuery[kSecValueData] = data
             let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
             if addStatus != errSecSuccess {
-                NSLog("ClaudeUsage: Keychain add failed for key '\(key)': \(addStatus)")
+                let addDesc = SecCopyErrorMessageString(addStatus, nil) as String? ?? "unknown"
+                NSLog("ClaudeUsage: Keychain add failed for key '\(key)': \(addStatus) – \(addDesc)")
             }
         } else if updateStatus != errSecSuccess {
-            NSLog("ClaudeUsage: Keychain update failed for key '\(key)': \(updateStatus)")
+            let updateDesc = SecCopyErrorMessageString(updateStatus, nil) as String? ?? "unknown"
+            NSLog("ClaudeUsage: Keychain update failed for key '\(key)': \(updateStatus) – \(updateDesc)")
         }
     }
 
@@ -54,7 +56,8 @@ struct KeychainHelper {
         ]
         let status = SecItemDelete(query as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {
-            NSLog("ClaudeUsage: Keychain delete failed for key '\(key)': \(status)")
+            let deleteDesc = SecCopyErrorMessageString(status, nil) as String? ?? "unknown"
+            NSLog("ClaudeUsage: Keychain delete failed for key '\(key)': \(status) – \(deleteDesc)")
         }
     }
 }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,56 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import Security
+
+struct KeychainHelper {
+    private static let service = "com.claude.usagebar"
+
+    static func save(_ value: String, forKey key: String) {
+        guard let data = value.data(using: .utf8) else { return }
+
+        // Try updating an existing item first
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key
+        ]
+        let attributes: [CFString: Any] = [kSecValueData: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            // Item doesn't exist yet — add it
+            var addQuery = query
+            addQuery[kSecValueData] = data
+            SecItemAdd(addQuery as CFDictionary, nil)
+        }
+    }
+
+    static func load(forKey key: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else { return nil }
+        return value
+    }
+
+    static func delete(forKey key: String) {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -7,8 +7,9 @@ import Security
 struct KeychainHelper {
     private static let service = "com.claude.usagebar"
 
-    static func save(_ value: String, forKey key: String) {
-        guard let data = value.data(using: .utf8) else { return }
+    @discardableResult
+    static func save(_ value: String, forKey key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
 
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -25,11 +26,14 @@ struct KeychainHelper {
             if addStatus != errSecSuccess {
                 let addDesc = SecCopyErrorMessageString(addStatus, nil) as String? ?? "unknown"
                 NSLog("ClaudeUsage: Keychain add failed for key '\(key)': \(addStatus) – \(addDesc)")
+                return false
             }
         } else if updateStatus != errSecSuccess {
             let updateDesc = SecCopyErrorMessageString(updateStatus, nil) as String? ?? "unknown"
             NSLog("ClaudeUsage: Keychain update failed for key '\(key)': \(updateStatus) – \(updateDesc)")
+            return false
         }
+        return true
     }
 
     static func load(forKey key: String) -> String? {
@@ -397,10 +401,13 @@ class UsageManager: ObservableObject {
         } else if let legacyCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
             // Migrate from UserDefaults to Keychain on first launch after update
             NSLog("ClaudeUsage: Migrating cookie from UserDefaults to Keychain")
-            KeychainHelper.save(legacyCookie, forKey: "session_cookie")
-            UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
-            UserDefaults.standard.synchronize()
-            sessionCookie = legacyCookie
+            if KeychainHelper.save(legacyCookie, forKey: "session_cookie") {
+                UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
+                sessionCookie = legacyCookie
+            } else {
+                NSLog("ClaudeUsage: Migration failed — cookie retained in UserDefaults")
+                sessionCookie = legacyCookie
+            }
         }
     }
 
@@ -431,8 +438,9 @@ class UsageManager: ObservableObject {
     func saveSessionCookie(_ cookie: String) {
         NSLog("ClaudeUsage: Saving cookie, length: \(cookie.count)")
         sessionCookie = cookie
-        KeychainHelper.save(cookie, forKey: "session_cookie")
-        NSLog("ClaudeUsage: Cookie saved to Keychain successfully")
+        if KeychainHelper.save(cookie, forKey: "session_cookie") {
+            NSLog("ClaudeUsage: Cookie saved to Keychain successfully")
+        }
     }
 
     func clearSessionCookie() {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -1154,8 +1154,8 @@ struct UsageView: View {
         .padding()
         .frame(width: 360)
         .onAppear {
-            // Load saved cookie when view appears
-            if let savedCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
+            // Show hint text if a cookie is already saved
+            if let savedCookie = KeychainHelper.load(forKey: "session_cookie") {
                 sessionCookieInput = String(savedCookie.prefix(20)) + "..."
             }
             // Force refresh to ensure progress bars show colors

--- a/app/build.sh
+++ b/app/build.sh
@@ -37,6 +37,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
+    -framework Security \
     -target arm64-apple-macos12.0
 
 # Compile for x86_64 (Intel)
@@ -45,6 +46,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
+    -framework Security \
     -target x86_64-apple-macos12.0
 
 # Create universal binary


### PR DESCRIPTION
## Summary

- Adds a `KeychainHelper` struct using the Security framework `SecItem*` API (non-deprecated)
- Migrates session cookie storage from plaintext `UserDefaults` to the encrypted macOS Keychain
- Includes a transparent migration path: on first launch after update, any existing UserDefaults cookie is copied to Keychain and removed automatically
- Adds `-framework Security` to both architecture compile targets in `build.sh`
- Adds error logging with human-readable `SecCopyErrorMessageString` descriptions for all Keychain failures

## Security improvement

| | Before | After |
|---|---|---|
| Storage | UserDefaults (plaintext plist) | macOS Keychain (OS-encrypted) |
| Access control | File permissions only | Keychain ACL |
| At-rest encryption | None | Yes |

## Changes

- `app/build.sh` — `-framework Security` added to arm64 and x86_64 compile passes
- `app/ClaudeUsageBar.swift` — `KeychainHelper` struct added; `loadSessionCookie`, `saveSessionCookie`, `clearSessionCookie`, and `UsageView.onAppear` updated

## Bug fixes (post-review)

- `KeychainHelper.save()` now returns `Bool` — the migration path only removes the UserDefaults entry after confirming the Keychain write succeeded, preventing permanent data loss on Keychain failure
- `saveSessionCookie` only logs "saved successfully" when the Keychain write actually succeeds

## Testing

- Built successfully with `bash build.sh`
- Confirmed app launches correctly
- `"claude_session_cookie"` UserDefaults key only referenced in the legacy migration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)