### PR TITLE
Fix popover top clipping by letting content size drive the popover height

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -42,11 +42,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Initial guess; SwiftUI's intrinsic size (capped at 600) will drive the actual size.
         popover.contentSize = NSSize(width: 360, height: 320)
         popover.behavior = .transient
-        popover.contentViewController = NSHostingController(rootView: UsageView(
+        let hostingController = NSHostingController(rootView: UsageView(
             usageManager: usageManager,
             statusManager: statusManager,
             updateManager: updateManager
         ))
+        // Let the SwiftUI content's fitting size drive the popover size. Without this the
+        // hosting controller never propagates its preferredContentSize, so the popover stays
+        // stuck at the initial contentSize (320) while the content is taller (~401pt). The
+        // overflow clips the top of the popover — the "Claude Usage" header row disappears.
+        // (The fixed contentSize above only seeds an initial guess, as its comment intends.)
+        if #available(macOS 13.0, *) {
+            hostingController.sizingOptions = [.preferredContentSize]
+        }
+        popover.contentViewController = hostingController
 
         // Fetch initial data
         usageManager.fetchUsage()


### PR DESCRIPTION
## Summary

The popover's top is clipped — the "Claude Usage" header row is cut off and content sits flush against the top edge, while the bottom renders fine. This makes the popover auto-size to its SwiftUI content so nothing is clipped.

## Why

The popover wraps `UsageView` in an `NSHostingController`, but `sizingOptions` is never set, so the controller's `preferredContentSize` is never propagated to the `NSPopover`. The popover stays at the initial `contentSize` (`360×320`) seeded in `applicationDidFinishLaunching`, while the real content is taller (~401pt here). The overflow clips the top.

Measured on macOS 26.5 before the fix:
- SwiftUI content fitting size: `(360, 401)`
- `popover.contentSize`: `(360, 320)` ← stuck at the initial guess

The existing `// … SwiftUI's intrinsic size … will drive the actual size` comment already describes the intended behavior — it just wasn't wired up.

## Implementation

Minimal, single-file change in `applicationDidFinishLaunching` (`app/ClaudeUsageBar.swift`, +10/-1):
- Hold the `NSHostingController` in a local and set `sizingOptions = [.preferredContentSize]` (guarded by `#available(macOS 13.0, *)`) before assigning it to the popover.
- The content's fitting size now drives the popover height; verified `popover.contentSize` grows to `(360, 401)` and the header is no longer clipped (macOS 26.5, Xcode 26.6).

`sizingOptions` requires macOS 13+; the deployment target is 12.0, so macOS 12 is unaffected by this change (it would need a manual `preferredContentSize` update).

## Related

Supersedes the approach in #7, which predates the current `ScrollView`-based layout and bumped a hardcoded height. This fixes the same symptom at the root by making the popover track its content size.
