### PR TITLE
fix(security): store session cookie in Keychain (device-only)

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,85 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import Security
+
+/**
+ * Stores the claude.ai session cookie in the Keychain instead of UserDefaults.
+ * The cookie carries `sessionKey` (full account access), so it must not sit in
+ * the world-readable preferences plist.
+ */
+enum KeychainHelper {
+    private static let service = "com.claude.usagebar"
+
+    /**
+     * Full-account credential: pin it to this device only (no iCloud Keychain
+     * sync or inclusion in backups) and keep it readable by the 5-minute
+     * background poll after the first unlock following boot.
+     */
+    private static let accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+    @discardableResult
+    static func save(_ value: String, forKey key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key
+        ]
+        let attributes: [CFString: Any] = [
+            kSecValueData: data,
+            kSecAttrAccessible: accessibility
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData] = data
+            addQuery[kSecAttrAccessible] = accessibility
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                let addDesc = SecCopyErrorMessageString(addStatus, nil) as String? ?? "unknown"
+                NSLog("ClaudeUsage: Keychain add failed for key '\(key)': \(addStatus) – \(addDesc)")
+                return false
+            }
+        } else if updateStatus != errSecSuccess {
+            let updateDesc = SecCopyErrorMessageString(updateStatus, nil) as String? ?? "unknown"
+            NSLog("ClaudeUsage: Keychain update failed for key '\(key)': \(updateStatus) – \(updateDesc)")
+            return false
+        }
+        return true
+    }
+
+    static func load(forKey key: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else { return nil }
+        return value
+    }
+
+    static func delete(forKey key: String) {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            let deleteDesc = SecCopyErrorMessageString(status, nil) as String? ?? "unknown"
+            NSLog("ClaudeUsage: Keychain delete failed for key '\(key)': \(status) – \(deleteDesc)")
+        }
+    }
+}
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -351,9 +430,23 @@ class UsageManager: ObservableObject {
     }
 
     func loadSessionCookie() {
-        if let savedCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
-            sessionCookie = savedCookie
+        if let cookie = KeychainHelper.load(forKey: "session_cookie") {
+            sessionCookie = cookie
+        } else if let legacyCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
+            // Migrate the plaintext cookie to the Keychain on first launch after update.
+            NSLog("ClaudeUsage: Migrating cookie from UserDefaults to Keychain")
+            sessionCookie = legacyCookie
+            if KeychainHelper.save(legacyCookie, forKey: "session_cookie") {
+                UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
+            } else {
+                NSLog("ClaudeUsage: Migration failed — cookie retained in UserDefaults")
+            }
         }
+    }
+
+    /** Truncated, non-secret placeholder hint for the cookie field — sourced from memory, never disk. */
+    var cookieHint: String? {
+        sessionCookie.isEmpty ? nil : String(sessionCookie.prefix(20)) + "..."
     }
 
     func loadSettings() {
@@ -401,16 +494,19 @@ class UsageManager: ObservableObject {
     func saveSessionCookie(_ cookie: String) {
         NSLog("ClaudeUsage: Saving cookie, length: \(cookie.count)")
         sessionCookie = cookie
-        UserDefaults.standard.set(cookie, forKey: "claude_session_cookie")
-        UserDefaults.standard.synchronize()
-        NSLog("ClaudeUsage: Cookie saved successfully")
+        if KeychainHelper.save(cookie, forKey: "session_cookie") {
+            NSLog("ClaudeUsage: Cookie saved to Keychain successfully")
+        } else {
+            NSLog("ClaudeUsage: Cookie save to Keychain FAILED — it will not persist across restart")
+        }
     }
 
     func clearSessionCookie() {
         NSLog("ClaudeUsage: Clearing cookie")
         sessionCookie = ""
+        KeychainHelper.delete(forKey: "session_cookie")
+        // Defensive: wipe any plaintext copy a pre-migration build may have left behind.
         UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
-        UserDefaults.standard.synchronize()
 
         // Reset all data
         sessionUsage = 0
@@ -1222,8 +1318,8 @@ struct UsageView: View {
                 measuredHeight = value
             }
             .onAppear {
-                if let savedCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
-                    sessionCookieInput = String(savedCookie.prefix(20)) + "..."
+                if let hint = usageManager.cookieHint {
+                    sessionCookieInput = hint
                 }
                 usageManager.updatePercentages()
             }

--- a/app/build.sh
+++ b/app/build.sh
@@ -39,6 +39,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
+    -framework Security \
     -target arm64-apple-macos12.0
 
 # Compile for x86_64 (Intel)
@@ -47,6 +48,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
+    -framework Security \
     -target x86_64-apple-macos12.0
 
 # Create universal binary


### PR DESCRIPTION
## Summary

The claude.ai session cookie includes `sessionKey`, which grants full account access. Today it's persisted in **plaintext** in `UserDefaults` (`~/Library/Preferences/com.claude.usagebar.plist`) — readable by any process running as the user and captured in unencrypted backups. This moves it to the Keychain.

This is built on the two existing community attempts and tries to combine their best parts:
- **#9 / #29** (@rodbegbie, @rimonhanna) — the `KeychainHelper` shape and the `SecCopyErrorMessageString` error decoding are taken from here.
- **#20** (@louisdengtw) — the `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` attribute, save-failure logging, and the defensive legacy-key wipe are ported from its `CookieKeychain`.

## What it does

- `KeychainHelper` stores the cookie as a generic password under service `com.claude.usagebar`, account `session_cookie`.
- **`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`** on both the add and update paths: the credential is never synced to iCloud Keychain or included in backups, and stays readable by the 5-minute background poll after the first unlock following boot.
- **One-shot migration** from the old `claude_session_cookie` UserDefaults key on first launch. The plaintext copy is removed *only after* the Keychain write succeeds; on failure the cookie is retained so the app keeps working.
- **Save failures are logged** (previously only success was). A failed write no longer silently drops the cookie on next restart.
- `clearSessionCookie` also removes any pre-migration plaintext leftover.
- The popover's cookie-field hint now reads the in-memory cookie via a `cookieHint` accessor on `UsageManager` instead of hitting the store directly on every open — removes the second source of truth and an extra Keychain read.

## Honest caveat on the accessibility class

On macOS's **file-based login keychain** (what an unsandboxed app like this uses), the `kSecAttrAccessible*` values are largely equivalent and do **not** provide true screen-lock-gated protection — that requires the opt-in data-protection keychain, which this doesn't use. `...AfterFirstUnlockThisDeviceOnly` is still the right choice because it's forward-correct and blocks iCloud sync of a full-account secret. The concrete win over the plaintext-plist status quo is **ACL-gated access (only this app) and no longer sitting in a world-readable plist** — not lock-state gating. Set expectations accordingly.

## Testing

- `swiftc -parse-as-library -typecheck` passes with zero errors (only the pre-existing `NSUserNotification` deprecation warnings remain).
- I could not run the full signed `build.sh` (no Developer ID cert), so the migration path hasn't been exercised on a real install — worth a manual check: install an old build, set a cookie, upgrade, confirm the cookie migrates and the plaintext key disappears (`defaults read com.claude.usagebar claude_session_cookie` should error afterwards).

Closes the security gap tracked by #9 / #29. Happy to adjust naming or fold in reviewer preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)