### PR TITLE
Show Claude Design weekly usage in the popover

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -319,9 +319,12 @@ class UsageManager: ObservableObject {
     @Published var weeklyLimit: Int = 100
     @Published var weeklySonnetUsage: Int = 0
     @Published var weeklySonnetLimit: Int = 100
+    @Published var weeklyDesignUsage: Int = 0
+    @Published var weeklyDesignLimit: Int = 100
     @Published var sessionResetsAt: Date?
     @Published var weeklyResetsAt: Date?
     @Published var weeklySonnetResetsAt: Date?
+    @Published var weeklyDesignResetsAt: Date?
     @Published var lastUpdated: Date = Date()
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
@@ -329,6 +332,7 @@ class UsageManager: ObservableObject {
     @Published var statusNotificationsEnabled: Bool = true
     @Published var openAtLogin: Bool = false
     @Published var hasWeeklySonnet: Bool = false
+    @Published var hasWeeklyDesign: Bool = false
     @Published var hasFetchedData: Bool = false
     @Published var isAccessibilityEnabled: Bool = false
     @Published var shortcutEnabled: Bool = true
@@ -416,11 +420,14 @@ class UsageManager: ObservableObject {
         sessionUsage = 0
         weeklyUsage = 0
         weeklySonnetUsage = 0
+        weeklyDesignUsage = 0
         sessionResetsAt = nil
         weeklyResetsAt = nil
         weeklySonnetResetsAt = nil
+        weeklyDesignResetsAt = nil
         hasFetchedData = false
         hasWeeklySonnet = false
+        hasWeeklyDesign = false
         errorMessage = nil
         lastNotifiedThreshold = 0
         UserDefaults.standard.set(0, forKey: "last_notified_threshold")
@@ -620,8 +627,34 @@ class UsageManager: ObservableObject {
                 hasWeeklySonnet = false
             }
 
+            // Check for seven_day_omelette (Claude Design — plan-dependent, separate bucket).
+            // "omelette" is Anthropic's internal codename for Claude Design (the design
+            // assistant at claude.ai/design). Its usage is tracked in its own weekly window,
+            // independent from seven_day / seven_day_sonnet / five_hour.
+            if let sevenDayDesign = json["seven_day_omelette"] as? [String: Any] {
+                hasWeeklyDesign = true
+                if let designUtil = sevenDayDesign["utilization"] as? Double {
+                    weeklyDesignUsage = Int(designUtil)
+                    weeklyDesignLimit = 100
+                }
+                if let resetsAtString = sevenDayDesign["resets_at"] as? String {
+                    NSLog("🕐 Weekly Design resets_at string: \(resetsAtString)")
+                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
+                        weeklyDesignResetsAt = resetsAt
+                        NSLog("✅ Parsed weekly Design reset time: \(resetsAt)")
+                    } else {
+                        NSLog("❌ Failed to parse weekly Design reset time")
+                    }
+                } else {
+                    // resets_at is null until first Claude Design use — keep nil
+                    weeklyDesignResetsAt = nil
+                }
+            } else {
+                hasWeeklyDesign = false
+            }
+
             // Log what we found
-            NSLog("✅ Parsed: Session \(sessionUsage)%, Weekly \(weeklyUsage)%\(hasWeeklySonnet ? ", Weekly Sonnet \(weeklySonnetUsage)%" : "")")
+            NSLog("✅ Parsed: Session \(sessionUsage)%, Weekly \(weeklyUsage)%\(hasWeeklySonnet ? ", Weekly Sonnet \(weeklySonnetUsage)%" : "")\(hasWeeklyDesign ? ", Weekly Design \(weeklyDesignUsage)%" : "")")
 
             lastUpdated = Date()
             errorMessage = nil
@@ -701,11 +734,13 @@ class UsageManager: ObservableObject {
     @Published var sessionPercentage: Double = 0.0
     @Published var weeklyPercentage: Double = 0.0
     @Published var weeklySonnetPercentage: Double = 0.0
+    @Published var weeklyDesignPercentage: Double = 0.0
 
     func updatePercentages() {
         sessionPercentage = Double(sessionUsage) / Double(sessionLimit)
         weeklyPercentage = Double(weeklyUsage) / Double(weeklyLimit)
         weeklySonnetPercentage = Double(weeklySonnetUsage) / Double(weeklySonnetLimit)
+        weeklyDesignPercentage = Double(weeklyDesignUsage) / Double(weeklyDesignLimit)
     }
 }
 
@@ -1356,6 +1391,33 @@ struct UsageView: View {
                         .tint(colorForPercentage(usageManager.weeklySonnetPercentage))
 
                     Text("\(Int(usageManager.weeklySonnetPercentage * 100))% used")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            // Claude Design Usage (only show if available — plan-dependent)
+            if usageManager.hasWeeklyDesign && usageManager.hasFetchedData {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Claude Design (7 day)")
+                            .font(.subheadline)
+                        Spacer()
+                        if let resetTime = usageManager.weeklyDesignResetsAt {
+                            Text("Resets \(formatResetTime(resetTime, includeDate: true))")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text("Not started yet")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    ProgressView(value: usageManager.weeklyDesignPercentage)
+                        .tint(colorForPercentage(usageManager.weeklyDesignPercentage))
+
+                    Text("\(Int(usageManager.weeklyDesignPercentage * 100))% used")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }


### PR DESCRIPTION
## Summary

Adds a new **"Claude Design (7 day)"** section in the popover, mirroring the existing "Weekly Sonnet (7 day)" pattern, to display the separate weekly limit for Claude Design (the design assistant at [claude.ai/design](https://claude.ai/design)).

Closes #23.

## Why

Anthropic exposes a dedicated weekly limit for Claude Design under the API key `seven_day_omelette` (`"omelette"` is its internal codename during rollout). This limit:

- Is **plan-dependent** (returned by the API only on plans that include Claude Design)
- Has **its own bucket** — independent from `five_hour`, `seven_day`, and `seven_day_sonnet`
- Was not displayed by the app, so users on Claude Design had no way to see how close they were to that limit

## Implementation

Single file change (`app/ClaudeUsageBar.swift`, +63/-1), strictly mirroring the existing `seven_day_sonnet` pattern:

- New `@Published` properties on `UsageManager`:
  - `weeklyDesignUsage`, `weeklyDesignLimit`, `weeklyDesignResetsAt`, `weeklyDesignPercentage`, `hasWeeklyDesign`
- Parsing of `seven_day_omelette` in `parseUsageData()` (same shape as the Sonnet block — `utilization` + `resets_at`)
- Reset of the new state in `clearSessionCookie()`
- New `"Claude Design (7 day)"` section in `UsageView`, rendered only when `hasWeeklyDesign && hasFetchedData` — so users without Claude Design see nothing

### Edge case: `resets_at: null`

Before the user's first Claude Design session, the API returns `resets_at: null`. The section displays **"Not started yet"** in that case instead of leaving the reset line empty. (Confirmed against my own account: the field was `null` before I touched claude.ai/design and turned into a real ISO date after.)

## Verification

Empirically verified by snapshotting `/api/organizations/$ORG/usage` before/after a Claude Design session:

| Field | Before | After Design session |
|---|---|---|
| `seven_day_omelette.utilization` | 0.0 | 2.0 |
| `seven_day_omelette.resets_at` | `null` | `2026-05-28T23:59:59...` |
| `seven_day.utilization` | 12.0 | 12.0 (unchanged) |
| `seven_day_sonnet.utilization` | 0.0 | 0.0 (unchanged) |

Only `seven_day_omelette` moved, confirming it is the right key and that the bucket is independent.

## Cross-references

The `seven_day_omelette` → Claude Design mapping is independently confirmed by three other open-source projects that already handle this window:

- [`AThevon/TokenEater`](https://github.com/AThevon/TokenEater) (Swift menu bar app):
  ```swift
  /// Claude Design (codenamed seven_day_omelette in the API during rollout).
  case sevenDayDesign = "seven_day_omelette"
  ```
- [`robinebers/openusage`](https://github.com/robinebers/openusage) docs: *"separate weekly Claude Design limit (optional, plan-dependent)"*
- [`tombelieber/claude-view`](https://github.com/tombelieber/claude-view) changelog v0.40.0: lists `seven_day_omelette` among newly-recognized Anthropic windows.

## Test plan

- [x] Builds cleanly (Xcode 16.4 / SDK 15.5, matching the release config).
- [x] Section is shown only when the API returns the block — accounts without Claude Design see no change.
- [x] When `resets_at: null` → "Not started yet" instead of an empty/missing reset line.
- [x] When `resets_at` is set → renders identically to the Weekly Sonnet section.
- [ ] Progress bar color follows the same threshold (green < 70%, orange 70-90%, red > 90%) as the other sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)