### PR TITLE
Refetch usage and status when Mac wakes from sleep

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -59,6 +59,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self.statusManager.fetch()
         }
 
+        // Foundation Timers are paused while the Mac sleeps and do not catch
+        // up missed ticks on wake — so without this, the menu bar can show
+        // pre-sleep stale data for up to 5 minutes after resume. Refetch
+        // immediately when the system wakes.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            NSLog("⏰ Mac woke from sleep — refetching usage and status")
+            self?.usageManager.fetchUsage()
+            self?.statusManager.fetch()
+        }
+
         // App updates are infrequent (new release at most weekly) — poll every 3 hours.
         Timer.scheduledTimer(withTimeInterval: 3 * 3600, repeats: true) { _ in
             self.updateManager.fetch()


### PR DESCRIPTION
## Summary

Listens for `NSWorkspace.didWakeNotification` and triggers an immediate `fetchUsage()` + `statusManager.fetch()` so the menu bar reflects current data right after the Mac wakes from sleep — instead of showing pre-sleep stale data for up to 5 minutes.

## Why

Foundation `Timer.scheduledTimer` instances are paused while the system sleeps and **do not catch up missed ticks** on wake. After a long sleep (overnight, lunch, lid closed for hours), the existing 5-minute polling Timer can take up to 5 minutes to fire its next tick — during which the menu bar keeps displaying pre-sleep values.

Symptom observed: opening the Mac at 22:36 with the popover showing `Resets at 21:00` (a session reset time from before the sleep). The data is stale until the next Timer tick.

## Implementation

Single, minimal change in `applicationDidFinishLaunching` (`app/ClaudeUsageBar.swift`, +14 lines, no deletions):

```swift
NSWorkspace.shared.notificationCenter.addObserver(
    forName: NSWorkspace.didWakeNotification,
    object: nil,
    queue: .main
) { [weak self] _ in
    NSLog("⏰ Mac woke from sleep — refetching usage and status")
    self?.usageManager.fetchUsage()
    self?.statusManager.fetch()
}
```

- Uses `NSWorkspace.shared.notificationCenter` (the workspace-specific notification center where wake/sleep events live, not `NotificationCenter.default`).
- `[weak self]` to avoid a retain cycle.
- `queue: .main` so the closure runs on the main thread — the same context the existing Timer callbacks run on.
- Reuses the same two calls the 5-minute Timer already makes — no new logic, just earlier invocation on a known event.
- The observer lives for the app's lifetime (no `removeObserver` call needed since `AppDelegate` is the application's sole delegate).

The `updateManager.fetch()` is intentionally NOT triggered on wake — app updates are infrequent and already on a 3-hour cadence, no need to hammer GitHub on every lid-open.

## Test plan

- [x] Builds cleanly as universal binary (Xcode 16.4 / SDK 15.5, matching the release config).
- [x] Manual: put Mac to sleep with usage data visible, sleep > 1 minute, wake → observe an immediate refresh in the console logs (`⏰ Mac woke from sleep`) and updated reset times in the popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)