### PR TITLE
Honor 'Skip for Now' on the Accessibility prompt

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -90,25 +90,39 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Check if app has Accessibility permissions
         let trusted = AXIsProcessTrusted()
 
-        if !trusted {
-            NSLog("⚠️ Accessibility permissions not granted")
-            // Show alert to guide user
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                let alert = NSAlert()
-                alert.messageText = "Accessibility Permission Required"
-                alert.informativeText = "ClaudeUsageBar needs Accessibility permission to use the Cmd+U keyboard shortcut.\n\nPlease enable it in:\nSystem Settings → Privacy & Security → Accessibility"
-                alert.alertStyle = .informational
-                alert.addButton(withTitle: "Open System Settings")
-                alert.addButton(withTitle: "Skip for Now")
-
-                let response = alert.runModal()
-                if response == .alertFirstButtonReturn {
-                    // Open System Settings
-                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-                }
-            }
-        } else {
+        if trusted {
             NSLog("✅ Accessibility permissions granted")
+            return
+        }
+
+        NSLog("⚠️ Accessibility permissions not granted")
+
+        // If the user previously chose "Skip for Now", honor that choice and
+        // don't keep re-prompting on every launch. They can still grant the
+        // permission later via the "Grant Accessibility Permission" button in
+        // Settings, which opens System Settings directly.
+        if UserDefaults.standard.bool(forKey: "accessibility_prompt_dismissed") {
+            NSLog("⏭️ Accessibility prompt previously dismissed — not re-prompting")
+            return
+        }
+
+        // Show alert to guide user
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            let alert = NSAlert()
+            alert.messageText = "Accessibility Permission Required"
+            alert.informativeText = "ClaudeUsageBar needs Accessibility permission to use the Cmd+U keyboard shortcut.\n\nPlease enable it in:\nSystem Settings → Privacy & Security → Accessibility"
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Open System Settings")
+            alert.addButton(withTitle: "Skip for Now")
+
+            let response = alert.runModal()
+            if response == .alertFirstButtonReturn {
+                // Open System Settings
+                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+            } else {
+                // "Skip for Now" — remember the choice so we don't re-prompt on every launch
+                UserDefaults.standard.set(true, forKey: "accessibility_prompt_dismissed")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Persists the user's choice when they click **"Skip for Now"** on the Accessibility-permission alert, so the prompt no longer re-appears on every launch.

## Why

Currently `checkAccessibilityPermissions()` shows the modal alert on every launch as long as `AXIsProcessTrusted()` returns false. The two buttons:

- **"Open System Settings"** → opens System Settings (useful)
- **"Skip for Now"** → dismisses the modal but **stores nothing** — so on the next launch (and the one after, etc.), the same alert is shown again, indefinitely

For users who don't want the Cmd+U global shortcut, this becomes a recurring nag on every cold start. The current code makes "Skip for Now" effectively impossible to honor.

## Fix

Persist a single UserDefaults flag (`accessibility_prompt_dismissed`) when the user picks "Skip for Now", and guard the auto-prompt with that flag.

The dev's original intent (prompt at launch when permission is missing) is preserved — the alert still shows **once**, at the first launch where permission is absent. Subsequent launches respect the user's "Skip" choice.

The existing **"Grant Accessibility Permission"** button in Settings continues to work and opens System Settings directly — so a user who later changes their mind has an explicit path to grant permission.

## Implementation

`app/ClaudeUsageBar.swift`, +32/-18, single file, no new external state beyond one `UserDefaults` key.

```swift
if UserDefaults.standard.bool(forKey: "accessibility_prompt_dismissed") {
    NSLog("⏭️ Accessibility prompt previously dismissed — not re-prompting")
    return
}
// ... show alert ...
if response == .alertSecondButtonReturn {
    UserDefaults.standard.set(true, forKey: "accessibility_prompt_dismissed")
}
```

Also refactored the function for early returns (granted / dismissed / show prompt) — cleaner than the original nested `if/else`.

## Test plan

- [x] Builds cleanly (Xcode 16.4 / SDK 15.5).
- [x] Manual:
  - First launch on a Mac where the app has never been granted Accessibility → alert appears ✅
  - Click "Skip for Now", relaunch → alert does NOT appear ✅
  - Click "Grant Accessibility Permission" in Settings → System Settings opens ✅
  - Grant permission in System Settings, relaunch → no alert, Cmd+U works ✅

## Notes

If a user has the flag set but later wants to be re-prompted at launch, they can clear it via:
```
defaults delete com.claude.usagebar accessibility_prompt_dismissed
```
or simply use the **"Grant Accessibility Permission"** button in Settings (which is the documented path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)