### PR TITLE
Menu bar: show session time remaining (opt-in)

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -59,6 +59,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self.statusManager.fetch()
         }
 
+        // Refresh menu bar title every minute so the session countdown stays accurate
+        // (no network call — only re-renders the title from already-fetched data).
+        Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
+            if self.usageManager.showSessionTimeInMenuBar {
+                self.usageManager.updateStatusBar()
+            }
+        }
+
         // App updates are infrequent (new release at most weekly) — poll every 3 hours.
         Timer.scheduledTimer(withTimeInterval: 3 * 3600, repeats: true) { _ in
             self.updateManager.fetch()
@@ -230,7 +238,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func updateStatusIcon(percentage: Int) {
+    func updateStatusIcon(percentage: Int, timeRemaining: String? = nil) {
         guard let button = statusItem.button else { return }
 
         // Determine color based on percentage
@@ -248,7 +256,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Set image and title
         button.image = sparkIcon
-        button.title = " \(percentage)%"
+        if let timeRemaining = timeRemaining {
+            button.title = " \(percentage)% · \(timeRemaining)"
+        } else {
+            button.title = " \(percentage)%"
+        }
     }
 
     func createSparkIcon(color: NSColor) -> NSImage {
@@ -332,6 +344,7 @@ class UsageManager: ObservableObject {
     @Published var hasFetchedData: Bool = false
     @Published var isAccessibilityEnabled: Bool = false
     @Published var shortcutEnabled: Bool = true
+    @Published var showSessionTimeInMenuBar: Bool = false
 
     private var statusItem: NSStatusItem?
     private var sessionCookie: String = ""
@@ -388,6 +401,8 @@ class UsageManager: ObservableObject {
         } else {
             shortcutEnabled = UserDefaults.standard.bool(forKey: "shortcut_enabled")
         }
+
+        showSessionTimeInMenuBar = UserDefaults.standard.bool(forKey: "show_session_time_in_menubar")
     }
 
     func saveSettings() {
@@ -395,6 +410,7 @@ class UsageManager: ObservableObject {
         UserDefaults.standard.set(statusNotificationsEnabled, forKey: "status_notifications_enabled")
         UserDefaults.standard.set(openAtLogin, forKey: "open_at_login")
         UserDefaults.standard.set(shortcutEnabled, forKey: "shortcut_enabled")
+        UserDefaults.standard.set(showSessionTimeInMenuBar, forKey: "show_session_time_in_menubar")
         UserDefaults.standard.synchronize()
     }
 
@@ -638,11 +654,27 @@ class UsageManager: ObservableObject {
     func updateStatusBar() {
         let sessionPercent = Int((Double(sessionUsage) / Double(sessionLimit)) * 100)
 
-        // Update the icon color
-        delegate?.updateStatusIcon(percentage: sessionPercent)
+        // Update the icon color (and optionally the time remaining until session resets)
+        let timeRemaining = showSessionTimeInMenuBar ? formatTimeUntilReset(sessionResetsAt) : nil
+        delegate?.updateStatusIcon(percentage: sessionPercent, timeRemaining: timeRemaining)
 
         // Check for notification thresholds
         checkNotificationThresholds(percentage: sessionPercent)
+    }
+
+    private func formatTimeUntilReset(_ resetsAt: Date?) -> String? {
+        guard let resetsAt = resetsAt else { return nil }
+        let seconds = Int(resetsAt.timeIntervalSinceNow)
+        guard seconds > 0 else { return nil }
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h\(String(format: "%02d", minutes))"
+        } else if minutes > 0 {
+            return "\(minutes)m"
+        } else {
+            return "<1m"
+        }
     }
 
     func checkNotificationThresholds(percentage: Int) {
@@ -1618,6 +1650,25 @@ struct UsageView: View {
                             Text("Launch app automatically when you log in")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
+                        }
+                    }
+                    .toggleStyle(.checkbox)
+
+                    Toggle(isOn: Binding(
+                        get: { usageManager.showSessionTimeInMenuBar },
+                        set: { newValue in
+                            usageManager.showSessionTimeInMenuBar = newValue
+                            usageManager.saveSettings()
+                            usageManager.updateStatusBar()
+                        }
+                    )) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Show Session Time in Menu Bar")
+                                .font(.caption)
+                            Text("Display time remaining until the 5-hour session resets, next to the usage percentage")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                     }
                     .toggleStyle(.checkbox)


### PR DESCRIPTION
## Summary

Adds an opt-in Settings toggle that displays the time remaining until the current 5-hour session resets, next to the usage percentage in the menu bar.

Closes #19.

**Default off** → existing users see no change in behavior.
**Toggled on** → menu bar shows `45% · 2h12` instead of `45%`.

## Why

[#19](https://github.com/Artzainnn/ClaudeUsageBar/issues/19) requested seeing the session usage percentage **and** the time remaining together in the menu bar.

## Implementation

Minimal, additive changes only — single file (`app/ClaudeUsageBar.swift`, +55/-4):

- New `@Published var showSessionTimeInMenuBar` on `UsageManager` (default `false`), persisted via the existing `loadSettings()` / `saveSettings()` flow (key: `show_session_time_in_menubar`).
- `updateStatusIcon(percentage:)` now takes an optional `timeRemaining: String? = nil` — backward-compatible with all existing call sites.
- `updateStatusBar()` reads from the same `sessionResetsAt` that the popover already uses for `"Resets at HH:MM"` — no new API call, no new data source.
- New helper `formatTimeUntilReset()` produces compact strings: `"2h12"` / `"45m"` / `"<1m"` / `nil`.
- One additional `Timer.scheduledTimer(withTimeInterval: 60, ...)` refreshes the title each minute when the toggle is on (no network call — just re-renders from cached data; no-op when off).
- New `Toggle` in Settings, mirroring the existing `"Open at Login"` style (`.toggleStyle(.checkbox)` + caption2 subtitle).

## Test plan

- [x] Builds cleanly as universal binary (Xcode 16.4 / SDK 15.5, matching the current release).
- [x] Default behavior unchanged when toggle is off.
- [x] Toggling on instantly updates the menu bar to `XX% · 2h12`.
- [x] Toggling off restores `XX%`.
- [x] Countdown stays accurate (1-minute refresh, no API calls).
- [x] Preference persists across app restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)