### PR TITLE
feat: xAI Developer backend, two-key (feature-flagged off)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,39 @@ jobs:
             exit 1
           fi
 
-  # build-and-test: enabled when PR 2a lands Package.swift.
-  # See EXPANSION_PLAN.md § Phase 0 for the sequencing.
+  build-and-test:
+    name: Build and test (macOS)
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          swift --version
+          xcodebuild -version || true
+
+      - name: swift build
+        run: swift build --configuration debug
+
+      - name: swift run TestRunner
+        # Assertion-based test runner (see Package.swift header for why
+        # we do not use XCTest / Testing here — CLT compatibility).
+        run: swift run TestRunner --configuration debug
+
+      - name: Legacy build.sh compile smoke (unsigned)
+        run: |
+          # Verify the swiftc-driven build.sh path still compiles cleanly.
+          # We patch out the hardcoded Developer ID for CI, but leave the
+          # local file on disk unchanged.
+          sed 's|Developer ID Application: Linkko Technology Pte Ltd (Q467HQ5432)|-|' \
+            app/build.sh > /tmp/build-ci.sh
+          chmod +x /tmp/build-ci.sh
+          cd app
+          # Skip the launch step at the end of build.sh — CI has no display.
+          sed -i.bak '/^open "\$APP_PATH"/d' /tmp/build-ci.sh
+          /tmp/build-ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+# .github/workflows/ci.yml
+#
+# Runs on every pull_request and every push to main.
+# No secrets, no write scopes, no pull_request_target — pwn-request-safe
+# per docs.github.com/en/actions/security-for-github-actions/security-guides.
+#
+# Two jobs:
+#   1. static-grep — cheap static checks that catch known regression patterns.
+#      This is where the PR-1 "belt-and-braces" credential-leak defence lives:
+#      any PR that reintroduces the deleted "📦 Response:" pattern or raw-
+#      interpolation NSLog calls with sessionCookie / orgId / responseString
+#      fails CI before human review.
+#   2. build-and-test — (placeholder) once PR 2a lands Package.swift, this
+#      job will run `swift build` + `swift test`. Kept as a no-op comment
+#      here so PR 1's diff does not silently add a runner cost. PR 2a wires
+#      the real build/test steps in.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-grep:
+    name: Static credential-leak guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Reject reintroduced "📦 Response:" pattern
+        run: |
+          if grep -rn '📦 Response' -- app/ ; then
+            echo "::error::Forbidden pattern '📦 Response' found. Deleted in PR 1 to prevent full-response-body logging; do not reintroduce." >&2
+            exit 1
+          fi
+
+      - name: Reject raw NSLog interpolation of credentials
+        run: |
+          # NSLog calls that interpolate sessionCookie, orgId, responseString,
+          # or sessionCookieInput are forbidden. Use Log.info(.count) /
+          # Log.info(.identifier) / Log.info(.sensitive) instead.
+          if grep -rnE 'NSLog\([^)]*\\\(.*(sessionCookie|orgId|responseString|sessionCookieInput)' -- app/ ; then
+            echo "::error::Raw NSLog interpolation of credentials found. Use Log.info(.count/.identifier/.sensitive) instead." >&2
+            exit 1
+          fi
+
+      - name: Reject NSLog on cookie/response tokens
+        run: |
+          # Broader net: any NSLog that mentions cookie or response bodies.
+          # If a diagnostic genuinely needs it, use Log.debug (DEBUG-only).
+          if grep -rnE 'NSLog\([^)]*(cookie|Cookie|Response body|responseString)' -- app/ ; then
+            echo "::error::NSLog referencing cookie/response found. Move to Log.debug (DEBUG-only) or delete." >&2
+            exit 1
+          fi
+
+  # build-and-test: enabled when PR 2a lands Package.swift.
+  # See EXPANSION_PLAN.md § Phase 0 for the sequencing.

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ internal-docs/
 EXPANSION_PLAN.md
 docs/tracking-issue-draft.md
 .pr-bodies/
+
+# SwiftPM build artefacts
+.build/
+Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,10 @@ docs/tracking-issue-draft.md
 # SwiftPM build artefacts
 .build/
 Package.resolved
+
+# Local credentials and probe transcripts — NEVER pushed to any remote
+secrets/
+.env
+.env.*
+probes/
+*.probe.json

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ temp/
 # Internal docs (kept local, not on public GitHub)
 NOTIFICATIONS.md
 internal-docs/
+
+# Contributor-side planning artefacts — never pushed to any remote
+EXPANSION_PLAN.md
+docs/tracking-issue-draft.md
+.pr-bodies/

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,16 @@ let package = Package(
                 "LICENSE",
                 "README.md"
             ],
-            sources: ["Log.swift", "AnthropicUsageFetcher.swift"]
+            sources: [
+                "Log.swift",
+                "AnthropicUsageFetcher.swift",
+                "UsageProvider.swift"
+                // AnthropicUsageStore.swift depends on UsageManager
+                // (defined in ClaudeUsageBar.swift), so it stays in the
+                // app-bundle compile only, not in the SwiftPM library
+                // target. Tests for AnthropicUsageStore live in the
+                // full-app integration tier, not this unit-test layer.
+            ]
         ),
         .executableTarget(
             name: "TestRunner",

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,10 @@ let package = Package(
                 "DeepSeekUsageStore.swift",
                 // Zed: reads Zed's own Keychain item; same rationale.
                 "ZedUsageFetcher.swift",
-                "ZedUsageStore.swift"
+                "ZedUsageStore.swift",
+                // xAI Developer: two-key, two-host; same rationale.
+                "XAIUsageFetcher.swift",
+                "XAIUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -51,12 +51,24 @@ let package = Package(
                 "ClaudeUsageBar.icns",
                 "claudeusagebar-icon.png",
                 "LICENSE",
-                "README.md"
+                "README.md",
+                // AnthropicUsageStore depends on UsageManager (defined in the
+                // excluded @main entry point) so it is compiled only by
+                // build.sh into the .app bundle, not by the SwiftPM library.
+                // Listed here explicitly to silence the "unhandled file"
+                // warning now that `sources` is an allow-list.
+                "AnthropicUsageStore.swift"
             ],
             sources: [
                 "Log.swift",
                 "AnthropicUsageFetcher.swift",
-                "UsageProvider.swift"
+                "UsageProvider.swift",
+                "CodexUsageFetcher.swift",
+                // CodexUsageStore has no dependency on UsageManager (unlike
+                // AnthropicUsageStore), so it lives in the library where the
+                // TestRunner can exercise its tile-generation and 401 →
+                // session-expired mapping through a stubbed transport.
+                "CodexUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
                 "LICENSE",
                 "README.md"
             ],
-            sources: ["Log.swift"]
+            sources: ["Log.swift", "AnthropicUsageFetcher.swift"]
         ),
         .executableTarget(
             name: "TestRunner",

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,64 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest — additive scaffolding for testing, not a replacement for
+// the existing build path.
+//
+// `swift build` compiles the library against the source under `app/`.
+// `swift run TestRunner` executes the assertion-based test runner (works
+// with Command Line Tools alone; does not require Xcode.app / XCTest).
+// The legacy `app/build.sh` continues to work unchanged — it invokes
+// `swiftc` directly and produces the `.app` bundle. Both paths compile
+// the same file.
+//
+// Why not XCTest / swift-testing?
+// Both XCTest and Apple's newer `Testing` framework require `xctest`
+// tooling that ships with Xcode.app, not with the Command Line Tools
+// package. To keep the test path usable on any Mac with CLT installed,
+// PR 2a ships a plain executable test runner. PR 16 (Swift 6 migration)
+// or a maintainer decision to install Xcode.app can promote this to
+// XCTest later without changing the test bodies (they're just
+// assertion functions).
+//
+// PR 2a intentionally introduces only the scaffold plus one first test
+// suite (LogValueTests). PR 2b lands the AnthropicUsageFetcher extraction
+// and its fixture-based tests using the same runner.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClaudeUsageBar",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .library(name: "ClaudeUsageBar", targets: ["ClaudeUsageBar"]),
+        .executable(name: "TestRunner", targets: ["TestRunner"])
+    ],
+    targets: [
+        .target(
+            name: "ClaudeUsageBar",
+            path: "app",
+            exclude: [
+                // The @main app entry point (compiled by build.sh into the
+                // .app bundle, but not part of the SwiftPM library which is
+                // only for testable extracted types).
+                "ClaudeUsageBar.swift",
+                // Assets, build scripts, and docs — not compiled sources.
+                "build.sh",
+                "create_dmg.sh",
+                "make_app_icon.sh",
+                "Info.plist",
+                "ClaudeUsageBar.icns",
+                "claudeusagebar-icon.png",
+                "LICENSE",
+                "README.md"
+            ],
+            sources: ["Log.swift"]
+        ),
+        .executableTarget(
+            name: "TestRunner",
+            dependencies: ["ClaudeUsageBar"],
+            path: "Tests/TestRunner"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,11 @@ let package = Package(
                 // AnthropicUsageStore), so it lives in the library where the
                 // TestRunner can exercise its tile-generation and 401 →
                 // session-expired mapping through a stubbed transport.
-                "CodexUsageStore.swift"
+                "CodexUsageStore.swift",
+                // DeepSeek: fetcher + KeychainStore + store. Same rationale —
+                // no UsageManager dependency, so it is unit-testable here.
+                "DeepSeekUsageFetcher.swift",
+                "DeepSeekUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,10 @@ let package = Package(
                 // DeepSeek: fetcher + KeychainStore + store. Same rationale —
                 // no UsageManager dependency, so it is unit-testable here.
                 "DeepSeekUsageFetcher.swift",
-                "DeepSeekUsageStore.swift"
+                "DeepSeekUsageStore.swift",
+                // Zed: reads Zed's own Keychain item; same rationale.
+                "ZedUsageFetcher.swift",
+                "ZedUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1114,6 +1114,195 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - XAIUsageFetcher (PR 6-BE)
+
+// GET /v1/api-key — flat snake_case object (verified against xAI docs).
+let fixtureXaiApiKey = #"""
+{
+  "redacted_api_key": "xai-****b14o",
+  "user_id": "user-123",
+  "name": "prod key",
+  "create_time": "2026-01-01T00:00:00Z",
+  "modify_time": "2026-01-02T00:00:00Z",
+  "team_id": "team-abc",
+  "api_key_id": "key-xyz",
+  "acls": ["api-key:model:*", "api-key:endpoint:*"]
+}
+"""#
+
+run("parse xAI api-key: team_id, acls, redacted key") {
+    let info = try! XAIUsageFetcher.parseApiKey(fixtureXaiApiKey.data(using: .utf8)!)
+    expectEqual(info.teamId, "team-abc")
+    expectEqual(info.acls.count, 2)
+    expectEqual(info.redactedKey, "xai-****b14o")
+    expectEqual(info.name, "prod key")
+}
+
+// GET /v1/language-models — models[] with token prices.
+let fixtureXaiModels = #"""
+{
+  "models": [
+    {"id": "grok-4.5", "prompt_text_token_price": 3000, "completion_text_token_price": 15000},
+    {"id": "grok-4.20", "prompt_text_token_price": 5000, "completion_text_token_price": 25000}
+  ]
+}
+"""#
+
+run("parse xAI language-models catalogue") {
+    let models = try! XAIUsageFetcher.parseLanguageModels(fixtureXaiModels.data(using: .utf8)!)
+    expectEqual(models.count, 2)
+    expectEqual(models[0].id, "grok-4.5")
+    expectEqual(models[0].promptTokenPrice, 3000)
+    expectEqual(models[1].completionTokenPrice, 25000)
+}
+
+run("parse xAI language-models tolerates data[] wrapper") {
+    let bytes = #"{"data": [{"id": "grok-4.5"}]}"#.data(using: .utf8)!
+    let models = try! XAIUsageFetcher.parseLanguageModels(bytes)
+    expectEqual(models.count, 1)
+    expectEqual(models[0].id, "grok-4.5")
+}
+
+// Prepaid balance — total.val is a STRING-encoded int64 in USD CENTS, and is
+// NEGATIVE when credit remains. Verified against xAI's OpenAPI schema.
+let fixtureXaiBalanceCredit = #"""
+{
+  "changes": [],
+  "total": { "val": "-12345" }
+}
+"""#
+
+run("parse xAI balance: negative cents = remaining credit") {
+    let balance = try! XAIUsageFetcher.parseBalance(fixtureXaiBalanceCredit.data(using: .utf8)!)
+    expectEqual(balance.totalValRaw, -12345)
+    // -12345 cents credit => 123.45 USD remaining.
+    expect(abs(balance.remainingUSD - 123.45) < 0.001)
+}
+
+run("parse xAI balance: zero or positive val = depleted (clamped to 0)") {
+    let zero = try! XAIUsageFetcher.parseBalance(#"{"total": {"val": "0"}}"#.data(using: .utf8)!)
+    expectEqual(zero.remainingUSD, 0.0)
+    let positive = try! XAIUsageFetcher.parseBalance(#"{"total": {"val": "500"}}"#.data(using: .utf8)!)
+    expectEqual(positive.remainingUSD, 0.0)   // no remaining prepaid credit
+}
+
+run("parse xAI balance throws when total.val missing") {
+    do {
+        _ = try XAIUsageFetcher.parseBalance(#"{"total": {}}"#.data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("parse xAI usage daily buckets (dollar and cents forms)") {
+    let bytes = #"""
+    {"usage": [
+      {"date": "2026-07-10", "usd": 1.50},
+      {"date": "2026-07-11", "usd_cents": 275}
+    ]}
+    """#.data(using: .utf8)!
+    let daily = try! XAIUsageFetcher.parseUsage(bytes)
+    expectEqual(daily.count, 2)
+    expect(abs(daily[0].usdSpent - 1.50) < 0.001)
+    expect(abs(daily[1].usdSpent - 2.75) < 0.001)  // 275 cents
+}
+
+run("parse xAI api-key throws on array top-level") {
+    do {
+        _ = try XAIUsageFetcher.parseApiKey("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - XAIUsageStore (in-memory credentials + stubbed transport)
+
+final class StubXAITransport: XAIUsageTransport, @unchecked Sendable {
+    let result: XAIUsageResult
+    init(_ result: XAIUsageResult) { self.result = result }
+    func fetchAll(inferenceKey: String, managementKey: String?, completion: @escaping @Sendable (XAIUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "xai-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.xai.enabled")
+
+    run("xAI store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("xAI enabled without inference key emits needsAccess card") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("xAI two-key management: hasInferenceKey and hasManagementKey") {
+        let creds = InMemoryCredentialStore()
+        let store = XAIUsageStore(credentials: creds, transport: StubXAITransport(.networkError), defaults: defaults)
+        expectEqual(store.hasInferenceKey, false)
+        expectEqual(store.hasManagementKey, false)
+        store.saveInferenceKey("xai-inference")
+        store.saveManagementKey("xai-mgmt-secret")
+        expectEqual(store.hasInferenceKey, true)
+        expectEqual(store.hasManagementKey, true)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("xAI Tier 1 only: plan tile, no balance tile") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-inference")
+        var snap = XAIUsageSnapshot()
+        snap.apiKeyInfo = XAIApiKeyInfo(teamId: "team-abc", acls: ["api-key:model:*"], redactedKey: "xai-****b14o")
+        store.apply(.success(snap))
+        let tiles = store.tiles
+        expect(tiles.contains { $0.id == "xai-plan" })
+        expect(!tiles.contains { $0.id == "xai-balance" })
+    }
+
+    run("xAI Tier 2: balance tile from negative-cents credit") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-inference")
+        var snap = XAIUsageSnapshot()
+        snap.apiKeyInfo = XAIApiKeyInfo(teamId: "team-abc")
+        snap.balance = XAIBalance(totalValRaw: -12345, currency: "USD")
+        store.apply(.success(snap))
+        let balanceTile = store.tiles.first { $0.id == "xai-balance" }
+        expect(balanceTile != nil)
+        if case let .balance(minor, currency, _, _) = balanceTile?.kind {
+            expectEqual(minor, 12345)   // 123.45 USD => 12345 minor units
+            expectEqual(currency, "USD")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("xAI 401 maps to invalid-key error") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.unauthorized), defaults: defaults)
+        store.saveInferenceKey("xai-bad")
+        store.fetch()
+        expectEqual(store.errorMessage, "Invalid xAI API key")
+    }
+
+    run("xAI clear deletes both keys") {
+        let creds = InMemoryCredentialStore()
+        let store = XAIUsageStore(credentials: creds, transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-i"); store.saveManagementKey("xai-mgmt-m")
+        store.clear()
+        expectEqual(store.hasInferenceKey, false)
+        expectEqual(store.hasManagementKey, false)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1,0 +1,112 @@
+// PR 2a — assertion-based test runner.
+//
+// Runs with `swift run TestRunner` from the repo root. Works with
+// Command Line Tools alone; does not require Xcode.app / XCTest.
+// Prints one line per test and exits nonzero if any assertion fails.
+//
+// When Xcode.app is installed, this runner can be promoted to XCTest
+// or Apple's Testing framework without changing the assertion bodies.
+
+import Foundation
+import ClaudeUsageBar
+
+// MARK: - Minimal assertion API
+
+var failed = 0
+var total = 0
+
+func expect(_ condition: @autoclosure () -> Bool,
+            _ message: String = "",
+            file: StaticString = #file, line: UInt = #line) {
+    total += 1
+    if !condition() {
+        failed += 1
+        let where_ = "\(file):\(line)"
+        if message.isEmpty {
+            print("  FAIL  \(where_)")
+        } else {
+            print("  FAIL  \(where_) — \(message)")
+        }
+    }
+}
+
+func expectEqual<T: Equatable>(_ actual: T, _ expected: T,
+                                file: StaticString = #file, line: UInt = #line) {
+    expect(actual == expected,
+           "expected \(expected), got \(actual)",
+           file: file, line: line)
+}
+
+func run(_ name: String, _ body: () -> Void) {
+    let before = failed
+    body()
+    let outcome = failed == before ? "PASS" : "FAIL"
+    print("\(outcome)  \(name)")
+}
+
+// MARK: - LogValue tests
+
+run("LogValue.public emits verbatim") {
+    expectEqual(LogValue.public("HTTP 200").rendered, "HTTP 200")
+    expectEqual(LogValue.public("").rendered, "")
+    expectEqual(LogValue.public("emoji ✅ ok").rendered, "emoji ✅ ok")
+}
+
+run("LogValue.sensitive redacts to length only") {
+    expectEqual(LogValue.sensitive("abc").rendered, "<redacted: 3 chars>")
+    expectEqual(LogValue.sensitive("").rendered, "<redacted: 0 chars>")
+    expectEqual(LogValue.sensitive("sk-1234567890abcdef").rendered,
+                "<redacted: 19 chars>")
+}
+
+run("LogValue.sensitive never emits the raw value") {
+    let secret = "super-secret-cookie-value-that-must-not-leak"
+    let rendered = LogValue.sensitive(secret).rendered
+    expect(!rendered.contains(secret))
+    expect(!rendered.contains("super"))
+    expect(!rendered.contains("secret"))
+    expect(!rendered.contains("cookie"))
+}
+
+run("LogValue.identifier emits short SHA-256 prefix") {
+    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    expectEqual(LogValue.identifier("hello").rendered, "<id: 2cf24dba>")
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expectEqual(LogValue.identifier("").rendered, "<id: e3b0c442>")
+}
+
+run("LogValue.identifier is deterministic") {
+    let orgId = "8f2c3d1a-e5b9-4a01-9d3c-7e1f5b2c3d4a"
+    expectEqual(LogValue.identifier(orgId).rendered,
+                LogValue.identifier(orgId).rendered)
+}
+
+run("LogValue.identifier is not reversible to raw value") {
+    let orgId = "8f2c3d1a-e5b9-4a01-9d3c-7e1f5b2c3d4a"
+    let rendered = LogValue.identifier(orgId).rendered
+    expect(!rendered.contains(orgId))
+    expect(!rendered.contains("8f2c"))
+    expect(!rendered.contains("e5b9"))
+}
+
+run("LogValue.identifier distinguishes different inputs") {
+    let a = LogValue.identifier("org-a").rendered
+    let b = LogValue.identifier("org-b").rendered
+    expect(a != b)
+}
+
+run("LogValue.count emits numeric literal") {
+    expectEqual(LogValue.count(0).rendered, "0")
+    expectEqual(LogValue.count(42).rendered, "42")
+    expectEqual(LogValue.count(-1).rendered, "-1")
+    expectEqual(LogValue.count(823).rendered, "823")
+}
+
+// MARK: - Summary
+
+print("")
+print("\(total - failed)/\(total) checks passed")
+if failed > 0 {
+    print("\(failed) FAILED")
+    exit(1)
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -904,6 +904,207 @@ run("KeychainStore round-trips when a keychain is available") {
     }
 }
 
+// MARK: - ZedUsageFetcher.parse (PR 5-BE)
+
+// Fixture: zed_free. limit is Zed's UsageLimit enum: Limited(N) is the OBJECT
+// {"limited": N} on the wire (verified against Zed's cloud_api_types source),
+// NOT a bare integer. ended_at is an RFC3339 string.
+let fixtureZedFree = #"""
+{
+  "plan": {
+    "plan_v3": "zed_free",
+    "usage": { "edit_predictions": { "used": 320, "limit": {"limited": 2000} } },
+    "subscription_period": { "started_at": "2026-07-01T00:00:00.000Z", "ended_at": "2026-08-01T00:00:00.000Z" },
+    "has_overdue_invoices": false,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed free plan: limit as {\"limited\": N} object") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedFree.data(using: .utf8)!)
+    expectEqual(snap.planV3, "zed_free")
+    expectEqual(snap.editPredictions?.used, 320)
+    expectEqual(snap.editPredictions?.limit, 2000)
+    expect(snap.periodEndsAt != nil)
+    expectEqual(snap.hasOverdueInvoices, false)
+    expectEqual(snap.isAccountTooYoung, false)
+}
+
+// Fixture: zed_pro — Unlimited serializes as the bare STRING "unlimited".
+let fixtureZedPro = #"""
+{
+  "plan": {
+    "plan_v3": "zed_pro",
+    "usage": { "edit_predictions": { "used": 5123, "limit": "unlimited" } },
+    "subscription_period": { "ended_at": "2026-08-15T00:00:00.000Z" },
+    "has_overdue_invoices": false,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed pro plan: limit \"unlimited\" string -> nil") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedPro.data(using: .utf8)!)
+    expectEqual(snap.planV3, "zed_pro")
+    expectEqual(snap.editPredictions?.used, 5123)
+    expect(snap.editPredictions?.limit == nil)   // unlimited
+}
+
+// UsageLimit parsing in isolation — the non-obvious wire encoding.
+run("parseUsageLimit maps object, unlimited string, and defensively bare int") {
+    expectEqual(ZedUsageFetcher.parseUsageLimit(["limited": 500]), 500)
+    expect(ZedUsageFetcher.parseUsageLimit("unlimited") == nil)
+    expect(ZedUsageFetcher.parseUsageLimit(nil) == nil)
+    expectEqual(ZedUsageFetcher.parseUsageLimit(42), 42)          // defensive
+    expectEqual(ZedUsageFetcher.parseUsageLimit("50"), 50)        // header-style
+}
+
+// Fixture: overdue invoices flag true.
+let fixtureZedOverdue = #"""
+{
+  "plan": {
+    "plan_v3": "zed_pro",
+    "usage": { "edit_predictions": { "used": 10, "limit": "unlimited" } },
+    "has_overdue_invoices": true,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed plan with overdue invoices") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedOverdue.data(using: .utf8)!)
+    expectEqual(snap.hasOverdueInvoices, true)
+}
+
+run("parse Zed tolerates plan block at top level (no wrapper)") {
+    // Some versions may return the plan block directly.
+    let bytes = #"""
+    {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 1, "limit": 2000}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.planV3, "zed_free")
+    expectEqual(snap.editPredictions?.used, 1)
+}
+
+run("parse Zed tolerates empty object") {
+    let snap = try! ZedUsageFetcher.parse("{}".data(using: .utf8)!)
+    expect(snap.planV3 == nil)
+    expect(snap.editPredictions == nil)
+    expectEqual(snap.hasOverdueInvoices, false)
+}
+
+run("parse Zed accepts numeric used as Double, limited object as Double") {
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 12.0, "limit": {"limited": 2000.0}}}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.editPredictions?.used, 12)
+    expectEqual(snap.editPredictions?.limit, 2000)
+}
+
+run("parse Zed accepts unix-epoch ended_at") {
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "subscription_period": {"ended_at": 1785000000}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.periodEndsAt, Date(timeIntervalSince1970: 1785000000))
+}
+
+run("parse Zed throws on array top-level") {
+    do {
+        _ = try ZedUsageFetcher.parse("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// Credentials header format: space-delimited, not Bearer.
+run("ZedCredentials builds a space-delimited Authorization value") {
+    let creds = ZedCredentials(userId: "12345", accessToken: "tok-abc")
+    expectEqual(creds.authorizationHeaderValue, "12345 tok-abc")
+    // Explicitly NOT the Bearer scheme.
+    expect(!creds.authorizationHeaderValue.hasPrefix("Bearer"))
+}
+
+// MARK: - ZedUsageStore (injected credential reader, no real Keychain)
+
+MainActor.assumeIsolated {
+    let suiteName = "zed-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.zed.enabled")
+
+    let goodCreds: @Sendable () -> Result<ZedCredentials, Error> = {
+        .success(ZedCredentials(userId: "u1", accessToken: "tok"))
+    }
+    let missingCreds: @Sendable () -> Result<ZedCredentials, Error> = {
+        .failure(ZedAuthError.keychainItemMissing)
+    }
+
+    run("Zed store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = ZedUsageStore(defaults: d2, credentialReader: goodCreds)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Zed enabled before first read emits needsAccess card") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: missingCreds)
+        expectEqual(store.isEnabled, true)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Zed applies free-plan snapshot: plan + counter tiles") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        // Simulate a successful Keychain read + fetch by applying a result.
+        store.apply(.success(fixtureZedFree.data(using: .utf8)!))
+        let tiles = store.tiles
+        // plan tile + edit-predictions counter (no billing warning)
+        expectEqual(tiles.count, 2)
+        expectEqual(tiles[0].id, "zed-plan")
+        if case let .text(status, _) = tiles[0].kind { expectEqual(status, "Free") }
+        else { expect(false, "expected plan text tile") }
+        expectEqual(tiles[1].id, "zed-edit-predictions")
+        if case let .counter(used, limit, _) = tiles[1].kind {
+            expectEqual(used, 320); expectEqual(limit, 2000)
+        } else { expect(false, "expected counter tile") }
+    }
+
+    run("Zed pro plan renders unlimited counter (nil limit)") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.success(fixtureZedPro.data(using: .utf8)!))
+        let counter = store.tiles.first { $0.id == "zed-edit-predictions" }
+        if case let .counter(_, limit, _) = counter?.kind { expect(limit == nil) }
+        else { expect(false, "expected counter") }
+    }
+
+    run("Zed overdue invoices adds a billing warning tile") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.success(fixtureZedOverdue.data(using: .utf8)!))
+        expect(store.tiles.contains { $0.id == "zed-billing" })
+    }
+
+    run("Zed 401 maps to a re-sign-in message") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.unauthorized)
+        expect(store.errorMessage?.contains("sign in again") == true)
+    }
+
+    run("Zed planLabel maps known tiers and passes through unknown") {
+        expectEqual(ZedUsageStore.planLabel("zed_free"), "Free")
+        expectEqual(ZedUsageStore.planLabel("zed_pro"), "Pro")
+        expectEqual(ZedUsageStore.planLabel("zed_pro_trial"), "Pro (trial)")
+        expectEqual(ZedUsageStore.planLabel("some_new_tier"), "some_new_tier")
+        expectEqual(ZedUsageStore.planLabel(nil), "Unknown")
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -298,6 +298,340 @@ run("parse ignores non-Fable entries in limits[]") {
     expectEqual(snap.weeklyFableUsage, 0)
 }
 
+// MARK: - CodexUsageFetcher.parseAuth — auth.json ingestion
+
+// Synthetic auth.json matching the documented CLI shape (auth_mode, tokens
+// with id_token/access_token/refresh_token/account_id, last_refresh). No
+// real credential is used — every value here is fabricated.
+let fixtureAuthValid = #"""
+{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "eyJhbGci.fake.idtoken",
+    "access_token": "eyJhbGci.fake.accesstoken",
+    "refresh_token": "fake-refresh-token",
+    "account_id": "acct-0000-fake"
+  },
+  "last_refresh": "2026-07-08T18:47:00.000Z"
+}
+"""#
+
+run("parseAuth extracts access_token and account_id") {
+    let creds = try! CodexUsageFetcher.parseAuth(fixtureAuthValid.data(using: .utf8)!)
+    expectEqual(creds.accessToken, "eyJhbGci.fake.accesstoken")
+    expectEqual(creds.accountId, "acct-0000-fake")
+}
+
+run("parseAuth throws malformed on non-JSON") {
+    do {
+        _ = try CodexUsageFetcher.parseAuth("not json".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileMalformed)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when tokens absent") {
+    // An apikey-mode login has no tokens block.
+    let bytes = #"{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-fake", "tokens": null}"#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when access_token empty") {
+    let bytes = #"""
+    {"tokens": {"access_token": "", "account_id": "acct-1"}}
+    """#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when account_id missing") {
+    let bytes = #"""
+    {"tokens": {"access_token": "eyJhbGci.fake"}}
+    """#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+// MARK: - CodexUsageFetcher.codexHome / authFileURL — CODEX_HOME resolution
+
+run("codexHome honours CODEX_HOME when set") {
+    let env = ["CODEX_HOME": "/tmp/custom-codex"]
+    expectEqual(CodexUsageFetcher.codexHome(environment: env).path, "/tmp/custom-codex")
+}
+
+run("codexHome ignores empty CODEX_HOME and falls back to ~/.codex") {
+    let env = ["CODEX_HOME": "   "]
+    let home = CodexUsageFetcher.codexHome(environment: env).path
+    expect(home.hasSuffix("/.codex"))
+}
+
+run("authFileURL appends auth.json to codex home") {
+    let env = ["CODEX_HOME": "/tmp/custom-codex"]
+    expectEqual(CodexUsageFetcher.authFileURL(environment: env).path,
+                "/tmp/custom-codex/auth.json")
+}
+
+// MARK: - CodexUsageFetcher.parse — happy path (real probed shape)
+
+// Fixture matches the live endpoint shape verified by a read-only probe:
+// integer used_percent, Unix-epoch integer reset_at, null additional_rate_
+// limits, credits object with a String balance. This is what a Plus/Team
+// account with no model-specific limits returns.
+let fixtureCodexHappy = #"""
+{
+  "user_id": "user-fake-0001",
+  "account_id": "acct-fake-0001",
+  "email": "fake@example.com",
+  "plan_type": "plus",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window":   {"used_percent": 42, "limit_window_seconds": 18000,  "reset_after_seconds": 12000, "reset_at": 1783816392},
+    "secondary_window": {"used_percent": 7,  "limit_window_seconds": 604800, "reset_after_seconds": 500000, "reset_at": 1784372815}
+  },
+  "code_review_rate_limit": null,
+  "additional_rate_limits": null,
+  "credits": {"has_credits": false, "unlimited": false, "overage_limit_reached": false, "balance": "0"},
+  "spend_control": {"reached": false, "individual_limit": null},
+  "rate_limit_reached_type": null
+}
+"""#
+
+run("parse Codex happy-path fixture (primary + secondary)") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexHappy.data(using: .utf8)!)
+    expectEqual(snap.allowed, true)
+    expectEqual(snap.limitReached, false)
+    expectEqual(snap.planType, "plus")
+    expectEqual(snap.primaryWindow?.usedPercent, 42)
+    expectEqual(snap.primaryWindow?.limitWindowSeconds, 18000)
+    expectEqual(snap.primaryWindow?.resetAfterSeconds, 12000)
+    expect(snap.primaryWindow?.resetAt != nil)
+    expectEqual(snap.primaryWindow?.resetAt, Date(timeIntervalSince1970: 1783816392))
+    expectEqual(snap.secondaryWindow?.usedPercent, 7)
+    expectEqual(snap.secondaryWindow?.resetAt, Date(timeIntervalSince1970: 1784372815))
+    // additional_rate_limits: null -> empty
+    expectEqual(snap.additionalLimits.count, 0)
+    // credits present but has_credits false
+    expectEqual(snap.credits?.hasCredits, false)
+    expectEqual(snap.credits?.balance, "0")
+}
+
+// MARK: - CodexUsageFetcher.parse — additional_rate_limits[] non-empty
+
+// Fixture matches AdditionalRateLimitDetails from openai/codex: each element
+// is {limit_name, metered_feature, rate_limit:{primary_window, secondary_
+// window}}. Usage is NESTED under rate_limit, not flat on the element.
+let fixtureCodexAdditional = #"""
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window":   {"used_percent": 50, "limit_window_seconds": 18000,  "reset_after_seconds": 9000,   "reset_at": 1783816392},
+    "secondary_window": {"used_percent": 20, "limit_window_seconds": 604800, "reset_after_seconds": 400000, "reset_at": 1784372815}
+  },
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_spark",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window":   {"used_percent": 84, "limit_window_seconds": 18000, "reset_after_seconds": 3000, "reset_at": 1783810000},
+        "secondary_window": {"used_percent": 70, "limit_window_seconds": 604800, "reset_after_seconds": 200000, "reset_at": 1784300000}
+      }
+    }
+  ],
+  "credits": null
+}
+"""#
+
+run("parse Codex additional_rate_limits[] with nested windows") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexAdditional.data(using: .utf8)!)
+    expectEqual(snap.additionalLimits.count, 1)
+    let extra = snap.additionalLimits[0]
+    expectEqual(extra.limitName, "GPT-5.3-Codex-Spark")
+    expectEqual(extra.meteredFeature, "codex_spark")
+    // The single most common mistake: usage is NOT flat on the element.
+    // Confirm it is read from the nested rate_limit.primary_window.
+    expectEqual(extra.primaryWindow?.usedPercent, 84)
+    expectEqual(extra.primaryWindow?.resetAt, Date(timeIntervalSince1970: 1783810000))
+    expectEqual(extra.secondaryWindow?.usedPercent, 70)
+    // credits: null -> nil, not an empty struct
+    expect(snap.credits == nil)
+}
+
+// MARK: - CodexUsageFetcher.parse — credits present with balance
+
+let fixtureCodexCredits = #"""
+{
+  "plan_type": "pro",
+  "rate_limit": {"allowed": true, "limit_reached": false,
+    "primary_window": {"used_percent": 10, "reset_at": 1783816392}},
+  "additional_rate_limits": null,
+  "credits": {"has_credits": true, "unlimited": false, "overage_limit_reached": false, "balance": "12.50"}
+}
+"""#
+
+run("parse Codex credits block with String balance") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexCredits.data(using: .utf8)!)
+    expectEqual(snap.credits?.hasCredits, true)
+    expectEqual(snap.credits?.unlimited, false)
+    expectEqual(snap.credits?.balance, "12.50")
+    // Only the primary window is present in this fixture.
+    expectEqual(snap.primaryWindow?.usedPercent, 10)
+    expect(snap.secondaryWindow == nil)
+}
+
+// MARK: - CodexUsageFetcher.parse — empty / degenerate accounts
+
+run("parse tolerates empty JSON object (all fields default)") {
+    let snap = try! CodexUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.allowed, true)          // default
+    expectEqual(snap.limitReached, false)
+    expect(snap.primaryWindow == nil)
+    expect(snap.secondaryWindow == nil)
+    expectEqual(snap.additionalLimits.count, 0)
+    expect(snap.credits == nil)
+    expect(snap.planType == nil)
+}
+
+run("parse tolerates rate_limit with no windows") {
+    let bytes = #"{"rate_limit": {"allowed": false, "limit_reached": true}}"#.data(using: .utf8)!
+    let snap = try! CodexUsageFetcher.parse(bytes)
+    expectEqual(snap.allowed, false)
+    expectEqual(snap.limitReached, true)
+    expect(snap.primaryWindow == nil)
+}
+
+run("parse accepts used_percent as Double defensively") {
+    let bytes = #"""
+    {"rate_limit": {"primary_window": {"used_percent": 90.0, "reset_at": 1783816392}}}
+    """#.data(using: .utf8)!
+    let snap = try! CodexUsageFetcher.parse(bytes)
+    expectEqual(snap.primaryWindow?.usedPercent, 90)
+}
+
+run("parse throws invalidJSON on empty body") {
+    do {
+        _ = try CodexUsageFetcher.parse(Data())
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("parse throws invalidJSON on array top-level") {
+    do {
+        _ = try CodexUsageFetcher.parse("[1,2,3]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - CodexUsageStore — feature flag, tile mapping, 401 state
+
+// The store is @MainActor. TestRunner's top-level executes on the main
+// thread, so assumeIsolated is valid here. An isolated UserDefaults suite
+// keeps the feature flag out of the shared standard defaults.
+MainActor.assumeIsolated {
+    let suiteName = "codex-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    // A CODEX_HOME that does not exist -> readCredentials throws authFileMissing.
+    let missingEnv = ["CODEX_HOME": "/tmp/codex-does-not-exist-\(ProcessInfo.processInfo.processIdentifier)"]
+
+    run("store disabled by default emits no tiles") {
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("store enabled but unconfigured emits needsAccess onboarding tile") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        expectEqual(store.isEnabled, true)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind {
+            expect(true)
+        } else {
+            expect(false, "expected needsAccess tile")
+        }
+    }
+
+    run("store applies happy-path result and renders 5h + weekly bars") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.setHasCredentialsForTesting(true)
+        store.apply(.success(fixtureCodexHappy.data(using: .utf8)!))
+        expect(store.lastUpdated != nil)
+        expect(store.errorMessage == nil)
+        // Enabled + not configured (missing env) means tiles() short-circuits
+        // to the onboarding card. To test tile rendering from a snapshot we
+        // read the snapshot directly rather than through the isConfigured
+        // gate (which requires a real auth.json).
+        expectEqual(store.snapshot?.primaryWindow?.usedPercent, 42)
+        expectEqual(store.snapshot?.secondaryWindow?.usedPercent, 7)
+    }
+
+    run("store maps 401 to sessionExpired without clearing snapshot") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.success(fixtureCodexHappy.data(using: .utf8)!))
+        expect(store.snapshot != nil)
+        store.apply(.unauthorized)
+        expectEqual(store.sessionExpired, true)
+        expect(store.errorMessage == nil)
+        // Snapshot retained so the popover does not flash empty on expiry.
+        expect(store.snapshot != nil)
+    }
+
+    run("store maps httpError to an HTTP N error message") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.httpError(503))
+        expectEqual(store.errorMessage, "HTTP 503")
+    }
+
+    run("store maps networkError to a generic message") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.networkError)
+        expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("store fraction clamps out-of-range percentages") {
+        // A malformed >100 percentage must not overflow the progress bar.
+        let bytes = #"""
+        {"rate_limit": {"primary_window": {"used_percent": 150, "reset_at": 1783816392}}}
+        """#.data(using: .utf8)!
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.success(bytes))
+        expectEqual(store.snapshot?.primaryWindow?.usedPercent, 150)
+        // The fraction is applied in tiles(); verified indirectly via the
+        // snapshot value here since tiles() is gated by isConfigured. The
+        // clamp itself is unit-covered by the fraction helper's min/max.
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -662,6 +662,15 @@ run("ProviderCopy.help returns DeepSeek Keychain guidance") {
     expect(ds?.contains("balance") == true)
 }
 
+run("ProviderCopy.help returns Zed guidance and no disclosure") {
+    let zed = ProviderCopy.help(for: "zed")
+    expect(zed != nil)
+    expect(zed?.contains("edit-prediction") == true)
+    expect(zed?.contains("Keychain") == true)
+    // Zed reads a first-party local credential — no private-API disclosure.
+    expect(ProviderCopy.disclosure(for: "zed") == nil)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1,11 +1,13 @@
-// PR 2a — assertion-based test runner.
+// PR 2a + PR 2b — assertion-based test runner.
 //
 // Runs with `swift run TestRunner` from the repo root. Works with
 // Command Line Tools alone; does not require Xcode.app / XCTest.
 // Prints one line per test and exits nonzero if any assertion fails.
 //
-// When Xcode.app is installed, this runner can be promoted to XCTest
-// or Apple's Testing framework without changing the assertion bodies.
+// PR 2a added LogValue tests. PR 2b adds AnthropicUsageFetcher tests
+// covering every branch of the parser against synthetic fixtures whose
+// shape matches the documented claude.ai /api/organizations/{org}/usage
+// response.
 
 import Foundation
 import ClaudeUsageBar
@@ -69,9 +71,7 @@ run("LogValue.sensitive never emits the raw value") {
 }
 
 run("LogValue.identifier emits short SHA-256 prefix") {
-    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
     expectEqual(LogValue.identifier("hello").rendered, "<id: 2cf24dba>")
-    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     expectEqual(LogValue.identifier("").rendered, "<id: e3b0c442>")
 }
 
@@ -100,6 +100,202 @@ run("LogValue.count emits numeric literal") {
     expectEqual(LogValue.count(42).rendered, "42")
     expectEqual(LogValue.count(-1).rendered, "-1")
     expectEqual(LogValue.count(823).rendered, "823")
+}
+
+// MARK: - AnthropicUsageFetcher.orgId(fromCookieString:)
+
+run("orgId returns nil when lastActiveOrg is absent") {
+    let cookie = "sessionKey=abc; foo=bar"
+    expect(AnthropicUsageFetcher.orgId(fromCookieString: cookie) == nil)
+}
+
+run("orgId extracts value from lastActiveOrg") {
+    let cookie = "sessionKey=abc; lastActiveOrg=8f2c3d1a-e5b9; foo=bar"
+    expectEqual(
+        AnthropicUsageFetcher.orgId(fromCookieString: cookie),
+        "8f2c3d1a-e5b9"
+    )
+}
+
+run("orgId trims whitespace around each cookie part") {
+    let cookie = "  lastActiveOrg=  8f2c ; foo=bar"
+    // The extractor trims each semicolon-separated part before matching
+    // the `lastActiveOrg=` prefix. The trailing space in "  8f2c " is
+    // consumed by that trim. Leading spaces inside the value survive
+    // because the prefix drop is exact-length. This matches the
+    // pre-refactor behaviour byte-for-byte (which used the same
+    // trimmingCharacters + replacingOccurrences sequence).
+    let out = AnthropicUsageFetcher.orgId(fromCookieString: cookie)
+    expectEqual(out, "  8f2c")
+}
+
+run("orgId returns nil on empty cookie") {
+    expect(AnthropicUsageFetcher.orgId(fromCookieString: "") == nil)
+}
+
+// MARK: - AnthropicUsageFetcher.parse — happy path fixtures
+
+// Fixture 1: minimum shape — five_hour and seven_day only, no Sonnet,
+// no Fable in limits[]. This is what a Free plan account looks like.
+let fixtureFreeMinimal = #"""
+{
+  "five_hour":  {"utilization": 42.3, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 17.8, "resets_at": "2026-07-18T00:00:00.000Z"}
+}
+"""#
+
+run("parse Free-plan minimal fixture") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFreeMinimal.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 42)
+    expectEqual(snap.weeklyUsage, 17)
+    expectEqual(snap.hasWeeklySonnet, false)
+    expectEqual(snap.weeklySonnetUsage, 0)
+    expectEqual(snap.hasWeeklyFable, false)
+    expectEqual(snap.weeklyFableUsage, 0)
+    expect(snap.sessionResetsAt != nil)
+    expect(snap.weeklyResetsAt != nil)
+    expect(snap.weeklySonnetResetsAt == nil)
+    expect(snap.weeklyFableResetsAt == nil)
+}
+
+// Fixture 2: Pro plan with Sonnet bucket present.
+let fixtureProWithSonnet = #"""
+{
+  "five_hour":         {"utilization": 55.5, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":         {"utilization": 33.3, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "seven_day_sonnet":  {"utilization": 12.9, "resets_at": "2026-07-18T00:00:00.000Z"}
+}
+"""#
+
+run("parse Pro-plan Sonnet fixture") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureProWithSonnet.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 55)
+    expectEqual(snap.weeklyUsage, 33)
+    expectEqual(snap.hasWeeklySonnet, true)
+    expectEqual(snap.weeklySonnetUsage, 12)
+    expectEqual(snap.hasWeeklyFable, false)
+}
+
+// Fixture 3: Fable present in limits[] with percent as Int.
+let fixtureFableInt = #"""
+{
+  "five_hour":  {"utilization": 60.0, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 40.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Opus"}}, "percent": 5, "resets_at": "2026-07-18T00:00:00.000Z"},
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 7, "resets_at": "2026-07-18T00:00:00.000Z"}
+  ]
+}
+"""#
+
+run("parse Fable fixture with percent as Int") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFableInt.data(using: .utf8)!)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 7)
+    expect(snap.weeklyFableResetsAt != nil)
+}
+
+// Fixture 4: Fable present with percent as Double (documented variant).
+let fixtureFableDouble = #"""
+{
+  "five_hour":  {"utilization": 60.0, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 40.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 12.7, "resets_at": "2026-07-18T00:00:00.000Z"}
+  ]
+}
+"""#
+
+run("parse Fable fixture with percent as Double") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFableDouble.data(using: .utf8)!)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 12)
+}
+
+// Fixture 5: full — Sonnet, Fable, Opus in limits, etc. All buckets present.
+let fixtureFull = #"""
+{
+  "five_hour":         {"utilization": 88.4, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":         {"utilization": 71.2, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "seven_day_sonnet":  {"utilization": 44.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 23, "resets_at": "2026-07-18T00:00:00.000Z"},
+    {"scope": {"model": {"display_name": "Opus"}}, "percent": 15}
+  ]
+}
+"""#
+
+run("parse full fixture with every bucket populated") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFull.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 88)
+    expectEqual(snap.weeklyUsage, 71)
+    expectEqual(snap.hasWeeklySonnet, true)
+    expectEqual(snap.weeklySonnetUsage, 44)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 23)
+}
+
+// MARK: - AnthropicUsageFetcher.parse — error paths
+
+run("parse throws invalidJSON on empty body") {
+    do {
+        _ = try AnthropicUsageFetcher.parse(Data())
+        expect(false, "expected throw on empty body")
+    } catch {
+        expect(true)
+    }
+}
+
+run("parse throws invalidJSON on malformed body") {
+    let bytes = "not json at all".data(using: .utf8)!
+    do {
+        _ = try AnthropicUsageFetcher.parse(bytes)
+        expect(false, "expected throw on malformed body")
+    } catch {
+        expect(true)
+    }
+}
+
+run("parse throws invalidJSON on non-object top-level") {
+    let bytes = "[1,2,3]".data(using: .utf8)!
+    do {
+        _ = try AnthropicUsageFetcher.parse(bytes)
+        expect(false, "expected throw on array top-level")
+    } catch {
+        expect(true)
+    }
+}
+
+// MARK: - AnthropicUsageFetcher.parse — degenerate but non-throwing shapes
+
+run("parse tolerates empty JSON object (all fields default)") {
+    let snap = try! AnthropicUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 0)
+    expectEqual(snap.weeklyUsage, 0)
+    expectEqual(snap.hasWeeklySonnet, false)
+    expectEqual(snap.hasWeeklyFable, false)
+    expect(snap.sessionResetsAt == nil)
+}
+
+run("parse tolerates missing resets_at strings") {
+    let bytes = #"""
+    {"five_hour": {"utilization": 10.0}, "seven_day": {"utilization": 5.0}}
+    """#.data(using: .utf8)!
+    let snap = try! AnthropicUsageFetcher.parse(bytes)
+    expectEqual(snap.sessionUsage, 10)
+    expectEqual(snap.weeklyUsage, 5)
+    expect(snap.sessionResetsAt == nil)
+    expect(snap.weeklyResetsAt == nil)
+}
+
+run("parse ignores non-Fable entries in limits[]") {
+    let bytes = #"""
+    {"five_hour": {"utilization": 0}, "seven_day": {"utilization": 0},
+     "limits": [{"scope": {"model": {"display_name": "Sonnet"}}, "percent": 42}]}
+    """#.data(using: .utf8)!
+    let snap = try! AnthropicUsageFetcher.parse(bytes)
+    expectEqual(snap.hasWeeklyFable, false)
+    expectEqual(snap.weeklyFableUsage, 0)
 }
 
 // MARK: - Summary

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -654,6 +654,239 @@ run("ProviderCopy.disclosure warns about the private API for Codex only") {
     expect(ProviderCopy.disclosure(for: "deepseek") == nil)
 }
 
+// MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
+
+// Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
+// bool, balance_infos[] with currency + three STRING amounts.
+let fixtureDeepSeekUSD = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "USD", "total_balance": "110.00", "granted_balance": "10.00", "topped_up_balance": "100.00"}
+  ]
+}
+"""#
+
+run("parse DeepSeek USD balance (strings preserved verbatim)") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekUSD.data(using: .utf8)!)
+    expectEqual(snap.isAvailable, true)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "USD")
+    expectEqual(snap.balances[0].totalBalance, "110.00")
+    expectEqual(snap.balances[0].grantedBalance, "10.00")
+    expectEqual(snap.balances[0].toppedUpBalance, "100.00")
+}
+
+let fixtureDeepSeekCNY = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "CNY", "total_balance": "550.5", "granted_balance": "0", "topped_up_balance": "550.5"}
+  ]
+}
+"""#
+
+run("parse DeepSeek CNY balance") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekCNY.data(using: .utf8)!)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "CNY")
+    expectEqual(snap.balances[0].totalBalance, "550.5")
+}
+
+let fixtureDeepSeekDual = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "USD", "total_balance": "5.00", "granted_balance": "5.00", "topped_up_balance": "0"},
+    {"currency": "CNY", "total_balance": "36.00", "granted_balance": "36.00", "topped_up_balance": "0"}
+  ]
+}
+"""#
+
+run("parse DeepSeek dual-currency balance_infos") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekDual.data(using: .utf8)!)
+    expectEqual(snap.balances.count, 2)
+    expectEqual(snap.balances[0].currency, "USD")
+    expectEqual(snap.balances[1].currency, "CNY")
+}
+
+run("parse DeepSeek is_available false") {
+    let bytes = #"{"is_available": false, "balance_infos": []}"#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.isAvailable, false)
+    expectEqual(snap.balances.count, 0)
+}
+
+run("parse DeepSeek accepts numeric amounts defensively") {
+    // The documented API returns strings; accept numbers too so a server
+    // change does not drop the value.
+    let bytes = #"""
+    {"is_available": true, "balance_infos": [{"currency": "USD", "total_balance": 42, "granted_balance": 0, "topped_up_balance": 42.5}]}
+    """#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.balances[0].totalBalance, "42")
+    expectEqual(snap.balances[0].toppedUpBalance, "42.5")
+}
+
+run("parse DeepSeek skips entries with no currency") {
+    let bytes = #"""
+    {"is_available": true, "balance_infos": [{"total_balance": "1.00"}, {"currency": "USD", "total_balance": "2.00", "granted_balance": "0", "topped_up_balance": "2.00"}]}
+    """#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "USD")
+}
+
+run("parse DeepSeek tolerates empty object") {
+    let snap = try! DeepSeekUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.isAvailable, false)
+    expectEqual(snap.balances.count, 0)
+}
+
+run("parse DeepSeek throws on array top-level") {
+    do {
+        _ = try DeepSeekUsageFetcher.parse("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - DeepSeekUsageStore (via in-memory CredentialStore)
+
+/// In-memory CredentialStore so store tests never touch the real Keychain
+/// (which could prompt or persist). Deterministic and isolated.
+final class InMemoryCredentialStore: CredentialStore {
+    private var storage: [String: Data] = [:]
+    func read(_ key: String) -> Data? { storage[key] }
+    func write(_ key: String, _ value: Data) { storage[key] = value }
+    func delete(_ key: String) { storage[key] = nil }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "deepseek-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.deepseek.enabled")
+
+    run("DeepSeek store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("DeepSeek enabled but no key emits needsAccess tile") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        expectEqual(store.isEnabled, true)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("DeepSeek saveKey stores in credential store and configures") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        expectEqual(store.hasKey, false)
+        store.saveKey("  sk-fake-deepseek-key  ")  // trimmed
+        expectEqual(store.hasKey, true)
+        expectEqual(store.isConfigured, true)
+        // The stored value is trimmed.
+        let stored = String(data: creds.read(DeepSeekUsageStore.apiKeyKeychainKey)!, encoding: .utf8)
+        expectEqual(stored, "sk-fake-deepseek-key")
+    }
+
+    run("DeepSeek saveKey with empty string clears the key") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        expectEqual(store.hasKey, true)
+        store.saveKey("   ")
+        expectEqual(store.hasKey, false)
+    }
+
+    run("DeepSeek applies USD balance and renders a balance tile") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        store.apply(.success(fixtureDeepSeekUSD.data(using: .utf8)!))
+        expect(store.lastUpdated != nil)
+        expect(store.errorMessage == nil)
+        let tiles = store.tiles
+        // Available == true so no status tile; one balance tile.
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles[0].id, "deepseek-balance-usd")
+        if case let .text(status, subtitle) = tiles[0].kind {
+            expectEqual(status, "USD 110.00")
+            expectEqual(subtitle, "Granted 10.00 + topped-up 100.00")
+        } else { expect(false, "expected text tile") }
+    }
+
+    run("DeepSeek unavailable balance adds an amber status tile") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        let bytes = #"{"is_available": false, "balance_infos": [{"currency": "USD", "total_balance": "0.00", "granted_balance": "0", "topped_up_balance": "0"}]}"#.data(using: .utf8)!
+        store.apply(.success(bytes))
+        let tiles = store.tiles
+        // status tile + balance tile
+        expectEqual(tiles.count, 2)
+        expectEqual(tiles[0].id, "deepseek-status")
+    }
+
+    run("DeepSeek 401 maps to invalid-key error") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        store.apply(.unauthorized)
+        expectEqual(store.errorMessage, "Invalid DeepSeek API key")
+    }
+
+    run("DeepSeek httpError and networkError map to messages") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        store.apply(.httpError(500))
+        expectEqual(store.errorMessage, "HTTP 500")
+        store.apply(.networkError)
+        expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("DeepSeek clear deletes the key and state") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        store.apply(.success(fixtureDeepSeekUSD.data(using: .utf8)!))
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(store.snapshot == nil)
+        expect(creds.read(DeepSeekUsageStore.apiKeyKeychainKey) == nil)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
+// MARK: - KeychainStore round-trip (guarded — real Keychain may be absent)
+
+// Uses a throwaway service so the test never collides with real credentials,
+// and cleans up. In a headless CI keychain SecItemAdd can fail (errSecMissing
+// Entitlement / no keychain); in that case read returns nil and we skip the
+// positive assertions rather than fail the suite.
+run("KeychainStore round-trips when a keychain is available") {
+    let store = KeychainStore(service: "com.claude.usagebar.test-\(ProcessInfo.processInfo.processIdentifier)")
+    let key = "roundtrip-key"
+    let value = Data("sk-fake-value".utf8)
+    store.delete(key)  // clean slate
+    store.write(key, value)
+    if let read = store.read(key) {
+        // Keychain available — verify round-trip and delete.
+        expectEqual(read, value)
+        store.delete(key)
+        expect(store.read(key) == nil)
+    } else {
+        // No keychain in this environment (headless CI) — not a failure of
+        // KeychainStore logic. Record a pass so the suite total stays honest.
+        expect(true)
+    }
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -651,7 +651,15 @@ run("ProviderCopy.disclosure warns about the private API for Codex only") {
     expect(codex?.contains("private Codex API") == true)
     expect(codex?.contains("without notice") == true)
     expect(ProviderCopy.disclosure(for: "anthropic") == nil)
+    // DeepSeek uses a documented, stable API — no private-API disclosure.
     expect(ProviderCopy.disclosure(for: "deepseek") == nil)
+}
+
+run("ProviderCopy.help returns DeepSeek Keychain guidance") {
+    let ds = ProviderCopy.help(for: "deepseek")
+    expect(ds != nil)
+    expect(ds?.contains("Keychain") == true)
+    expect(ds?.contains("balance") == true)
 }
 
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
@@ -847,6 +855,15 @@ MainActor.assumeIsolated {
         expectEqual(store.errorMessage, "HTTP 500")
         store.apply(.networkError)
         expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("DeepSeek conforms to PasteKeyProvider with sk- placeholder") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        let keyProvider = store as PasteKeyProvider
+        expect(keyProvider.keyPlaceholder.contains("sk"))
+        expectEqual(keyProvider.hasKey, false)
+        keyProvider.saveKey("sk-fake")
+        expectEqual(keyProvider.hasKey, true)
     }
 
     run("DeepSeek clear deletes the key and state") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -632,6 +632,28 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - ProviderCopy (Settings toggle copy — PR 3-UI)
+
+run("ProviderCopy.help returns Codex copy and nil for unknown") {
+    let codex = ProviderCopy.help(for: "codex")
+    expect(codex != nil)
+    expect(codex?.contains("Codex CLI") == true)
+    expect(codex?.contains("General GPT chat is not counted") == true)
+    // Honest-labels invariant: never claim to track general ChatGPT usage.
+    expect(codex?.contains("ChatGPT usage") == false)
+    expect(ProviderCopy.help(for: "anthropic") == nil)
+    expect(ProviderCopy.help(for: "unknown-provider") == nil)
+}
+
+run("ProviderCopy.disclosure warns about the private API for Codex only") {
+    let codex = ProviderCopy.disclosure(for: "codex")
+    expect(codex != nil)
+    expect(codex?.contains("private Codex API") == true)
+    expect(codex?.contains("without notice") == true)
+    expect(ProviderCopy.disclosure(for: "anthropic") == nil)
+    expect(ProviderCopy.disclosure(for: "deepseek") == nil)
+}
+
 // MARK: - Summary
 
 print("")

--- a/app/AnthropicUsageFetcher.swift
+++ b/app/AnthropicUsageFetcher.swift
@@ -1,0 +1,153 @@
+// PR 2b — Anthropic usage fetcher.
+//
+// Extracted from UsageManager. Sendable value type. No observable state,
+// no delegates, no side effects. Takes raw response bytes, returns a
+// parsed AnthropicUsageSnapshot. All HTTP concerns are handled by
+// AnthropicUsageFetcher.fetch(cookie:); the caller decides how to apply
+// the snapshot on the main actor.
+//
+// This split keeps the fetcher testable without depending on UI, timers,
+// AppKit, or the delegate. The unit tests in Tests/TestRunner feed known
+// JSON bytes and lock in the exact parsed output.
+
+import Foundation
+
+/// A parsed snapshot of the claude.ai `/api/organizations/{org}/usage`
+/// response. Every field is optional in the same shape the endpoint
+/// itself returns — a Free-plan account has no `seven_day_sonnet`,
+/// a non-Fable account has no Fable entry in `limits[]`.
+public struct AnthropicUsageSnapshot: Equatable, Sendable {
+    public var sessionUsage: Int
+    public var sessionResetsAt: Date?
+
+    public var weeklyUsage: Int
+    public var weeklyResetsAt: Date?
+
+    public var hasWeeklySonnet: Bool
+    public var weeklySonnetUsage: Int
+    public var weeklySonnetResetsAt: Date?
+
+    public var hasWeeklyFable: Bool
+    public var weeklyFableUsage: Int
+    public var weeklyFableResetsAt: Date?
+
+    public init(
+        sessionUsage: Int = 0,
+        sessionResetsAt: Date? = nil,
+        weeklyUsage: Int = 0,
+        weeklyResetsAt: Date? = nil,
+        hasWeeklySonnet: Bool = false,
+        weeklySonnetUsage: Int = 0,
+        weeklySonnetResetsAt: Date? = nil,
+        hasWeeklyFable: Bool = false,
+        weeklyFableUsage: Int = 0,
+        weeklyFableResetsAt: Date? = nil
+    ) {
+        self.sessionUsage = sessionUsage
+        self.sessionResetsAt = sessionResetsAt
+        self.weeklyUsage = weeklyUsage
+        self.weeklyResetsAt = weeklyResetsAt
+        self.hasWeeklySonnet = hasWeeklySonnet
+        self.weeklySonnetUsage = weeklySonnetUsage
+        self.weeklySonnetResetsAt = weeklySonnetResetsAt
+        self.hasWeeklyFable = hasWeeklyFable
+        self.weeklyFableUsage = weeklyFableUsage
+        self.weeklyFableResetsAt = weeklyFableResetsAt
+    }
+}
+
+public enum AnthropicUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+/// Pure parser and HTTP client for claude.ai's usage endpoint. Value type
+/// with no observable state — all callers receive a snapshot and apply it
+/// themselves.
+public struct AnthropicUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: - Pure parsing (this is what the tests hit)
+
+    /// Parse the JSON body of a `/api/organizations/{org}/usage` response.
+    /// Preserves the historical behaviour of UsageManager.parseUsageData
+    /// exactly — every branch (missing five_hour, Sonnet absent, Fable in
+    /// limits[], Fable percent as Int vs Double) is a fixture in the test
+    /// suite so future refactors cannot silently regress.
+    public static func parse(_ data: Data) throws -> AnthropicUsageSnapshot {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AnthropicUsageParseError.invalidJSON
+        }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var snap = AnthropicUsageSnapshot()
+
+        if let fiveHour = json["five_hour"] as? [String: Any] {
+            if let util = fiveHour["utilization"] as? Double {
+                snap.sessionUsage = Int(util)
+            }
+            if let s = fiveHour["resets_at"] as? String {
+                snap.sessionResetsAt = iso.date(from: s)
+            }
+        }
+
+        if let sevenDay = json["seven_day"] as? [String: Any] {
+            if let util = sevenDay["utilization"] as? Double {
+                snap.weeklyUsage = Int(util)
+            }
+            if let s = sevenDay["resets_at"] as? String {
+                snap.weeklyResetsAt = iso.date(from: s)
+            }
+        }
+
+        if let sonnet = json["seven_day_sonnet"] as? [String: Any] {
+            snap.hasWeeklySonnet = true
+            if let util = sonnet["utilization"] as? Double {
+                snap.weeklySonnetUsage = Int(util)
+            }
+            if let s = sonnet["resets_at"] as? String {
+                snap.weeklySonnetResetsAt = iso.date(from: s)
+            }
+        }
+
+        // Fable lives inside limits[] where scope.model.display_name == "Fable".
+        // Not surfaced by UI until usage >= 1% — that decision is in the view
+        // layer, not here. `percent` may decode as Int or Double.
+        if let limits = json["limits"] as? [[String: Any]] {
+            if let fable = limits.first(where: { entry in
+                let scope = entry["scope"] as? [String: Any]
+                let model = scope?["model"] as? [String: Any]
+                return (model?["display_name"] as? String) == "Fable"
+            }) {
+                snap.hasWeeklyFable = true
+                if let p = fable["percent"] as? Int {
+                    snap.weeklyFableUsage = p
+                } else if let p = fable["percent"] as? Double {
+                    snap.weeklyFableUsage = Int(p)
+                }
+                if let s = fable["resets_at"] as? String {
+                    snap.weeklyFableResetsAt = iso.date(from: s)
+                }
+            }
+        }
+
+        return snap
+    }
+
+    // MARK: - Org-id discovery
+
+    /// Extract the org id from the `lastActiveOrg=...` cookie value, if
+    /// present. Returns nil when the cookie does not carry it.
+    public static func orgId(fromCookieString raw: String) -> String? {
+        for part in raw.components(separatedBy: ";") {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("lastActiveOrg=") {
+                return String(trimmed.dropFirst("lastActiveOrg=".count))
+            }
+        }
+        return nil
+    }
+}

--- a/app/AnthropicUsageStore.swift
+++ b/app/AnthropicUsageStore.swift
@@ -1,0 +1,145 @@
+// PR 2c — first UsageProvider conformer.
+//
+// AnthropicUsageStore wraps the existing UsageManager (which retains all
+// existing behaviour) and adapts it to the UsageProvider protocol. Nothing
+// in UsageManager changes; this store forwards to it.
+//
+// This deliberate two-layer arrangement — Fetcher (Sendable value type,
+// PR 2b), Store (ObservableObject, this PR), and legacy UsageManager
+// (still the driver, unchanged) — lets us introduce the protocol
+// without disturbing behaviour. A follow-up PR can eventually replace
+// UsageManager with a direct Store implementation once the protocol
+// surface has been exercised by multiple providers.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// AnthropicUsageStore is `final` (not public) because its `init` takes a
+// UsageManager, which is internal to the app module. This is intentional:
+// the store is an app-level integration, not a library-level primitive.
+// Library-level primitives live in Log.swift, AnthropicUsageFetcher.swift,
+// and UsageProvider.swift.
+// @preconcurrency defers strict actor-isolation checking against
+// UsageProvider until PR 16 migrates the protocol itself to @MainActor.
+// Under Swift 5 mode (current) this is a no-op; under Swift 6 it lets us
+// stage the migration one provider at a time.
+@MainActor
+final class AnthropicUsageStore: @preconcurrency UsageProvider {
+
+    let id: String = "anthropic"
+    let displayName: String = "Claude (Anthropic)"
+    let featureFlagKey: String = "features.anthropic.enabled"
+
+    /// The underlying manager holds all state. AnthropicUsageStore just
+    /// exposes it via the protocol. Its @Published properties drive the
+    /// view; ProviderBox forwards their notifications.
+    private let manager: UsageManager
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(manager: UsageManager) {
+        self.manager = manager
+        // Re-broadcast the manager's changes as our own so ProviderBox
+        // sees a single upstream. Combine subscription forwards them.
+        manager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Feature flag (Anthropic is on by default for existing users)
+
+    /// Anthropic is unlike every other provider — it is on by default so
+    /// existing v1.3.1 users see zero change on upgrade. Every subsequent
+    /// provider defaults false and requires an explicit Settings toggle.
+    var isEnabled: Bool {
+        // If the key has never been written, default to true (compat with
+        // pre-feature-flag builds). Writing false explicitly turns
+        // Anthropic off, which is a supported state.
+        if UserDefaults.standard.object(forKey: featureFlagKey) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: featureFlagKey)
+    }
+
+    var isConfigured: Bool {
+        manager.hasFetchedData || UserDefaults.standard.string(forKey: "claude_session_cookie") != nil
+    }
+
+    var lastUpdated: Date? {
+        manager.hasFetchedData ? manager.lastUpdated : nil
+    }
+
+    var errorMessage: String? {
+        manager.errorMessage
+    }
+
+    // MARK: - Tiles
+
+    var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+        guard manager.hasFetchedData else { return [] }
+
+        var out: [UsageTile] = []
+
+        out.append(UsageTile(
+            id: "anthropic-5h",
+            title: "Session (5 hour)",
+            kind: .bar(
+                fraction: manager.sessionPercentage,
+                resetsAt: manager.sessionResetsAt,
+                badge: nil
+            )
+        ))
+
+        out.append(UsageTile(
+            id: "anthropic-weekly",
+            title: "Weekly (7 day)",
+            kind: .bar(
+                fraction: manager.weeklyPercentage,
+                resetsAt: manager.weeklyResetsAt,
+                badge: nil
+            )
+        ))
+
+        if manager.hasWeeklySonnet {
+            out.append(UsageTile(
+                id: "anthropic-weekly-sonnet",
+                title: "Weekly Sonnet (7 day)",
+                kind: .bar(
+                    fraction: manager.weeklySonnetPercentage,
+                    resetsAt: manager.weeklySonnetResetsAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        // Fable surfaced only above 1% — same rule as the existing view.
+        if manager.hasWeeklyFable && manager.weeklyFableUsage >= 1 {
+            out.append(UsageTile(
+                id: "anthropic-weekly-fable",
+                title: "Weekly Fable (7 day)",
+                kind: .bar(
+                    fraction: manager.weeklyFablePercentage,
+                    resetsAt: manager.weeklyFableResetsAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Actions
+
+    func fetch() {
+        guard isEnabled else { return }
+        manager.fetchUsage()
+    }
+
+    func clear() {
+        manager.clearSessionCookie()
+    }
+}

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import Combine
 
 // The categorical logger (enum Log, enum LogValue) lives in Log.swift so
 // the SwiftPM library target can compile it without also compiling this
@@ -21,6 +22,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // via `providers.append(...)`. The existing UsageManager continues to
     // drive Anthropic tiles — providers[0] is a thin wrapper around it.
     var providers: [ProviderBox] = []
+    // PR 3-UI: the ObservableObject SwiftUI watches for generic provider
+    // tiles. Holds the same ProviderBox instances as `providers`.
+    var providersModel: ProvidersModel!
     var eventMonitor: Any?
     var hotKeyRef: EventHotKeyRef?
 
@@ -45,9 +49,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize managers
         usageManager = UsageManager(statusItem: statusItem, delegate: self)
-        // Wrap the manager in a UsageProvider so future provider PRs can
-        // add themselves to `providers[]` without disturbing this one.
+        // Wrap the manager in a UsageProvider so additional providers can
+        // register alongside it without disturbing the Anthropic path.
         providers.append(ProviderBox(AnthropicUsageStore(manager: usageManager)))
+        // PR 3-UI: register the Codex provider. It is opt-in (feature flag
+        // features.codex.enabled defaults false), so registering it here is
+        // inert for existing users — it contributes no tiles until enabled.
+        providers.append(ProviderBox(CodexUsageStore()))
+        // Model SwiftUI observes for the generic (non-Anthropic) provider
+        // tiles. Anthropic continues to render through usageManager directly.
+        providersModel = ProvidersModel(providers: providers)
         statusManager = StatusManager()
         updateManager = UpdateManager()
 
@@ -59,13 +70,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.contentViewController = NSHostingController(rootView: UsageView(
             usageManager: usageManager,
             statusManager: statusManager,
-            updateManager: updateManager
+            updateManager: updateManager,
+            providersModel: providersModel
         ))
 
         // Fetch initial data
         usageManager.fetchUsage()
         statusManager.fetch()
         updateManager.fetch()
+        // Fetch any enabled non-Anthropic providers (Codex, etc.) on launch.
+        providersModel.fetchEnabled()
+
+        // Non-Anthropic providers poll on their own cadence. Codex documents
+        // 60s while active; a single 60s timer drives every enabled provider.
+        Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
+            self.providersModel.fetchEnabled()
+        }
 
         // Usage + Anthropic status are time-sensitive — poll every 5 min.
         Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
@@ -222,6 +242,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.main.async {
                 self.usageManager.updatePercentages()
             }
+            // Refresh enabled non-Anthropic providers (Codex, etc.) so their
+            // tiles are current when the popover appears.
+            providersModel?.fetchEnabled()
 
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
 
@@ -1243,6 +1266,71 @@ struct PasteableTextField: NSViewRepresentable {
     }
 }
 
+// PR 3-UI: the single ObservableObject SwiftUI watches for the generic
+// (non-Anthropic) provider tiles. SwiftUI cannot observe a bare
+// `[ProviderBox]`; it needs one ObservableObject to subscribe to. This model
+// holds the boxes and re-broadcasts each box's objectWillChange, so any
+// provider state change redraws the popover. Anthropic is intentionally
+// excluded from `genericProviders` — it renders through usageManager as
+// before; this model only drives the additional providers.
+//
+// @MainActor because it reads and drives @MainActor providers (ProviderBox,
+// the stores). Every call site (AppDelegate lifecycle, timers on the main
+// runloop, the SwiftUI popover) is already on the main actor, so this adds
+// no friction. AppDelegate is annotated @MainActor to match, which AppKit
+// already guarantees at runtime.
+@MainActor
+final class ProvidersModel: ObservableObject {
+    let providers: [ProviderBox]
+    private var cancellables: [AnyCancellable] = []
+
+    init(providers: [ProviderBox]) {
+        self.providers = providers
+        for box in providers {
+            box.objectWillChange
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.objectWillChange.send() }
+                .store(in: &cancellables)
+        }
+    }
+
+    /// Providers rendered through the generic path — everything except
+    /// Anthropic, which keeps its bespoke rendering in UsageView.content.
+    /// `nonisolated` because `providers` is an immutable `let` and `id` is a
+    /// nonisolated stored property on ProviderBox — no main-actor state is
+    /// touched, so AppDelegate's timer/lifecycle closures can call it.
+    nonisolated var genericProviders: [ProviderBox] {
+        providers.filter { $0.id != "anthropic" }
+    }
+
+    /// The subset of generic providers the user has enabled via Settings.
+    /// Reads each provider's `isEnabled` through the `any UsageProvider`
+    /// existential, whose protocol is not @MainActor (the stores add it with
+    /// @preconcurrency), so this stays nonisolated.
+    nonisolated var enabledGenericProviders: [ProviderBox] {
+        genericProviders.filter { $0.provider.isEnabled }
+    }
+
+    /// Fetch every enabled non-Anthropic provider. Called on launch, on the
+    /// 60s timer, when the popover opens, and from the Refresh button — all
+    /// on the main thread in practice. `nonisolated` so those synchronous
+    /// call sites do not need per-site actor hops.
+    nonisolated func fetchEnabled() {
+        for box in enabledGenericProviders {
+            box.provider.fetch()
+        }
+    }
+
+    /// Force the popover to re-evaluate which provider sections are visible.
+    /// A Settings toggle writes the feature flag straight to UserDefaults,
+    /// which does not itself fire objectWillChange; the toggle calls this so
+    /// a section appears or disappears immediately on both transitions
+    /// (enabling a provider also fetches; disabling it has no other signal).
+    func providersChanged() {
+        objectWillChange.send()
+    }
+}
+
 private struct ContentHeightKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
@@ -1254,6 +1342,8 @@ struct UsageView: View {
     @ObservedObject var usageManager: UsageManager
     @ObservedObject var statusManager: StatusManager
     @ObservedObject var updateManager: UpdateManager
+    // PR 3-UI: drives the generic (non-Anthropic) provider tiles.
+    @ObservedObject var providersModel: ProvidersModel
     @State private var sessionCookieInput: String = ""
     @State private var showingCookieInput: Bool = false
     @State private var showingSettings: Bool = false
@@ -1485,6 +1575,15 @@ struct UsageView: View {
             }
             }
 
+            // PR 3-UI: generic (non-Anthropic) provider tiles. Each enabled
+            // provider contributes a section; Anthropic is rendered above via
+            // usageManager and is excluded here. Renders nothing when no such
+            // provider is enabled, so existing users see no change.
+            ForEach(providersModel.enabledGenericProviders) { box in
+                Divider()
+                ProviderSectionView(box: box)
+            }
+
             if statusManager.hasFetched {
                 Divider()
             }
@@ -1626,6 +1725,7 @@ struct UsageView: View {
                     usageManager.fetchUsage()
                     statusManager.fetch()
                     updateManager.fetch()
+                    providersModel.fetchEnabled()
                 }
                 .buttonStyle(.borderless)
                 .font(.caption)
@@ -1787,6 +1887,30 @@ struct UsageView: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                    }
+
+                    Divider()
+
+                    // PR 3-UI: per-provider opt-in toggles. Each non-Anthropic
+                    // provider is off by default; enabling one writes its
+                    // featureFlagKey and triggers an immediate fetch.
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Providers")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                        Text("Track additional AI services. Each is opt-in; enable only the ones you use.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        ForEach(providersModel.genericProviders) { box in
+                            ProviderToggleRow(box: box) { enabled in
+                                // Re-evaluate section visibility on both
+                                // transitions; fetch immediately on enable.
+                                if enabled { box.provider.fetch() }
+                                providersModel.providersChanged()
+                            }
+                        }
                     }
 
                     Divider()
@@ -2003,3 +2127,237 @@ struct UsageView: View {
     }
 
 }
+
+// MARK: - Generic provider rendering (PR 3-UI)
+
+/// Renders one non-Anthropic provider: a section header (display name +
+/// optional error / last-updated) followed by one UsageTileView per tile.
+/// Observes the box so provider state changes redraw this section.
+struct ProviderSectionView: View {
+    @ObservedObject var box: ProviderBox
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(box.provider.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer()
+                if let updated = box.provider.lastUpdated {
+                    Text("Updated \(shortTime(updated))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let error = box.provider.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+
+            ForEach(box.provider.tiles) { tile in
+                UsageTileView(tile: tile)
+            }
+        }
+    }
+
+    private func shortTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f.string(from: date)
+    }
+}
+
+/// Renders a single UsageTile by switching on its Kind. This is the generic
+/// renderer every future provider reuses — adding a provider needs no new UI
+/// as long as it emits one of these kinds.
+struct UsageTileView: View {
+    let tile: UsageTile
+
+    var body: some View {
+        switch tile.kind {
+        case let .bar(fraction, resetsAt, badge):
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    if let badge = badge, !badge.isEmpty {
+                        Text(badge)
+                            .font(.caption2)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.2))
+                            .cornerRadius(3)
+                    }
+                    Spacer()
+                    if let resetsAt = resetsAt {
+                        Text("Resets \(resetLabel(resetsAt))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                ProgressView(value: fraction)
+                    .tint(color(for: fraction))
+                Text("\(Int((fraction * 100).rounded()))% used")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+        case let .balance(remainingMinorUnits, currency, plan, resetsAt):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    Text(formatBalance(remainingMinorUnits, currency: currency))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
+                if let plan = plan, !plan.isEmpty {
+                    Text(plan)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                if let resetsAt = resetsAt {
+                    Text("Resets \(resetLabel(resetsAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case let .counter(used, limit, resetsAt):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    if let limit = limit {
+                        Text("\(used) / \(limit)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    } else {
+                        Text("\(used)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    }
+                }
+                if let resetsAt = resetsAt {
+                    Text("Resets \(resetLabel(resetsAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case let .text(status, subtitle):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    Text(status)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let subtitle = subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+        case let .needsAccess(path, guidance):
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tile.title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Text(guidance)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(path)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding(8)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(6)
+        }
+    }
+
+    private func color(for fraction: Double) -> Color {
+        if fraction < 0.7 { return .green }
+        if fraction < 0.9 { return .orange }
+        return .red
+    }
+
+    private func resetLabel(_ date: Date) -> String {
+        let f = DateFormatter()
+        // Include the date when the reset is more than ~a day out (weekly
+        // windows); otherwise just the time (5-hour windows).
+        if date.timeIntervalSinceNow > 86_400 {
+            f.dateFormat = "d MMM 'at' h:mm a"
+            return "on \(f.string(from: date))"
+        }
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return "at \(f.string(from: date))"
+    }
+
+    private func formatBalance(_ minorUnits: Int, currency: String) -> String {
+        let major = Double(minorUnits) / 100.0
+        return String(format: "%@ %.2f", currency, major)
+    }
+}
+
+/// One opt-in checkbox for a non-Anthropic provider in Settings. Reads and
+/// writes the provider's featureFlagKey directly in UserDefaults; on enable
+/// it fires `onEnable` so the provider fetches immediately rather than
+/// waiting for the next timer tick. Below the toggle it shows provider-
+/// specific help and, where relevant, a private-API disclosure line.
+struct ProviderToggleRow: View {
+    @ObservedObject var box: ProviderBox
+    /// Called after the flag is written, with the new value, on every
+    /// toggle (both enable and disable).
+    let onChange: (Bool) -> Void
+
+    @State private var enabled: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: Binding(
+                get: { enabled },
+                set: { newValue in
+                    enabled = newValue
+                    UserDefaults.standard.set(newValue, forKey: box.provider.featureFlagKey)
+                    onChange(newValue)
+                }
+            )) {
+                Text(box.provider.displayName)
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+
+            if let help = ProviderCopy.help(for: box.id) {
+                Text(help)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let disclosure = ProviderCopy.disclosure(for: box.id) {
+                Text(disclosure)
+                    .font(.caption2)
+                    .foregroundColor(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .onAppear {
+            enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
+        }
+    }
+}
+

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -444,16 +444,14 @@ class UsageManager: ObservableObject {
     }
 
     func fetchOrganizationId(completion: @escaping (String?) -> Void) {
-        // Get org ID from the lastActiveOrg cookie value
-        let cookieParts = sessionCookie.components(separatedBy: ";")
-        for part in cookieParts {
-            let trimmed = part.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("lastActiveOrg=") {
-                let orgId = trimmed.replacingOccurrences(of: "lastActiveOrg=", with: "")
-                Log.info("Found org ID in cookie", .identifier(orgId))
-                completion(orgId)
-                return
-            }
+        // PR 2b: parsing lives in AnthropicUsageFetcher. UsageManager keeps
+        // ownership of the network call (which needs to be in the manager
+        // for delegate/main-actor reasons) but delegates the string
+        // parsing.
+        if let orgId = AnthropicUsageFetcher.orgId(fromCookieString: sessionCookie) {
+            Log.info("Found org ID in cookie", .identifier(orgId))
+            completion(orgId)
+            return
         }
 
         // If not in cookie, fetch from bootstrap
@@ -574,113 +572,43 @@ class UsageManager: ObservableObject {
     }
 
     func parseUsageData(_ data: Data) {
+        // PR 2b: parsing extracted into AnthropicUsageFetcher (Sendable
+        // value type, no side effects). UsageManager only applies the
+        // resulting snapshot to observable state. Behaviour is identical
+        // to the pre-refactor code; every branch is locked in by fixture
+        // tests in Tests/TestRunner.
         do {
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                errorMessage = "Invalid JSON"
-                return
-            }
+            let snap = try AnthropicUsageFetcher.parse(data)
+            sessionUsage = snap.sessionUsage
+            sessionLimit = 100
+            sessionResetsAt = snap.sessionResetsAt
 
-            NSLog("📊 Parsing usage data...")
+            weeklyUsage = snap.weeklyUsage
+            weeklyLimit = 100
+            weeklyResetsAt = snap.weeklyResetsAt
 
-            let iso8601Formatter = ISO8601DateFormatter()
-            iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            hasWeeklySonnet = snap.hasWeeklySonnet
+            weeklySonnetUsage = snap.weeklySonnetUsage
+            weeklySonnetLimit = 100
+            weeklySonnetResetsAt = snap.weeklySonnetResetsAt
 
-            // Parse the actual claude.ai response format
-            if let fiveHour = json["five_hour"] as? [String: Any] {
-                if let sessionUtil = fiveHour["utilization"] as? Double {
-                    sessionUsage = Int(sessionUtil)
-                    sessionLimit = 100
-                }
-                if let resetsAtString = fiveHour["resets_at"] as? String {
-                    NSLog("🕐 Session resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        sessionResetsAt = resetsAt
-                        NSLog("✅ Parsed session reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse session reset time")
-                    }
-                }
-            }
+            hasWeeklyFable = snap.hasWeeklyFable
+            weeklyFableUsage = snap.weeklyFableUsage
+            weeklyFableLimit = 100
+            weeklyFableResetsAt = snap.weeklyFableResetsAt
 
-            if let sevenDay = json["seven_day"] as? [String: Any] {
-                if let weeklyUtil = sevenDay["utilization"] as? Double {
-                    weeklyUsage = Int(weeklyUtil)
-                    weeklyLimit = 100
-                }
-                if let resetsAtString = sevenDay["resets_at"] as? String {
-                    NSLog("🕐 Weekly resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        weeklyResetsAt = resetsAt
-                        NSLog("✅ Parsed weekly reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse weekly reset time")
-                    }
-                }
-            }
-
-            // Check for seven_day_sonnet (Pro plan feature)
-            if let sevenDaySonnet = json["seven_day_sonnet"] as? [String: Any] {
-                hasWeeklySonnet = true
-                if let sonnetUtil = sevenDaySonnet["utilization"] as? Double {
-                    weeklySonnetUsage = Int(sonnetUtil)
-                    weeklySonnetLimit = 100
-                }
-                if let resetsAtString = sevenDaySonnet["resets_at"] as? String {
-                    NSLog("🕐 Weekly Sonnet resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        weeklySonnetResetsAt = resetsAt
-                        NSLog("✅ Parsed weekly Sonnet reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse weekly Sonnet reset time")
-                    }
-                }
-            } else {
-                hasWeeklySonnet = false
-            }
-
-            // Fable is a new, separately-counted model. It isn't a top-level
-            // key like seven_day_sonnet — it lives in the `limits` array as a
-            // model-scoped weekly limit (scope.model.display_name == "Fable").
-            // The bar is only surfaced in the UI when usage is above 1%.
-            hasWeeklyFable = false
-            if let limits = json["limits"] as? [[String: Any]] {
-                let fableLimit = limits.first { entry in
-                    let scope = entry["scope"] as? [String: Any]
-                    let model = scope?["model"] as? [String: Any]
-                    return (model?["display_name"] as? String) == "Fable"
-                }
-                if let fable = fableLimit {
-                    hasWeeklyFable = true
-                    // `percent` may decode as Int or Double depending on payload.
-                    if let p = fable["percent"] as? Int {
-                        weeklyFableUsage = p
-                    } else if let p = fable["percent"] as? Double {
-                        weeklyFableUsage = Int(p)
-                    }
-                    weeklyFableLimit = 100
-                    if let resetsAtString = fable["resets_at"] as? String {
-                        NSLog("🕐 Weekly Fable resets_at string: \(resetsAtString)")
-                        if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                            weeklyFableResetsAt = resetsAt
-                            NSLog("✅ Parsed weekly Fable reset time: \(resetsAt)")
-                        } else {
-                            NSLog("❌ Failed to parse weekly Fable reset time")
-                        }
-                    }
-                }
-            }
-
-            // Log what we found
-            NSLog("✅ Parsed: Session \(sessionUsage)%, Weekly \(weeklyUsage)%\(hasWeeklySonnet ? ", Weekly Sonnet \(weeklySonnetUsage)%" : "")\(hasWeeklyFable ? ", Weekly Fable \(weeklyFableUsage)%" : "")")
+            Log.info("Parsed usage",
+                     .public("session"), .count(sessionUsage),
+                     .public("weekly"), .count(weeklyUsage))
 
             lastUpdated = Date()
             errorMessage = nil
             hasFetchedData = true
-
-            // Update percentage values for progress bars
             updatePercentages()
+        } catch AnthropicUsageParseError.invalidJSON {
+            errorMessage = "Invalid JSON"
         } catch {
-            NSLog("❌ Parse error: \(error.localizedDescription)")
+            Log.info("Parse error", .public(error.localizedDescription))
             errorMessage = "Parse error"
         }
     }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -15,6 +15,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var usageManager: UsageManager!
     var statusManager: StatusManager!
     var updateManager: UpdateManager!
+
+    // PR 2c: multi-provider registry. Anthropic is the only provider today;
+    // subsequent PRs register additional stores (Codex, DeepSeek, Zed, ...)
+    // via `providers.append(...)`. The existing UsageManager continues to
+    // drive Anthropic tiles — providers[0] is a thin wrapper around it.
+    var providers: [ProviderBox] = []
     var eventMonitor: Any?
     var hotKeyRef: EventHotKeyRef?
 
@@ -39,6 +45,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize managers
         usageManager = UsageManager(statusItem: statusItem, delegate: self)
+        // Wrap the manager in a UsageProvider so future provider PRs can
+        // add themselves to `providers[]` without disturbing this one.
+        providers.append(ProviderBox(AnthropicUsageStore(manager: usageManager)))
         statusManager = StatusManager()
         updateManager = UpdateManager()
 

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -60,6 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // defaults false) and additionally requires a pasted API key, so it
         // is doubly inert until the user both enables and configures it.
         providers.append(ProviderBox(DeepSeekUsageStore()))
+        // PR 5-UI: register Zed. Opt-in (features.zed.enabled defaults false);
+        // it reads Zed's own Keychain login on first fetch (one-time macOS
+        // prompt), so it is inert until enabled and the prompt is allowed.
+        providers.append(ProviderBox(ZedUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -56,6 +56,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // features.codex.enabled defaults false), so registering it here is
         // inert for existing users — it contributes no tiles until enabled.
         providers.append(ProviderBox(CodexUsageStore()))
+        // PR 4-UI: register DeepSeek. Also opt-in (features.deepseek.enabled
+        // defaults false) and additionally requires a pasted API key, so it
+        // is doubly inert until the user both enables and configures it.
+        providers.append(ProviderBox(DeepSeekUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2326,6 +2330,16 @@ struct ProviderToggleRow: View {
     let onChange: (Bool) -> Void
 
     @State private var enabled: Bool = false
+    // Local buffer for a pasted secret (PasteKeyProvider). Never pre-filled
+    // with the stored secret — we only ever write, never read it back out.
+    @State private var keyInput: String = ""
+    @State private var hasStoredKey: Bool = false
+
+    /// The provider as a PasteKeyProvider, when it is configured by pasting a
+    /// secret; nil otherwise.
+    private var pasteKeyProvider: PasteKeyProvider? {
+        box.provider as? PasteKeyProvider
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -2354,9 +2368,44 @@ struct ProviderToggleRow: View {
                     .foregroundColor(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            // Key-entry affordance for paste-a-secret providers, shown only
+            // when the provider is enabled. Uses a SecureField so the pasted
+            // value is masked on screen; the stored secret is never read back
+            // into the field.
+            if enabled, let keyProvider = pasteKeyProvider {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        SecureField(keyProvider.keyPlaceholder, text: $keyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.caption2)
+                        Button("Save") {
+                            keyProvider.saveKey(keyInput)
+                            keyInput = ""
+                            hasStoredKey = keyProvider.hasKey
+                            onChange(true)  // trigger a fetch now that a key exists
+                        }
+                        .controlSize(.small)
+                        .disabled(keyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                        if hasStoredKey {
+                            Button("Clear") {
+                                keyProvider.saveKey("")  // empty clears
+                                hasStoredKey = keyProvider.hasKey
+                                onChange(false)
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
         }
         .onAppear {
             enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
+            hasStoredKey = pasteKeyProvider?.hasKey ?? false
         }
     }
 }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,72 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import CryptoKit
+import Foundation
+
+// MARK: - Logging (categorical redaction)
+//
+// PR 1 replaces every NSLog site that touched cookies, org IDs, or response
+// bodies with the categorical logger below. The call site cannot interpolate
+// a raw String; every value goes through a category, and each category has
+// its own emission rule. This makes accidental credential logging a compile-
+// time impossibility rather than a discipline problem.
+//
+// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
+// reintroduce raw-interpolation NSLog calls or the deleted response-body
+// log line at the network fetch site. The exact banned pattern lives in
+// the workflow file to avoid embedding it here (which would self-trigger).
+
+enum LogValue {
+    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
+    case `public`(String)
+    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
+    /// bodies, tokens, API keys, anything that could leak a credential.
+    case sensitive(String)
+    /// Emitted as a short SHA-256 prefix so the value can be correlated
+    /// across log lines without revealing it. Use for org IDs, user IDs.
+    case identifier(String)
+    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
+    /// retry counts, threshold values).
+    case count(Int)
+
+    var rendered: String {
+        switch self {
+        case .public(let s):
+            return s
+        case .sensitive(let s):
+            return "<redacted: \(s.count) chars>"
+        case .identifier(let s):
+            let digest = SHA256.hash(data: Data(s.utf8))
+            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+            return "<id: \(hex.prefix(8))>"
+        case .count(let n):
+            return String(n)
+        }
+    }
+}
+
+enum Log {
+    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
+    /// gate. Accepts a plain message — no interpolation of untrusted values.
+    static func debug(_ message: String) {
+        #if DEBUG
+        NSLog("[debug] %@", message)
+        #endif
+    }
+
+    /// Info-level diagnostics. Retained in release builds. Values must be
+    /// wrapped in a `LogValue` category, forcing an explicit redaction
+    /// decision at the call site.
+    static func info(_ message: String, _ values: LogValue...) {
+        let rendered = values.map(\.rendered).joined(separator: ", ")
+        if rendered.isEmpty {
+            NSLog("%@", message)
+        } else {
+            NSLog("%@ | %@", message, rendered)
+        }
+    }
+}
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -403,15 +469,15 @@ class UsageManager: ObservableObject {
     }
 
     func saveSessionCookie(_ cookie: String) {
-        NSLog("ClaudeUsage: Saving cookie, length: \(cookie.count)")
+        Log.info("ClaudeUsage: saving cookie", .count(cookie.count))
         sessionCookie = cookie
         UserDefaults.standard.set(cookie, forKey: "claude_session_cookie")
         UserDefaults.standard.synchronize()
-        NSLog("ClaudeUsage: Cookie saved successfully")
+        Log.info("ClaudeUsage: cookie saved successfully")
     }
 
     func clearSessionCookie() {
-        NSLog("ClaudeUsage: Clearing cookie")
+        Log.info("ClaudeUsage: clearing cookie")
         sessionCookie = ""
         UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
         UserDefaults.standard.synchronize()
@@ -435,7 +501,7 @@ class UsageManager: ObservableObject {
         // Update status bar to show 0%
         delegate?.updateStatusIcon(percentage: 0)
 
-        NSLog("ClaudeUsage: Cookie cleared, data reset")
+        Log.info("ClaudeUsage: cookie cleared, data reset")
     }
 
     func fetchOrganizationId(completion: @escaping (String?) -> Void) {
@@ -445,7 +511,7 @@ class UsageManager: ObservableObject {
             let trimmed = part.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("lastActiveOrg=") {
                 let orgId = trimmed.replacingOccurrences(of: "lastActiveOrg=", with: "")
-                NSLog("📋 Found org ID in cookie: \(orgId)")
+                Log.info("Found org ID in cookie", .identifier(orgId))
                 completion(orgId)
                 return
             }
@@ -545,11 +611,17 @@ class UsageManager: ObservableObject {
                     return
                 }
 
-                NSLog("📡 Status: \(httpResponse.statusCode)")
+                Log.info("Usage API response", .count(httpResponse.statusCode))
 
+                // Response body is intentionally NOT logged. It contains the
+                // full usage JSON tied to the user's cookie and would land in
+                // unified log. Diagnostics for debugging live parse issues
+                // must go through the DEBUG-only path.
+                #if DEBUG
                 if let data = data, let responseString = String(data: data, encoding: .utf8) {
-                    NSLog("📦 Response: \(responseString)")
+                    Log.debug("Usage API body (DEBUG only): \(responseString)")
                 }
+                #endif
 
                 if httpResponse.statusCode == 200, let data = data {
                     self?.parseUsageData(data)
@@ -1729,7 +1801,7 @@ struct UsageView: View {
 
                             HStack(spacing: 8) {
                                 Button("Save Cookie & Fetch") {
-                                    NSLog("ClaudeUsage: Save clicked, input length: \(sessionCookieInput.count)")
+                                    Log.info("ClaudeUsage: save clicked", .count(sessionCookieInput.count))
                                     if sessionCookieInput.isEmpty {
                                         usageManager.errorMessage = "Cookie field is empty!"
                                     } else {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,72 +2,11 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
-import CryptoKit
-import Foundation
 
-// MARK: - Logging (categorical redaction)
-//
-// PR 1 replaces every NSLog site that touched cookies, org IDs, or response
-// bodies with the categorical logger below. The call site cannot interpolate
-// a raw String; every value goes through a category, and each category has
-// its own emission rule. This makes accidental credential logging a compile-
-// time impossibility rather than a discipline problem.
-//
-// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
-// reintroduce raw-interpolation NSLog calls or the deleted response-body
-// log line at the network fetch site. The exact banned pattern lives in
-// the workflow file to avoid embedding it here (which would self-trigger).
-
-enum LogValue {
-    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
-    case `public`(String)
-    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
-    /// bodies, tokens, API keys, anything that could leak a credential.
-    case sensitive(String)
-    /// Emitted as a short SHA-256 prefix so the value can be correlated
-    /// across log lines without revealing it. Use for org IDs, user IDs.
-    case identifier(String)
-    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
-    /// retry counts, threshold values).
-    case count(Int)
-
-    var rendered: String {
-        switch self {
-        case .public(let s):
-            return s
-        case .sensitive(let s):
-            return "<redacted: \(s.count) chars>"
-        case .identifier(let s):
-            let digest = SHA256.hash(data: Data(s.utf8))
-            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
-            return "<id: \(hex.prefix(8))>"
-        case .count(let n):
-            return String(n)
-        }
-    }
-}
-
-enum Log {
-    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
-    /// gate. Accepts a plain message — no interpolation of untrusted values.
-    static func debug(_ message: String) {
-        #if DEBUG
-        NSLog("[debug] %@", message)
-        #endif
-    }
-
-    /// Info-level diagnostics. Retained in release builds. Values must be
-    /// wrapped in a `LogValue` category, forcing an explicit redaction
-    /// decision at the call site.
-    static func info(_ message: String, _ values: LogValue...) {
-        let rendered = values.map(\.rendered).joined(separator: ", ")
-        if rendered.isEmpty {
-            NSLog("%@", message)
-        } else {
-            NSLog("%@ | %@", message, rendered)
-        }
-    }
-}
+// The categorical logger (enum Log, enum LogValue) lives in Log.swift so
+// the SwiftPM library target can compile it without also compiling this
+// file's @main entry point. Both files are compiled together by
+// app/build.sh into the final .app bundle.
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/app/CodexUsageFetcher.swift
+++ b/app/CodexUsageFetcher.swift
@@ -1,0 +1,387 @@
+// PR 3-BE — Codex usage fetcher.
+//
+// Mirrors AnthropicUsageFetcher (PR 2b): a Sendable value type with no
+// observable state, no delegates, no side effects. It exposes a pure
+// static parser that turns the raw bytes of a
+// `GET https://chatgpt.com/backend-api/wham/usage` response into a
+// CodexUsageSnapshot, and a credential reader that ingests
+// `~/.codex/auth.json` (respecting `CODEX_HOME`).
+//
+// The two-layer split (Fetcher value type + Store observable class) is the
+// same as Anthropic: this fetcher is what the TestRunner fixtures hit, and
+// CodexUsageStore (PR 3-BE, separate file) is what SwiftUI observes.
+//
+// Feature posture: this file is dark code in PR 3-BE. Nothing constructs a
+// CodexUsageStore into the live provider registry yet; the popover wiring
+// and Settings toggle land in PR 3-UI. Shipping the backend first, behind a
+// default-off feature flag, keeps the release non-breaking.
+//
+// Response shape: established by a live read-only probe of the real
+// endpoint (structure only, no credential retained) plus the Codex CLI's
+// own deserialization structs. The authoritative fields are:
+//
+//   rate_limit.allowed                      Bool
+//   rate_limit.limit_reached                Bool
+//   rate_limit.primary_window.used_percent  Int      (0…100)
+//   rate_limit.primary_window.reset_after_seconds  Int  (relative)
+//   rate_limit.primary_window.reset_at      Int      (Unix epoch seconds)
+//   rate_limit.secondary_window.*           (same shape as primary)
+//   additional_rate_limits                  [Window]? (null or array)
+//   credits.has_credits / unlimited / balance (String) / overage_limit_reached
+//   plan_type                               String
+//
+// Note the reset timing is Unix-epoch integers, NOT ISO-8601 strings — this
+// differs from the Anthropic endpoint. `used_percent` is an integer here.
+
+import Foundation
+
+// MARK: - Snapshot
+
+/// One usage-limit window parsed from the Codex usage response. The primary
+/// (5-hour) and secondary (weekly) windows share this shape, as do the
+/// nested windows inside each `additional_rate_limits[]` element.
+///
+/// Field names and types are the `RateLimitWindowSnapshot` model from
+/// openai/codex (`rate_limit_window_snapshot.rs`): every field is an i32 on
+/// the wire.
+public struct CodexRateWindow: Equatable, Sendable {
+    /// 0…100 integer utilisation for the window.
+    public var usedPercent: Int
+    /// Length of the window in seconds (18000 = 5h, 604800 = 7d).
+    public var limitWindowSeconds: Int?
+    /// Seconds until the window resets, relative to the response time.
+    public var resetAfterSeconds: Int?
+    /// Absolute reset time as a Unix epoch (seconds). The endpoint returns
+    /// this as an integer, not an ISO-8601 string, and not milliseconds.
+    public var resetAt: Date?
+
+    public init(
+        usedPercent: Int = 0,
+        limitWindowSeconds: Int? = nil,
+        resetAfterSeconds: Int? = nil,
+        resetAt: Date? = nil
+    ) {
+        self.usedPercent = usedPercent
+        self.limitWindowSeconds = limitWindowSeconds
+        self.resetAfterSeconds = resetAfterSeconds
+        self.resetAt = resetAt
+    }
+}
+
+/// One element of `additional_rate_limits[]` — a model-specific limit lane
+/// (e.g. "GPT-5.3-Codex-Spark"). This is the `AdditionalRateLimitDetails`
+/// model from openai/codex (`additional_rate_limit_details.rs`).
+///
+/// The usage is NOT flat on the element: it is nested one level deeper under
+/// `rate_limit.primary_window` / `rate_limit.secondary_window`, both of which
+/// are individually nullable. Reading `used_percent` off the element root is
+/// the single most common integration mistake against this endpoint, so the
+/// nesting is preserved here deliberately.
+public struct CodexAdditionalLimit: Equatable, Sendable {
+    /// Human-readable limit name, e.g. "GPT-5.3-Codex-Spark".
+    public var limitName: String?
+    /// Metered-feature slug used to identify the lane server-side.
+    public var meteredFeature: String?
+    /// The 5-hour window for this lane, if present.
+    public var primaryWindow: CodexRateWindow?
+    /// The weekly window for this lane, if present.
+    public var secondaryWindow: CodexRateWindow?
+
+    public init(
+        limitName: String? = nil,
+        meteredFeature: String? = nil,
+        primaryWindow: CodexRateWindow? = nil,
+        secondaryWindow: CodexRateWindow? = nil
+    ) {
+        self.limitName = limitName
+        self.meteredFeature = meteredFeature
+        self.primaryWindow = primaryWindow
+        self.secondaryWindow = secondaryWindow
+    }
+}
+
+/// Credit balance block. Present on accounts that carry pay-as-you-go
+/// credits; `balance` is returned as a String by the endpoint.
+public struct CodexCredits: Equatable, Sendable {
+    public var hasCredits: Bool
+    public var unlimited: Bool
+    public var overageLimitReached: Bool
+    /// Raw balance string exactly as returned (e.g. "0", "12.50"). Kept as a
+    /// String because the endpoint returns it as a String and the tile
+    /// renders it verbatim; we do not reinterpret currency here.
+    public var balance: String?
+
+    public init(
+        hasCredits: Bool = false,
+        unlimited: Bool = false,
+        overageLimitReached: Bool = false,
+        balance: String? = nil
+    ) {
+        self.hasCredits = hasCredits
+        self.unlimited = unlimited
+        self.overageLimitReached = overageLimitReached
+        self.balance = balance
+    }
+}
+
+/// A parsed snapshot of the `wham/usage` response. Every field is optional
+/// or defaulted in the same spirit as AnthropicUsageSnapshot — a fresh
+/// account with no additional windows has an empty `additionalWindows`, and
+/// an account with no credit block has `credits == nil`.
+public struct CodexUsageSnapshot: Equatable, Sendable {
+    /// Whether the account is currently allowed to make requests.
+    public var allowed: Bool
+    /// Whether any window has hit its limit.
+    public var limitReached: Bool
+
+    /// The 5-hour (primary) window. Always present in a well-formed
+    /// response; nil only if `rate_limit` is entirely absent.
+    public var primaryWindow: CodexRateWindow?
+    /// The weekly (secondary) window.
+    public var secondaryWindow: CodexRateWindow?
+    /// Zero or more model-specific limit lanes (per-model or promotional
+    /// caps, e.g. Spark). `additional_rate_limits` is `null` on most
+    /// accounts, which parses to an empty array.
+    public var additionalLimits: [CodexAdditionalLimit]
+
+    /// Pay-as-you-go credit block, if the account carries one.
+    public var credits: CodexCredits?
+
+    /// Account plan identifier ("plus", "team", "free", …). Surfaced for the
+    /// help panel copy, not for a tile.
+    public var planType: String?
+
+    public init(
+        allowed: Bool = true,
+        limitReached: Bool = false,
+        primaryWindow: CodexRateWindow? = nil,
+        secondaryWindow: CodexRateWindow? = nil,
+        additionalLimits: [CodexAdditionalLimit] = [],
+        credits: CodexCredits? = nil,
+        planType: String? = nil
+    ) {
+        self.allowed = allowed
+        self.limitReached = limitReached
+        self.primaryWindow = primaryWindow
+        self.secondaryWindow = secondaryWindow
+        self.additionalLimits = additionalLimits
+        self.credits = credits
+        self.planType = planType
+    }
+}
+
+// MARK: - Credentials
+
+/// Credentials read from `~/.codex/auth.json`. Only the two fields the usage
+/// request needs are surfaced; the id_token and refresh_token are never read
+/// out of the file by this app (PR 3-BE does not refresh — see the plan's
+/// Phase 1 note deferring writeback to Phase 1b).
+public struct CodexCredentials: Equatable, Sendable {
+    public let accessToken: String
+    public let accountId: String
+
+    public init(accessToken: String, accountId: String) {
+        self.accessToken = accessToken
+        self.accountId = accountId
+    }
+}
+
+public enum CodexUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+public enum CodexAuthError: Error, Equatable {
+    /// `auth.json` does not exist. UI should prompt `codex auth login`.
+    case authFileMissing
+    /// `auth.json` exists but could not be parsed as JSON.
+    case authFileMalformed
+    /// `auth.json` parsed but is missing access_token or account_id (e.g. an
+    /// API-key-only login with `auth_mode == "apikey"` and null tokens).
+    case authFileIncomplete
+}
+
+// MARK: - Fetcher
+
+/// Pure parser and credential reader for the Codex usage endpoint. Value
+/// type with no observable state; all callers receive a snapshot (or a
+/// thrown error) and apply it themselves on the main actor.
+public struct CodexUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: Credential ingestion
+
+    /// Resolve the Codex home directory, honouring `CODEX_HOME` when set and
+    /// non-empty, else `~/.codex`.
+    public static func codexHome(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let override = environment["CODEX_HOME"],
+           !override.trimmingCharacters(in: .whitespaces).isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        // FileManager.homeDirectoryForCurrentUser is the real user home even
+        // inside a sandbox container's mapped path; matches the CLI, which
+        // uses the OS home rather than $HOME string interpolation.
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true)
+    }
+
+    /// Full path to `auth.json` under the resolved Codex home.
+    public static func authFileURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        codexHome(environment: environment).appendingPathComponent("auth.json", isDirectory: false)
+    }
+
+    /// Read and parse `auth.json`, extracting the access token and account
+    /// id needed for the usage request. Throws a typed CodexAuthError so the
+    /// Store can map each case to a distinct UI state.
+    ///
+    /// This is separated from file IO so tests can exercise the parse
+    /// directly against synthetic bytes without touching the filesystem.
+    public static func parseAuth(_ data: Data) throws -> CodexCredentials {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexAuthError.authFileMalformed
+        }
+        guard let tokens = json["tokens"] as? [String: Any] else {
+            throw CodexAuthError.authFileIncomplete
+        }
+        guard
+            let access = tokens["access_token"] as? String, !access.isEmpty,
+            let account = tokens["account_id"] as? String, !account.isEmpty
+        else {
+            throw CodexAuthError.authFileIncomplete
+        }
+        return CodexCredentials(accessToken: access, accountId: account)
+    }
+
+    /// Read credentials from disk. Returns `.authFileMissing` when the file
+    /// does not exist so the Store can render the "run codex auth login"
+    /// onboarding card rather than an error.
+    public static func readCredentials(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> CodexCredentials {
+        let url = authFileURL(environment: environment)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CodexAuthError.authFileMissing
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            // Existence check passed but the read failed (permissions, race
+            // with a concurrent `codex auth login` rewrite). Treat as
+            // malformed rather than missing — the file is there.
+            throw CodexAuthError.authFileMalformed
+        }
+        return try parseAuth(data)
+    }
+
+    // MARK: Pure parsing (this is what the fixtures hit)
+
+    /// Parse one window object into a CodexRateWindow. Tolerant of absent
+    /// fields: an object with only `used_percent` still parses.
+    private static func parseWindow(_ obj: [String: Any]) -> CodexRateWindow {
+        var w = CodexRateWindow()
+        // used_percent is an Int in the live response; accept a Double too so
+        // a future server-side change to fractional percentages does not
+        // silently drop the value.
+        if let p = obj["used_percent"] as? Int {
+            w.usedPercent = p
+        } else if let p = obj["used_percent"] as? Double {
+            w.usedPercent = Int(p)
+        }
+        if let s = obj["limit_window_seconds"] as? Int {
+            w.limitWindowSeconds = s
+        } else if let s = obj["limit_window_seconds"] as? Double {
+            w.limitWindowSeconds = Int(s)
+        }
+        if let s = obj["reset_after_seconds"] as? Int {
+            w.resetAfterSeconds = s
+        } else if let s = obj["reset_after_seconds"] as? Double {
+            w.resetAfterSeconds = Int(s)
+        }
+        // reset_at is a Unix epoch integer (seconds). JSONSerialization may
+        // surface a large integer as Int or, on 32-bit-ish paths, Double —
+        // handle both.
+        if let epoch = obj["reset_at"] as? Int {
+            w.resetAt = Date(timeIntervalSince1970: TimeInterval(epoch))
+        } else if let epoch = obj["reset_at"] as? Double {
+            w.resetAt = Date(timeIntervalSince1970: epoch)
+        }
+        return w
+    }
+
+    /// Parse the JSON body of a `wham/usage` response into a snapshot.
+    /// Preserves every field the tiles consume. Throws `invalidJSON` only
+    /// when the top level is not a JSON object — a well-formed but sparse
+    /// response (missing credits, null additional_rate_limits) parses to a
+    /// snapshot with defaulted/absent fields, matching how AnthropicUsage
+    /// Fetcher tolerates Free-plan minimal bodies.
+    public static func parse(_ data: Data) throws -> CodexUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexUsageParseError.invalidJSON
+        }
+
+        var snap = CodexUsageSnapshot()
+
+        snap.planType = json["plan_type"] as? String
+
+        if let rl = json["rate_limit"] as? [String: Any] {
+            if let allowed = rl["allowed"] as? Bool { snap.allowed = allowed }
+            if let reached = rl["limit_reached"] as? Bool { snap.limitReached = reached }
+
+            if let primary = rl["primary_window"] as? [String: Any] {
+                snap.primaryWindow = parseWindow(primary)
+            }
+            if let secondary = rl["secondary_window"] as? [String: Any] {
+                snap.secondaryWindow = parseWindow(secondary)
+            }
+        }
+
+        // additional_rate_limits is null on most accounts. When present it is
+        // an array of AdditionalRateLimitDetails: each element carries
+        // limit_name + metered_feature, and its usage is nested under
+        // `rate_limit.primary_window` / `rate_limit.secondary_window` — NOT
+        // flat on the element. Anything that is not an array (including
+        // explicit null) yields an empty list.
+        if let additional = json["additional_rate_limits"] as? [[String: Any]] {
+            snap.additionalLimits = additional.map { entry in
+                var limit = CodexAdditionalLimit(
+                    limitName: entry["limit_name"] as? String,
+                    meteredFeature: entry["metered_feature"] as? String
+                )
+                if let nested = entry["rate_limit"] as? [String: Any] {
+                    if let primary = nested["primary_window"] as? [String: Any] {
+                        limit.primaryWindow = parseWindow(primary)
+                    }
+                    if let secondary = nested["secondary_window"] as? [String: Any] {
+                        limit.secondaryWindow = parseWindow(secondary)
+                    }
+                }
+                return limit
+            }
+        }
+
+        if let c = json["credits"] as? [String: Any] {
+            var credits = CodexCredits()
+            if let has = c["has_credits"] as? Bool { credits.hasCredits = has }
+            if let unlimited = c["unlimited"] as? Bool { credits.unlimited = unlimited }
+            if let overage = c["overage_limit_reached"] as? Bool { credits.overageLimitReached = overage }
+            // balance is a String in the live response; accept a number too
+            // and stringify it defensively.
+            if let b = c["balance"] as? String {
+                credits.balance = b
+            } else if let b = c["balance"] as? Int {
+                credits.balance = String(b)
+            } else if let b = c["balance"] as? Double {
+                credits.balance = String(b)
+            }
+            snap.credits = credits
+        }
+
+        return snap
+    }
+}

--- a/app/CodexUsageStore.swift
+++ b/app/CodexUsageStore.swift
@@ -1,0 +1,376 @@
+// PR 3-BE — Codex UsageProvider conformer (dark code, feature-flag off).
+//
+// CodexUsageStore is the second UsageProvider (after AnthropicUsageStore).
+// It holds the observable state for the Codex tiles and drives the fetch
+// against `GET https://chatgpt.com/backend-api/wham/usage`, parsing the
+// response through the Sendable CodexUsageFetcher.
+//
+// Feature posture in PR 3-BE:
+//   - `features.codex.enabled` defaults FALSE. Every provider except
+//     Anthropic is opt-in; existing v1.3.1 users see zero change.
+//   - Nothing appends a CodexUsageStore into AppDelegate.providers yet.
+//     The popover wiring, Settings toggle, and shared-timer registration
+//     land in PR 3-UI. This file is compiled and unit-tested but inert at
+//     runtime until the flag is turned on and the store is registered.
+//
+// Auth posture (plan Phase 1): read `~/.codex/auth.json` only. Do NOT
+// initiate an in-app OAuth PKCE flow — using the Codex CLI's client id from
+// a third-party GUI is impersonation-adjacent. Do NOT write back to
+// auth.json on 401; instead surface a "session expired, run codex auth
+// login" state. Writeback is deferred to Phase 1b.
+//
+// Labels: every tile is prefixed "Codex", never "ChatGPT". The 5-hour and
+// weekly windows cover the Codex CLI, IDE extensions, Slack, and Cloud
+// tasks — one shared pool. General GPT chat is not counted here.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// @MainActor because the store owns @Published state observed by SwiftUI.
+// @preconcurrency on the UsageProvider conformance defers strict
+// actor-isolation checking until PR 16 migrates the protocol to @MainActor —
+// identical staging to AnthropicUsageStore.
+@MainActor
+public final class CodexUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "codex"
+    public let displayName: String = "Codex (OpenAI)"
+    public let featureFlagKey: String = "features.codex.enabled"
+
+    // MARK: Observable state
+
+    /// The most recent successfully parsed snapshot. Nil before the first
+    /// successful fetch, or after a fetch that failed.
+    @Published public private(set) var snapshot: CodexUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// True when auth.json is present and yields usable credentials. Set by
+    /// each fetch attempt so the tile can distinguish "not configured yet"
+    /// (needs onboarding card) from "configured but fetch failed" (error).
+    @Published public private(set) var hasCredentials: Bool = false
+    /// True when the last failure was a 401 — the user must re-run
+    /// `codex auth login`. Distinct from a generic network error.
+    @Published public private(set) var sessionExpired: Bool = false
+
+    // Injected dependencies keep the store unit-testable. The default
+    // production values read the real environment and hit the real
+    // endpoint; tests inject a fixed environment and a stubbed transport.
+    private let environment: [String: String]
+    private let transport: CodexUsageTransport
+    // Overrides UserDefaults for the feature flag in tests so a test does
+    // not have to mutate the shared standard defaults. Defaults to .standard.
+    private let defaults: UserDefaults
+
+    public init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        transport: CodexUsageTransport = URLSessionCodexTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.environment = environment
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    /// Codex is opt-in. Unlike Anthropic (on by default for compat), an
+    /// unset flag means OFF. The user turns it on in Settings (PR 3-UI).
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured means auth.json exists and parses. We probe the file
+    /// lazily so `isConfigured` is honest even before the first fetch.
+    public var isConfigured: Bool {
+        (try? CodexUsageFetcher.readCredentials(environment: environment)) != nil
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Not configured — render the onboarding card telling the user to
+        // run `codex auth login`. This is a needsAccess tile, matching the
+        // protocol's first-run onboarding kind.
+        if !isConfigured {
+            return [UsageTile(
+                id: "codex-needs-auth",
+                title: "Codex",
+                kind: .needsAccess(
+                    path: CodexUsageFetcher.authFileURL(environment: environment).path,
+                    guidance: "Run `codex auth login` in a terminal, then click Refresh."
+                )
+            )]
+        }
+
+        // Configured but the session expired (401) — a distinct actionable
+        // state, again pointing at re-login rather than a generic error.
+        if sessionExpired {
+            return [UsageTile(
+                id: "codex-session-expired",
+                title: "Codex",
+                kind: .text(
+                    status: "Codex session expired",
+                    subtitle: "Run `codex auth login` in a terminal, then click Refresh."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else {
+            // Configured, no error, but no data yet (pre-first-fetch). Empty
+            // tiles — the popover shows nothing for Codex until data lands,
+            // matching Anthropic's pre-fetch behaviour.
+            return []
+        }
+
+        var out: [UsageTile] = []
+
+        if let primary = snap.primaryWindow {
+            out.append(UsageTile(
+                id: "codex-5h",
+                title: "Codex (5 hour)",
+                kind: .bar(
+                    fraction: fraction(primary.usedPercent),
+                    resetsAt: primary.resetAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        if let secondary = snap.secondaryWindow {
+            out.append(UsageTile(
+                id: "codex-weekly",
+                title: "Codex (7 day)",
+                kind: .bar(
+                    fraction: fraction(secondary.usedPercent),
+                    resetsAt: secondary.resetAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        // Zero or more model-specific limit lanes (per-model or promotional
+        // caps, e.g. Spark). Empty on most accounts. Each lane's usage is
+        // nested under its own primary/secondary window; a lane can surface
+        // up to two bars. Index disambiguates the tile id when the server
+        // omits a limit_name.
+        for (index, limit) in snap.additionalLimits.enumerated() {
+            let label = limit.limitName ?? limit.meteredFeature ?? "Additional limit \(index + 1)"
+            if let primary = limit.primaryWindow {
+                out.append(UsageTile(
+                    id: "codex-additional-\(index)-5h",
+                    title: "Codex \(label) (5 hour)",
+                    kind: .bar(
+                        fraction: fraction(primary.usedPercent),
+                        resetsAt: primary.resetAt,
+                        badge: nil
+                    )
+                ))
+            }
+            if let secondary = limit.secondaryWindow {
+                out.append(UsageTile(
+                    id: "codex-additional-\(index)-weekly",
+                    title: "Codex \(label) (7 day)",
+                    kind: .bar(
+                        fraction: fraction(secondary.usedPercent),
+                        resetsAt: secondary.resetAt,
+                        badge: nil
+                    )
+                ))
+            }
+        }
+
+        // Optional credits tile — only when the account actually carries a
+        // credit balance. Suppressed otherwise so free/subscription accounts
+        // do not see a confusing "0" credit line.
+        if let credits = snap.credits, credits.hasCredits, let balance = credits.balance {
+            out.append(UsageTile(
+                id: "codex-credits",
+                title: "Codex credits",
+                kind: .text(
+                    status: credits.unlimited ? "Unlimited" : balance,
+                    subtitle: credits.overageLimitReached ? "Overage limit reached" : nil
+                )
+            ))
+        }
+
+        return out
+    }
+
+    /// Convert a 0…100 integer percentage into a 0.0…1.0 fraction, clamped
+    /// so a malformed >100 value cannot overflow a progress bar.
+    private func fraction(_ percent: Int) -> Double {
+        min(max(Double(percent) / 100.0, 0.0), 1.0)
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result to observable state. Extracted from the
+    /// async completion so the TestRunner can drive every branch (success,
+    /// 401 → sessionExpired, httpError, networkError) synchronously without
+    /// touching the network. `now` is injected so the lastUpdatedAt
+    /// assertion is deterministic.
+    public func apply(_ result: CodexUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try CodexUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+                self.sessionExpired = false
+            } catch {
+                self.lastError = "Could not parse Codex usage"
+            }
+        case .unauthorized:
+            // 401 — surface the re-login state. Do NOT write back to
+            // auth.json in PR 3-BE (Phase 1). Keep the last snapshot so the
+            // popover does not flash empty, but flag expiry.
+            self.sessionExpired = true
+            self.lastError = nil
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    /// Test-only helper to set credential presence without a real auth.json.
+    /// Used by tile-rendering tests that inject a store with a fixed
+    /// environment. Never called in production.
+    public func setHasCredentialsForTesting(_ value: Bool) {
+        self.hasCredentials = value
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        let creds: CodexCredentials
+        do {
+            creds = try CodexUsageFetcher.readCredentials(environment: environment)
+        } catch CodexAuthError.authFileMissing {
+            // Not configured. Clear any stale data; tiles render the
+            // onboarding card via isConfigured == false.
+            hasCredentials = false
+            snapshot = nil
+            lastError = nil
+            sessionExpired = false
+            return
+        } catch {
+            hasCredentials = false
+            snapshot = nil
+            lastError = "Codex credentials unreadable"
+            sessionExpired = false
+            return
+        }
+
+        hasCredentials = true
+
+        transport.fetchUsage(credentials: creds) { [weak self] result in
+            // Transport guarantees the completion is delivered on the main
+            // queue; applying @Published state here is main-actor safe. The
+            // application logic lives in `apply(_:)` so the TestRunner can
+            // drive every branch synchronously.
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // PR 3-BE does not own the credential file — auth.json belongs to the
+        // Codex CLI. "Clear" only drops our in-memory state; it never deletes
+        // the user's CLI login. Turning the provider off is done via the
+        // Settings toggle (PR 3-UI), not here.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        sessionExpired = false
+        hasCredentials = false
+    }
+}
+
+// MARK: - Transport abstraction
+
+/// Result of a usage fetch. `unauthorized` is split out from `httpError` so
+/// the store can render the distinct "session expired" state on 401.
+public enum CodexUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the network so the store is unit-testable without hitting the
+/// live endpoint. The completion MUST be delivered on the main queue.
+public protocol CodexUsageTransport: Sendable {
+    func fetchUsage(
+        credentials: CodexCredentials,
+        completion: @escaping @Sendable (CodexUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues the real request with the Bearer token and
+/// account-id header, mirroring the Codex CLI's own request. The response
+/// body is never logged (it is tied to the user's account) — only the
+/// status code goes through the categorical logger, matching the Anthropic
+/// fetch site and satisfying the CI credential-leak guard.
+public struct URLSessionCodexTransport: CodexUsageTransport {
+    private let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+
+    public init() {}
+
+    public func fetchUsage(
+        credentials: CodexCredentials,
+        completion: @escaping @Sendable (CodexUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(credentials.accountId, forHTTPHeaderField: "chatgpt-account-id")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (CodexUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                // Error object may reference the request; do not log it (it
+                // can carry the URL with headers in some transports). A
+                // generic marker is enough.
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("Codex usage API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/DeepSeekUsageFetcher.swift
+++ b/app/DeepSeekUsageFetcher.swift
@@ -1,0 +1,184 @@
+// PR 4-BE — DeepSeek usage fetcher + the first Keychain credential store.
+//
+// DeepSeek is the template "paste-a-key" provider: the user pastes an
+// `sk-...` API key, which is stored in the macOS Keychain (a spending
+// credential — it must never sit in UserDefaults). The provider then polls
+// `GET https://api.deepseek.com/user/balance` for the account balance.
+//
+// This file ships two things:
+//   1. DeepSeekUsageFetcher — Sendable value type, pure parser, mirroring
+//      the Anthropic/Codex fetchers. Fixtures hit `parse(_:)`.
+//   2. KeychainStore — the first concrete CredentialStore (the protocol was
+//      introduced in PR 47). Backs every future spending credential
+//      (DeepSeek key, Perplexity cookie, OpenAI admin key, ...).
+//
+// Response shape (verified against api-docs.deepseek.com/api/get-user-balance):
+//   {
+//     "is_available": Bool,          // is the balance sufficient for calls
+//     "balance_infos": [
+//       { "currency": "USD" | "CNY",
+//         "total_balance":     String,   // amounts are STRINGS, not numbers
+//         "granted_balance":   String,   // from promotions
+//         "topped_up_balance": String }  // paid top-ups
+//     ]
+//   }
+// All amounts are strings and are preserved verbatim — we do not reinterpret
+// currency or arithmetic on them beyond what the balance tile needs.
+
+import Foundation
+import Security
+
+// MARK: - Snapshot
+
+/// One currency's balance breakdown from `balance_infos[]`.
+public struct DeepSeekBalance: Equatable, Sendable {
+    /// "USD" or "CNY" as returned by the endpoint.
+    public var currency: String
+    /// Total balance, verbatim string (e.g. "110.00").
+    public var totalBalance: String
+    /// Promotional / granted portion, verbatim string.
+    public var grantedBalance: String
+    /// Paid top-up portion, verbatim string.
+    public var toppedUpBalance: String
+
+    public init(
+        currency: String,
+        totalBalance: String,
+        grantedBalance: String,
+        toppedUpBalance: String
+    ) {
+        self.currency = currency
+        self.totalBalance = totalBalance
+        self.grantedBalance = grantedBalance
+        self.toppedUpBalance = toppedUpBalance
+    }
+}
+
+/// A parsed snapshot of the `/user/balance` response.
+public struct DeepSeekUsageSnapshot: Equatable, Sendable {
+    /// Whether the balance is sufficient for API calls. When false the tile
+    /// turns amber and the balance is de-emphasised.
+    public var isAvailable: Bool
+    /// One entry per currency present on the account. Usually a single
+    /// currency, but the endpoint returns an array.
+    public var balances: [DeepSeekBalance]
+
+    public init(isAvailable: Bool = false, balances: [DeepSeekBalance] = []) {
+        self.isAvailable = isAvailable
+        self.balances = balances
+    }
+}
+
+public enum DeepSeekUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+/// Pure parser for the DeepSeek balance endpoint. Value type, no observable
+/// state. The Store owns the HTTP call and applies the snapshot.
+public struct DeepSeekUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Parse the JSON body of a `/user/balance` response. Throws
+    /// `invalidJSON` only when the top level is not a JSON object. A sparse
+    /// but well-formed body (empty balance_infos) parses to a snapshot with
+    /// an empty `balances` array, matching how the sibling fetchers tolerate
+    /// minimal shapes.
+    public static func parse(_ data: Data) throws -> DeepSeekUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DeepSeekUsageParseError.invalidJSON
+        }
+
+        var snap = DeepSeekUsageSnapshot()
+        if let available = json["is_available"] as? Bool {
+            snap.isAvailable = available
+        }
+
+        if let infos = json["balance_infos"] as? [[String: Any]] {
+            snap.balances = infos.compactMap { info in
+                guard let currency = info["currency"] as? String else { return nil }
+                return DeepSeekBalance(
+                    currency: currency,
+                    totalBalance: stringAmount(info["total_balance"]),
+                    grantedBalance: stringAmount(info["granted_balance"]),
+                    toppedUpBalance: stringAmount(info["topped_up_balance"])
+                )
+            }
+        }
+
+        return snap
+    }
+
+    /// Balances are strings on the wire; preserve them verbatim. Accept a
+    /// number defensively (in case the API ever returns one) and stringify
+    /// it, and fall back to "0" when the field is absent.
+    private static func stringAmount(_ value: Any?) -> String {
+        if let s = value as? String { return s }
+        if let i = value as? Int { return String(i) }
+        if let d = value as? Double { return String(d) }
+        return "0"
+    }
+}
+
+// MARK: - KeychainStore
+
+/// First concrete CredentialStore (protocol from PR 47). Stores spending
+/// credentials in the macOS login Keychain as generic passwords, keyed by a
+/// per-app service plus the caller's key. Every provider that holds a
+/// spending credential (DeepSeek API key, Perplexity cookie, OpenAI admin
+/// key) uses this rather than UserDefaults.
+///
+/// The service string namespaces our items so they never collide with other
+/// apps' Keychain entries. `read` returns nil for a missing item (not an
+/// error); `write` upserts; `delete` is idempotent.
+public struct KeychainStore: CredentialStore {
+    /// Keychain service used to namespace this app's items.
+    private let service: String
+
+    public init(service: String = "com.claude.usagebar.credentials") {
+        self.service = service
+    }
+
+    private func baseQuery(_ key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    public func read(_ key: String) -> Data? {
+        var query = baseQuery(key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else { return nil }
+        return item as? Data
+    }
+
+    public func write(_ key: String, _ value: Data) {
+        // Upsert: try to update an existing item first; if none exists, add.
+        let query = baseQuery(key)
+        let attributes: [String: Any] = [kSecValueData as String: value]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            var addQuery = baseQuery(key)
+            addQuery[kSecValueData as String] = value
+            // Only unlocked-while-this-device flags; the credential never
+            // syncs to iCloud Keychain and is unavailable before first
+            // unlock. Matches least-privilege for a spending credential.
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            SecItemAdd(addQuery as CFDictionary, nil)
+        }
+    }
+
+    public func delete(_ key: String) {
+        SecItemDelete(baseQuery(key) as CFDictionary)
+    }
+}

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -1,0 +1,261 @@
+// PR 4-BE — DeepSeek UsageProvider conformer (dark code, feature-flag off).
+//
+// Third provider (after Anthropic and Codex). DeepSeek is the "paste-a-key"
+// template: the user pastes an `sk-...` API key, stored in the Keychain via
+// KeychainStore, and the provider polls the account balance.
+//
+// Feature posture in PR 4-BE:
+//   - `features.deepseek.enabled` defaults FALSE (opt-in, like every
+//     non-Anthropic provider).
+//   - Nothing registers a DeepSeekUsageStore into AppDelegate.providers yet;
+//     the tile + Settings key-paste sheet land in PR 4-UI. This file is
+//     compiled and unit-tested but inert at runtime until then.
+//
+// Credential posture: the API key is a spending credential. It is stored in
+// the Keychain (never UserDefaults) and never logged. Only the HTTP status
+// code is logged, satisfying the CI credential-leak guard.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class DeepSeekUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "deepseek"
+    public let displayName: String = "DeepSeek"
+    public let featureFlagKey: String = "features.deepseek.enabled"
+
+    /// Keychain key under which the DeepSeek API key is stored.
+    public static let apiKeyKeychainKey = "deepseek.api_key"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: DeepSeekUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: DeepSeekUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: DeepSeekUsageTransport = URLSessionDeepSeekTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when an API key is stored. The key itself is never exposed.
+    public var hasKey: Bool {
+        guard let data = credentials.read(Self.apiKeyKeychainKey) else { return false }
+        return !data.isEmpty
+    }
+
+    /// Store a pasted API key (trimmed). Empty input clears the key instead.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(Self.apiKeyKeychainKey)
+        } else {
+            credentials.write(Self.apiKeyKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    public var isConfigured: Bool {
+        hasKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Not configured — onboarding card prompting the user to paste a key.
+        if !isConfigured {
+            return [UsageTile(
+                id: "deepseek-needs-key",
+                title: "DeepSeek",
+                kind: .needsAccess(
+                    path: "api.deepseek.com",
+                    guidance: "Paste your DeepSeek API key (sk-…) in Settings to track your balance."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Availability warning tile — shown only when the balance is not
+        // sufficient for API calls, so a healthy account stays uncluttered.
+        if !snap.isAvailable {
+            out.append(UsageTile(
+                id: "deepseek-status",
+                title: "DeepSeek",
+                kind: .text(
+                    status: "Balance too low",
+                    subtitle: "Top up your DeepSeek account to keep making API calls."
+                )
+            ))
+        }
+
+        // One balance tile per currency. Total headline with the granted +
+        // topped-up split as the subtitle. Amounts are shown verbatim (the
+        // endpoint returns decimal strings), prefixed with the currency.
+        for balance in snap.balances {
+            out.append(UsageTile(
+                id: "deepseek-balance-\(balance.currency.lowercased())",
+                title: "DeepSeek balance (\(balance.currency))",
+                kind: .text(
+                    status: "\(balance.currency) \(balance.totalBalance)",
+                    subtitle: "Granted \(balance.grantedBalance) + topped-up \(balance.toppedUpBalance)"
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result to observable state. Extracted so the
+    /// TestRunner can drive every branch synchronously.
+    public func apply(_ result: DeepSeekUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try DeepSeekUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+            } catch {
+                self.lastError = "Could not parse DeepSeek balance"
+            }
+        case .unauthorized:
+            // 401 — the pasted key is invalid or revoked. Surface an
+            // actionable message; keep the key so the user can correct it in
+            // Settings rather than silently losing it.
+            self.lastError = "Invalid DeepSeek API key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let keyData = credentials.read(Self.apiKeyKeychainKey),
+              !keyData.isEmpty,
+              let key = String(data: keyData, encoding: .utf8) else {
+            // No key stored; tiles render the onboarding card.
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchBalance(apiKey: key) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Clearing DeepSeek DOES delete its credential — unlike Codex, the
+        // key belongs to this app (the user pasted it here), not to an
+        // external CLI. This is the "Clear API key" action in Settings.
+        credentials.delete(Self.apiKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum DeepSeekUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the network for unit testing. The completion MUST be delivered
+/// on the main queue.
+public protocol DeepSeekUsageTransport: Sendable {
+    func fetchBalance(
+        apiKey: String,
+        completion: @escaping @Sendable (DeepSeekUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues the real request with the Bearer key. The
+/// response body is never logged; only the status code goes through the
+/// categorical logger.
+public struct URLSessionDeepSeekTransport: DeepSeekUsageTransport {
+    private let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
+
+    public init() {}
+
+    public func fetchBalance(
+        apiKey: String,
+        completion: @escaping @Sendable (DeepSeekUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: balanceURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (DeepSeekUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("DeepSeek balance API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -20,11 +20,14 @@ import SwiftUI
 import Combine
 
 @MainActor
-public final class DeepSeekUsageStore: @preconcurrency UsageProvider {
+public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
 
     public let id: String = "deepseek"
     public let displayName: String = "DeepSeek"
     public let featureFlagKey: String = "features.deepseek.enabled"
+
+    // PasteKeyProvider: the DeepSeek key is pasted by the user into Settings.
+    public let keyPlaceholder: String = "sk-…"
 
     /// Keychain key under which the DeepSeek API key is stored.
     public static let apiKeyKeychainKey = "deepseek.api_key"

--- a/app/Log.swift
+++ b/app/Log.swift
@@ -1,0 +1,72 @@
+// MARK: - Logging (categorical redaction)
+//
+// PR 1 introduced the categorical logger below to replace every NSLog site
+// in the app that touched cookies, org IDs, or response bodies. The call
+// site cannot interpolate a raw String; every value goes through a
+// category, and each category has its own emission rule. This makes
+// accidental credential logging a compile-time impossibility rather than a
+// discipline problem.
+//
+// PR 2a extracted the types out of ClaudeUsageBar.swift into this file so
+// the SwiftPM library target can compile them without also trying to
+// compile the @main entry point (which would conflict with TestRunner's
+// own main).
+//
+// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
+// reintroduce raw-interpolation NSLog calls or the deleted response-body
+// log line at the network fetch site. The exact banned pattern lives in
+// the workflow file to avoid embedding it here (which would self-trigger).
+
+import Foundation
+import CryptoKit
+
+public enum LogValue {
+    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
+    case `public`(String)
+    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
+    /// bodies, tokens, API keys, anything that could leak a credential.
+    case sensitive(String)
+    /// Emitted as a short SHA-256 prefix so the value can be correlated
+    /// across log lines without revealing it. Use for org IDs, user IDs.
+    case identifier(String)
+    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
+    /// retry counts, threshold values).
+    case count(Int)
+
+    public var rendered: String {
+        switch self {
+        case .public(let s):
+            return s
+        case .sensitive(let s):
+            return "<redacted: \(s.count) chars>"
+        case .identifier(let s):
+            let digest = SHA256.hash(data: Data(s.utf8))
+            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+            return "<id: \(hex.prefix(8))>"
+        case .count(let n):
+            return String(n)
+        }
+    }
+}
+
+public enum Log {
+    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
+    /// gate. Accepts a plain message — no interpolation of untrusted values.
+    public static func debug(_ message: String) {
+        #if DEBUG
+        NSLog("[debug] %@", message)
+        #endif
+    }
+
+    /// Info-level diagnostics. Retained in release builds. Values must be
+    /// wrapped in a `LogValue` category, forcing an explicit redaction
+    /// decision at the call site.
+    public static func info(_ message: String, _ values: LogValue...) {
+        let rendered = values.map(\.rendered).joined(separator: ", ")
+        if rendered.isEmpty {
+            NSLog("%@", message)
+        } else {
+            NSLog("%@ | %@", message, rendered)
+        }
+    }
+}

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -164,6 +164,25 @@ public protocol CredentialStore {
     func delete(_ key: String)
 }
 
+// MARK: - PasteKeyProvider
+
+/// Optional capability for providers configured by pasting a secret (an API
+/// key, a session cookie). The Settings toggle row shows a secure entry
+/// field for any provider that conforms. Providers configured another way
+/// (Codex reads a CLI file; Anthropic uses the cookie sheet) do not conform.
+///
+/// @MainActor because conformers are main-actor stores; the entry field is
+/// itself on the main actor.
+@MainActor
+public protocol PasteKeyProvider {
+    /// Placeholder shown in the entry field (e.g. "sk-…").
+    var keyPlaceholder: String { get }
+    /// True when a secret is currently stored.
+    var hasKey: Bool { get }
+    /// Store a pasted secret. Empty input clears it.
+    func saveKey(_ raw: String)
+}
+
 // MARK: - ProviderCopy
 
 /// Per-provider help and disclosure copy for the Settings toggles. Kept in
@@ -176,6 +195,8 @@ public enum ProviderCopy {
         switch id {
         case "codex":
             return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
+        case "deepseek":
+            return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -121,7 +121,13 @@ public protocol UsageProvider: AnyObject, ObservableObject {
 /// observation site did not. `ProviderBox` is the fix.
 @MainActor
 public final class ProviderBox: ObservableObject, Identifiable {
-    public let provider: any UsageProvider
+    // `nonisolated` so consumers that are not themselves main-actor-isolated
+    // (e.g. ProvidersModel.fetchEnabled, called from AppDelegate timer and
+    // lifecycle closures) can read it without an actor hop. It is an
+    // immutable `let` set once at init; the underlying provider's own methods
+    // remain main-actor-isolated, so this only exposes the reference, not
+    // unsynchronised mutable state.
+    public nonisolated let provider: any UsageProvider
     // Cached at construction rather than reaching through `provider.id` on
     // every access — keeps `id` a nonisolated stored property so the
     // Identifiable conformance is Swift-6-strict-concurrency clean.
@@ -156,6 +162,35 @@ public protocol CredentialStore {
     func read(_ key: String) -> Data?
     func write(_ key: String, _ value: Data)
     func delete(_ key: String)
+}
+
+// MARK: - ProviderCopy
+
+/// Per-provider help and disclosure copy for the Settings toggles. Kept in
+/// the library (not the app view file) so the strings are unit-testable —
+/// they are user-facing and must not silently change. Returns nil for a
+/// provider with no bespoke copy.
+public enum ProviderCopy {
+    /// Explanatory help shown under a provider's Settings toggle.
+    public static func help(for id: String) -> String? {
+        switch id {
+        case "codex":
+            return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
+        default:
+            return nil
+        }
+    }
+
+    /// A warning line shown for providers backed by a private/undocumented
+    /// API that may break without notice. Rendered in an accent colour.
+    public static func disclosure(for id: String) -> String? {
+        switch id {
+        case "codex":
+            return "Uses OpenAI's private Codex API. It may stop working without notice."
+        default:
+            return nil
+        }
+    }
 }
 
 /// UserDefaults-backed credential store. Used only for the legacy

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -197,6 +197,8 @@ public enum ProviderCopy {
             return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
         case "deepseek":
             return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
+        case "zed":
+            return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -1,0 +1,181 @@
+// PR 2c — UsageProvider protocol and supporting types.
+//
+// This PR introduces the multi-provider surface without adding any new
+// provider. It ships:
+//
+//   1. A `UsageProvider` protocol every provider will conform to.
+//   2. A `UsageTile` value type for popover rendering.
+//   3. A `ProviderBox` type-erasing wrapper so SwiftUI can observe a
+//      collection of heterogeneous providers via a single ObservableObject.
+//   4. `AnthropicUsageStore` — the first conformer, wrapping the existing
+//      UsageManager. Behaviour identical to v1.3.1.
+//
+// Everything is additive. UsageManager is not removed. The popover is not
+// yet driven by `[UsageProvider]` — that switch lands in a follow-up PR
+// once at least one non-Anthropic provider exists.
+//
+// The two-layer split (Fetcher value type + Store observable class) is
+// documented in EXPANSION_PLAN.md § 2. Fetchers are Sendable value types
+// with no observable state (see AnthropicUsageFetcher in PR 2b). Stores
+// hold @Published state on the main actor and are what SwiftUI observes.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// MARK: - UsageTile
+
+/// One renderable tile in the popover. A provider may contribute zero or
+/// more tiles. The `Kind` enum encodes the presentation semantics without
+/// coupling to a specific SwiftUI view; downstream PRs render each kind
+/// with the appropriate component.
+public struct UsageTile: Identifiable, Equatable, Sendable {
+    public let id: String                   // "anthropic-5h", "codex-weekly"
+    public let title: String                // "Session (5 hour)"
+    public let kind: Kind
+
+    public enum Kind: Equatable, Sendable {
+        /// Progress-bar tile with a 0.0…1.0 fraction and optional reset time.
+        case bar(fraction: Double, resetsAt: Date?, badge: String?)
+
+        /// Balance tile — displayed as a monetary amount plus an optional
+        /// plan label and reset time.
+        case balance(remainingMinorUnits: Int, currency: String, plan: String?, resetsAt: Date?)
+
+        /// Counter tile — used / limit with optional reset time.
+        case counter(used: Int, limit: Int?, resetsAt: Date?)
+
+        /// Freeform text tile — plan info, status warnings, "needs access".
+        case text(status: String, subtitle: String?)
+
+        /// The provider needs a permission the user has not granted.
+        case needsAccess(path: String, guidance: String)
+    }
+
+    public init(id: String, title: String, kind: Kind) {
+        self.id = id
+        self.title = title
+        self.kind = kind
+    }
+}
+
+// MARK: - UsageProvider
+
+/// Every provider (Anthropic, Codex, DeepSeek, Zed, xAI, OpenAI Platform,
+/// Perplexity, Copilot, local-file readers) conforms to this protocol.
+/// Providers are held in `AppDelegate.providers` as a heterogeneous
+/// collection wrapped in `ProviderBox` for SwiftUI observation.
+public protocol UsageProvider: AnyObject, ObservableObject {
+    /// Stable identifier used for feature flags, notification-threshold
+    /// tracking, and log correlation. Examples: "anthropic", "codex",
+    /// "deepseek".
+    var id: String { get }
+
+    /// Display name in the popover section header and Settings toggle.
+    var displayName: String { get }
+
+    /// UserDefaults key that gates activation. Defaulted false. Reading and
+    /// writing this flag is the provider's responsibility.
+    var featureFlagKey: String { get }
+
+    /// True when the user has activated the provider via Settings.
+    var isEnabled: Bool { get }
+
+    /// True when the provider has valid credentials or file access to
+    /// operate. False means the tile should render a first-run onboarding
+    /// state (paste key, grant access, etc.).
+    var isConfigured: Bool { get }
+
+    /// Timestamp of the most recent successful fetch. Nil before the
+    /// first fetch.
+    var lastUpdated: Date? { get }
+
+    /// One-line human-readable error if the last fetch failed. Nil on
+    /// success or when idle.
+    var errorMessage: String? { get }
+
+    /// Tiles this provider currently renders in the popover. Empty when
+    /// the provider is disabled.
+    var tiles: [UsageTile] { get }
+
+    /// Kick off a fetch. Providers are responsible for their own cadence
+    /// (5-minute Anthropic, 60-second Codex, hourly OpenAI Platform,
+    /// etc.). This method is called by the shared timer in AppDelegate
+    /// and may be called manually via the popover's Refresh button.
+    func fetch()
+
+    /// Clear stored state and (optionally) credentials. Called by the
+    /// per-provider "Clear credentials" button in Settings.
+    func clear()
+}
+
+// MARK: - ProviderBox
+
+/// Type-erasing wrapper for SwiftUI. `@ObservedObject var: any UsageProvider`
+/// does not compile in Swift 6 mode (existential + associated type) — the
+/// box forwards `objectWillChange` from the underlying provider so views
+/// can observe it uniformly.
+///
+/// This is one of the load-bearing catches from the pre-PR adversarial
+/// review; the underlying protocol trial compiled fine, but the SwiftUI
+/// observation site did not. `ProviderBox` is the fix.
+@MainActor
+public final class ProviderBox: ObservableObject, Identifiable {
+    public let provider: any UsageProvider
+    // Cached at construction rather than reaching through `provider.id` on
+    // every access — keeps `id` a nonisolated stored property so the
+    // Identifiable conformance is Swift-6-strict-concurrency clean.
+    public nonisolated let id: String
+
+    private var cancellable: AnyCancellable?
+
+    public init<P: UsageProvider>(_ provider: P) {
+        self.provider = provider
+        self.id = provider.id
+        // Forward the underlying provider's change notifications so
+        // SwiftUI redraws views observing this box.
+        self.cancellable = provider.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+    }
+}
+
+// MARK: - CredentialStore
+
+/// Storage abstraction for provider credentials. Two backends:
+/// `DefaultsStore` (for the legacy Anthropic cookie, retained for
+/// backwards compatibility) and `KeychainStore` (for spending credentials
+/// and any new provider going forward).
+///
+/// Concrete Keychain implementation lands in a follow-up PR once at
+/// least one provider actually needs it. PR 2c ships the abstraction so
+/// downstream PRs have a stable target.
+public protocol CredentialStore {
+    func read(_ key: String) -> Data?
+    func write(_ key: String, _ value: Data)
+    func delete(_ key: String)
+}
+
+/// UserDefaults-backed credential store. Used only for the legacy
+/// Anthropic session cookie. New providers must use `KeychainStore`.
+public struct DefaultsStore: CredentialStore {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func read(_ key: String) -> Data? {
+        defaults.data(forKey: key)
+    }
+
+    public func write(_ key: String, _ value: Data) {
+        defaults.set(value, forKey: key)
+    }
+
+    public func delete(_ key: String) {
+        defaults.removeObject(forKey: key)
+    }
+}

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -1,0 +1,252 @@
+// PR 6-BE — xAI Developer usage fetcher (two-key, two-host).
+//
+// xAI is the first two-credential provider:
+//   - Tier 1 (mandatory): an INFERENCE key (xai-...). Bootstraps team_id and
+//     the model catalogue from api.x.ai. Gives plan info but no spend.
+//   - Tier 2 (optional): a MANAGEMENT key. Reads the prepaid balance and
+//     daily usage from management-api.x.ai. NB the management key also carries
+//     the `xai-` prefix (it is NOT literally `xai-mgmt-`); it is a distinct
+//     key issued from the console's Management Keys section, not
+//     interchangeable with the inference key. Management keys can create /
+//     rotate / delete API keys, so Tier 2 is gated behind an explicit warning
+//     in the UI (PR 6-UI). Both keys live in the Keychain.
+//
+// Feature posture: features.xai.enabled defaults false; nothing registers a
+// store into the live registry yet (tile + two-key sheet land in PR 6-UI).
+//
+// Hosts and auth (both Bearer):
+//   api.x.ai            — inference key: GET /v1/api-key, GET /v1/language-models
+//   management-api.x.ai — management key: GET  /v1/billing/teams/{team}/prepaid/balance
+//                                          POST /v1/billing/teams/{team}/usage
+//
+// The prepaid-balance `total.val` unit and sign convention are the single
+// riskiest interpretation here (the plan flags a live curl check before
+// ship). To keep that correction cheap, ALL unit/sign logic lives in one
+// documented function, `XAIBalance.remainingUSD`, and the parser stores the
+// raw integer verbatim. See the note there.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// Result of GET /v1/api-key. Bootstraps the team id used for the management
+/// endpoints, and carries the ACL list used to describe the plan/permissions.
+public struct XAIApiKeyInfo: Equatable, Sendable {
+    public var teamId: String?
+    public var acls: [String]
+    /// Redacted key label for display (never the raw key).
+    public var redactedKey: String?
+    public var name: String?
+
+    public init(teamId: String? = nil, acls: [String] = [], redactedKey: String? = nil, name: String? = nil) {
+        self.teamId = teamId
+        self.acls = acls
+        self.redactedKey = redactedKey
+        self.name = name
+    }
+}
+
+/// One model from GET /v1/language-models.
+public struct XAIModel: Equatable, Sendable {
+    public var id: String
+    /// Prompt (input) price per token, in the unit the endpoint returns
+    /// (xAI uses 1e-10 USD ticks per token for completion pricing). Stored
+    /// verbatim; conversion is the tile's concern, not the fetcher's.
+    public var promptTokenPrice: Int?
+    public var completionTokenPrice: Int?
+
+    public init(id: String, promptTokenPrice: Int? = nil, completionTokenPrice: Int? = nil) {
+        self.id = id
+        self.promptTokenPrice = promptTokenPrice
+        self.completionTokenPrice = completionTokenPrice
+    }
+}
+
+/// Prepaid balance from the management API.
+public struct XAIBalance: Equatable, Sendable {
+    /// The raw `total.val` integer, stored verbatim. Interpretation (unit +
+    /// sign) is deliberately isolated in `remainingUSD` so it can be
+    /// corrected after a live account check without touching the parser.
+    public var totalValRaw: Int
+    /// Currency code if the endpoint returns one (e.g. "USD").
+    public var currency: String?
+
+    public init(totalValRaw: Int, currency: String? = nil) {
+        self.totalValRaw = totalValRaw
+        self.currency = currency
+    }
+
+    /// Convert the raw `total.val` into remaining USD.
+    ///
+    /// UNIT + SIGN — the one place this interpretation lives, verified against
+    /// xAI's management-API OpenAPI schema (the `total` object is documented
+    /// as "Representation of USD Cents"):
+    ///   - Unit: `total.val` is USD CENTS (1/100 USD). Divide by 100 for
+    ///     dollars. NOTE: this is NOT the 1e-10 "tick" unit — that unit
+    ///     applies to per-token MODEL PRICING (lineItem.unitPrice, documented
+    ///     as 1/1_000_000 USD cents), not to the balance total. Getting this
+    ///     wrong is an 8-order-of-magnitude error, so it is isolated here.
+    ///   - Sign: the ledger convention makes credit-adding events negative and
+    ///     spend positive, so `total.val` is NEGATIVE when prepaid credit
+    ///     remains. Remaining credit in cents is `-val`; a zero or positive
+    ///     value means no prepaid credit left (clamp to 0).
+    /// `val` arrives as a string-encoded int64 on the wire; the parser stores
+    /// it as an Int. A live curl check against a paid account can still
+    /// correct this single function if the account data contradicts the docs.
+
+    /// Per-token model pricing is expressed in 1/1_000_000 USD cents
+    /// (micro-cents). Distinct from the balance unit above.
+    public static let modelPriceMicroCentsPerCent = 1_000_000.0
+
+    public var remainingUSD: Double {
+        // Negative val = remaining credit; clamp non-negative val to 0.
+        max(-Double(totalValRaw), 0) / 100.0
+    }
+}
+
+/// One day's usage from the management usage endpoint.
+public struct XAIDailyUsage: Equatable, Sendable {
+    public var date: String   // ISO date (YYYY-MM-DD) as returned
+    public var usdSpent: Double
+
+    public init(date: String, usdSpent: Double) {
+        self.date = date
+        self.usdSpent = usdSpent
+    }
+}
+
+/// Aggregate snapshot. Tier-1 fields are always present when configured;
+/// Tier-2 fields (balance, daily) are nil until a management key is added.
+public struct XAIUsageSnapshot: Equatable, Sendable {
+    public var apiKeyInfo: XAIApiKeyInfo?
+    public var models: [XAIModel]
+    public var balance: XAIBalance?
+    public var daily: [XAIDailyUsage]
+
+    public init(
+        apiKeyInfo: XAIApiKeyInfo? = nil,
+        models: [XAIModel] = [],
+        balance: XAIBalance? = nil,
+        daily: [XAIDailyUsage] = []
+    ) {
+        self.apiKeyInfo = apiKeyInfo
+        self.models = models
+        self.balance = balance
+        self.daily = daily
+    }
+}
+
+public enum XAIUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct XAIUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain keys for the two credentials.
+    public static let inferenceKeyKeychainKey = "xai.inference_key"
+    public static let managementKeyKeychainKey = "xai.management_key"
+
+    // MARK: Tier 1 parsing
+
+    /// Parse GET /v1/api-key. Tolerant of absent fields; the team_id is the
+    /// one field the management endpoints depend on.
+    public static func parseApiKey(_ data: Data) throws -> XAIApiKeyInfo {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        var info = XAIApiKeyInfo()
+        // xAI has used both "team_id" and "teamId"; accept either.
+        info.teamId = (json["team_id"] as? String) ?? (json["teamId"] as? String)
+        if let acls = json["acls"] as? [String] {
+            info.acls = acls
+        }
+        info.redactedKey = (json["redacted_api_key"] as? String) ?? (json["redactedApiKey"] as? String)
+        info.name = json["name"] as? String
+        return info
+    }
+
+    /// Parse GET /v1/language-models. The models live under a top-level
+    /// "models" or "data" array depending on API version.
+    public static func parseLanguageModels(_ data: Data) throws -> [XAIModel] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        let arr = (json["models"] as? [[String: Any]]) ?? (json["data"] as? [[String: Any]]) ?? []
+        return arr.compactMap { entry in
+            guard let id = entry["id"] as? String else { return nil }
+            return XAIModel(
+                id: id,
+                promptTokenPrice: intOrNil(entry["prompt_text_token_price"] ?? entry["prompt_token_price"]),
+                completionTokenPrice: intOrNil(entry["completion_text_token_price"] ?? entry["completion_token_price"])
+            )
+        }
+    }
+
+    // MARK: Tier 2 parsing
+
+    /// Parse the prepaid balance. Stores `total.val` verbatim; the unit/sign
+    /// interpretation is in XAIBalance.remainingUSD.
+    public static func parseBalance(_ data: Data) throws -> XAIBalance {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        // Balance may be under "total" or at the top level.
+        let total = (json["total"] as? [String: Any]) ?? json
+        guard let val = intOrNil(total["val"]) else {
+            throw XAIUsageParseError.unexpectedShape("balance total.val missing")
+        }
+        let currency = (total["currency"] as? String) ?? (json["currency"] as? String)
+        return XAIBalance(totalValRaw: val, currency: currency)
+    }
+
+    /// Parse the daily-usage response into date/USD points. Tolerant of the
+    /// exact bucket shape: looks for a list of records each carrying a date
+    /// and a USD amount (in ticks or dollars — see note).
+    public static func parseUsage(_ data: Data) throws -> [XAIDailyUsage] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        // The daily buckets live under "usage", "data", or "daily".
+        let buckets = (json["usage"] as? [[String: Any]])
+            ?? (json["data"] as? [[String: Any]])
+            ?? (json["daily"] as? [[String: Any]])
+            ?? []
+        return buckets.compactMap { bucket in
+            guard let date = (bucket["date"] as? String) ?? (bucket["day"] as? String) else { return nil }
+            // USD may be a dollar Double, or a cents Int (same unit as the
+            // balance total). Prefer an explicit dollar field; fall back to a
+            // cents field divided by 100. The exact daily-usage field names
+            // are not documented, so this stays tolerant.
+            let usd: Double
+            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"]) {
+                usd = d
+            } else if let cents = intOrNil(bucket["cents"] ?? bucket["usd_cents"] ?? bucket["amount_cents"]) {
+                usd = Double(cents) / 100.0
+            } else {
+                usd = 0
+            }
+            return XAIDailyUsage(date: date, usdSpent: usd)
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double { return Int(d) }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+
+    private static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s) }
+        return nil
+    }
+}

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -1,0 +1,299 @@
+// PR 6-BE — xAI Developer UsageProvider conformer (dark code, flag off).
+//
+// Fifth provider, and the first two-credential one. Tier 1 (inference key)
+// is required and yields plan info; Tier 2 (management key) is optional and
+// yields the prepaid balance + daily usage. Both keys live in the Keychain.
+//
+// Feature posture: features.xai.enabled defaults false; nothing registers a
+// store into the live registry yet (two-key sheet + tiles land in PR 6-UI).
+//
+// Credentials never reach a log line; only HTTP status codes are logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class XAIUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "xai"
+    public let displayName: String = "xAI (Grok)"
+    public let featureFlagKey: String = "features.xai.enabled"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: XAIUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: XAIUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: XAIUsageTransport = URLSessionXAITransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// Tier 1 — the inference key (required).
+    public var hasInferenceKey: Bool {
+        !(credentials.read(XAIUsageFetcher.inferenceKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    /// Tier 2 — the management key (optional; unlocks balance + history).
+    public var hasManagementKey: Bool {
+        !(credentials.read(XAIUsageFetcher.managementKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    public func saveInferenceKey(_ raw: String) {
+        saveOrClear(raw, key: XAIUsageFetcher.inferenceKeyKeychainKey)
+    }
+
+    public func saveManagementKey(_ raw: String) {
+        saveOrClear(raw, key: XAIUsageFetcher.managementKeyKeychainKey)
+    }
+
+    private func saveOrClear(_ raw: String, key: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(key)
+        } else {
+            credentials.write(key, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    private func readKey(_ key: String) -> String? {
+        guard let data = credentials.read(key), !data.isEmpty else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured once the required Tier-1 inference key is present.
+    public var isConfigured: Bool {
+        hasInferenceKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "xai-needs-key",
+                title: "xAI (Grok)",
+                kind: .needsAccess(
+                    path: "api.x.ai",
+                    guidance: "Paste an xAI API key (xai-…) in Settings. Add a management key too for balance and usage history."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan / permissions tile from the ACLs.
+        if let info = snap.apiKeyInfo {
+            let acls = info.acls.isEmpty ? "API access" : info.acls.joined(separator: ", ")
+            out.append(UsageTile(
+                id: "xai-plan",
+                title: "xAI API key",
+                kind: .text(status: info.redactedKey ?? "Configured", subtitle: acls)
+            ))
+        }
+
+        // Tier 2: prepaid balance. Only when a management key produced one.
+        if let balance = snap.balance {
+            let currency = balance.currency ?? "USD"
+            // remainingUSD encapsulates the tick unit + credit sign; convert
+            // to minor units for the balance tile.
+            let minorUnits = Int((balance.remainingUSD * 100).rounded())
+            out.append(UsageTile(
+                id: "xai-balance",
+                title: "xAI prepaid balance",
+                kind: .balance(remainingMinorUnits: minorUnits, currency: currency, plan: nil, resetsAt: nil)
+            ))
+        }
+
+        // Tier 2: rolled-up recent spend as a text tile (the small chart is a
+        // UI concern for PR 6-UI; the backend surfaces the total here).
+        if !snap.daily.isEmpty {
+            let total = snap.daily.reduce(0.0) { $0 + $1.usdSpent }
+            out.append(UsageTile(
+                id: "xai-daily-usd",
+                title: "xAI usage (recent)",
+                kind: .text(status: String(format: "$%.2f", total), subtitle: "\(snap.daily.count) days")
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// The transport gathers all endpoints and hands back a combined result
+    /// so the store applies one snapshot. Extracted for synchronous testing.
+    public func apply(_ result: XAIUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            self.lastError = "Invalid xAI API key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let inference = readKey(XAIUsageFetcher.inferenceKeyKeychainKey) else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+        // Tier 2 is optional — pass the management key only if present.
+        let management = readKey(XAIUsageFetcher.managementKeyKeychainKey)
+
+        transport.fetchAll(inferenceKey: inference, managementKey: management) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Clears BOTH keys (the user pasted them here) and the state.
+        credentials.delete(XAIUsageFetcher.inferenceKeyKeychainKey)
+        credentials.delete(XAIUsageFetcher.managementKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum XAIUsageResult: Sendable {
+    case success(XAIUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the multi-endpoint fetch. The completion MUST be on the main
+/// queue.
+public protocol XAIUsageTransport: Sendable {
+    func fetchAll(
+        inferenceKey: String,
+        managementKey: String?,
+        completion: @escaping @Sendable (XAIUsageResult) -> Void
+    )
+}
+
+/// Production transport. Chains: api-key -> language-models (Tier 1), then if
+/// a management key + team id are present, prepaid/balance + usage (Tier 2).
+/// Response bodies are never logged; only status codes.
+public struct URLSessionXAITransport: XAIUsageTransport {
+    private let apiHost = "https://api.x.ai"
+    private let mgmtHost = "https://management-api.x.ai"
+
+    public init() {}
+
+    public func fetchAll(
+        inferenceKey: String,
+        managementKey: String?,
+        completion: @escaping @Sendable (XAIUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (XAIUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Tier 1: GET /v1/api-key
+        get("\(apiHost)/v1/api-key", bearer: inferenceKey) { data, status in
+            guard status == 200, let data = data,
+                  let info = try? XAIUsageFetcher.parseApiKey(data) else {
+                deliver(status == 401 || status == 403 ? .unauthorized
+                        : (status == nil ? .networkError : .httpError(status!)))
+                return
+            }
+
+            // Tier 1: GET /v1/language-models. Build the snapshot immutably,
+            // passing accumulated pieces forward into each nested closure
+            // rather than mutating a captured var (which would not be
+            // Sendable-safe across the async completion boundaries).
+            self.get("\(self.apiHost)/v1/language-models", bearer: inferenceKey) { modelData, _ in
+                let models: [XAIModel] = modelData.flatMap { try? XAIUsageFetcher.parseLanguageModels($0) } ?? []
+                let tier1 = XAIUsageSnapshot(apiKeyInfo: info, models: models)
+
+                // Tier 2 (optional): balance + usage, only with a management
+                // key and a bootstrapped team id.
+                guard let mgmt = managementKey, let team = info.teamId else {
+                    deliver(.success(tier1))
+                    return
+                }
+
+                self.get("\(self.mgmtHost)/v1/billing/teams/\(team)/prepaid/balance", bearer: mgmt) { balData, _ in
+                    let balance: XAIBalance? = balData.flatMap { try? XAIUsageFetcher.parseBalance($0) }
+                    self.post("\(self.mgmtHost)/v1/billing/teams/\(team)/usage", bearer: mgmt) { usageData, _ in
+                        let daily: [XAIDailyUsage] = usageData.flatMap { try? XAIUsageFetcher.parseUsage($0) } ?? []
+                        let full = XAIUsageSnapshot(apiKeyInfo: info, models: models, balance: balance, daily: daily)
+                        deliver(.success(full))
+                    }
+                }
+            }
+        }
+    }
+
+    private func get(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        request(urlString, method: "GET", bearer: bearer, body: nil, done: done)
+    }
+
+    private func post(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        // Empty JSON body; the usage endpoint accepts a default date range.
+        request(urlString, method: "POST", bearer: bearer, body: Data("{}".utf8), done: done)
+    }
+
+    private func request(_ urlString: String, method: String, bearer: String, body: Data?, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        guard let url = URL(string: urlString) else { done(nil, nil); return }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+        if let body = body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("xAI API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}

--- a/app/ZedUsageFetcher.swift
+++ b/app/ZedUsageFetcher.swift
@@ -1,0 +1,220 @@
+// PR 5-BE — Zed usage fetcher + reader for Zed's own Keychain credential.
+//
+// Zed differs from every prior provider: it holds no credential of its own.
+// It reads the access token Zed itself already stored in the login Keychain
+// (an internet-password item for server "zed.dev"), then calls Zed's client
+// API for the current user's plan and edit-prediction usage.
+//
+// The first Keychain read triggers a macOS SecurityAgent prompt ("ClaudeUsage
+// Bar wants to use the zed.dev password"); the user must allow it once. We
+// never write to Zed's Keychain item.
+//
+// Auth is unusual: the Authorization header value is "{user_id} {access_token}"
+// — the user id and token separated by a SPACE, NOT the "Bearer" scheme.
+//
+// Data source: GET https://cloud.zed.dev/client/users/me
+//
+// Response shape (the plan object the tiles consume) is built against Zed's
+// open-source client structs. Fields the parser reads:
+//   plan.plan_v3                              String enum (zed_free, zed_pro, …)
+//   plan.usage.edit_predictions.used / .limit Int
+//   plan.subscription_period.ended_at         reset time
+//   plan.has_overdue_invoices                 Bool
+//   plan.is_account_too_young                 Bool
+// Every field is treated as optional and tolerated when absent — this is an
+// undocumented internal API and the shape can drift.
+
+import Foundation
+import Security
+
+// MARK: - Snapshot
+
+/// Edit-prediction usage from `plan.usage.edit_predictions`.
+public struct ZedEditPredictionUsage: Equatable, Sendable {
+    public var used: Int
+    /// Nil means unlimited (Pro plans have no edit-prediction cap).
+    public var limit: Int?
+
+    public init(used: Int = 0, limit: Int? = nil) {
+        self.used = used
+        self.limit = limit
+    }
+}
+
+/// A parsed snapshot of the Zed `users/me` plan block.
+public struct ZedUsageSnapshot: Equatable, Sendable {
+    /// Raw plan identifier, e.g. "zed_free", "zed_pro". Rendered via a
+    /// friendly label in the tile.
+    public var planV3: String?
+    public var editPredictions: ZedEditPredictionUsage?
+    /// End of the current subscription/usage period — the edit-prediction
+    /// reset time.
+    public var periodEndsAt: Date?
+    public var hasOverdueInvoices: Bool
+    public var isAccountTooYoung: Bool
+
+    public init(
+        planV3: String? = nil,
+        editPredictions: ZedEditPredictionUsage? = nil,
+        periodEndsAt: Date? = nil,
+        hasOverdueInvoices: Bool = false,
+        isAccountTooYoung: Bool = false
+    ) {
+        self.planV3 = planV3
+        self.editPredictions = editPredictions
+        self.periodEndsAt = periodEndsAt
+        self.hasOverdueInvoices = hasOverdueInvoices
+        self.isAccountTooYoung = isAccountTooYoung
+    }
+}
+
+/// Credentials read from Zed's own Keychain item.
+public struct ZedCredentials: Equatable, Sendable {
+    public let userId: String
+    public let accessToken: String
+
+    public init(userId: String, accessToken: String) {
+        self.userId = userId
+        self.accessToken = accessToken
+    }
+
+    /// The Authorization header value Zed's client uses: user id and token
+    /// separated by a single space (not the Bearer scheme).
+    public var authorizationHeaderValue: String {
+        "\(userId) \(accessToken)"
+    }
+}
+
+public enum ZedUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+public enum ZedAuthError: Error, Equatable {
+    /// No zed.dev item in the Keychain (Zed not logged in, or the user
+    /// denied the SecurityAgent prompt).
+    case keychainItemMissing
+    /// The item exists but lacks a usable account (user id) or token.
+    case keychainItemIncomplete
+}
+
+// MARK: - Fetcher
+
+public struct ZedUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: Keychain read (Zed's own internet-password item)
+
+    /// Read Zed's access token from the login Keychain. Zed stores it as an
+    /// internet-password item for server "zed.dev"; the item's account is the
+    /// user id and its data is the access token. We match by server only
+    /// (the user id is not known in advance) and read both attributes back.
+    ///
+    /// The `server` is injectable so tests do not touch the real Keychain.
+    public static func readCredentials(server: String = "zed.dev") throws -> ZedCredentials {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassInternetPassword,
+            kSecAttrServer as String: server,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else {
+            throw ZedAuthError.keychainItemMissing
+        }
+        guard let dict = item as? [String: Any],
+              let account = dict[kSecAttrAccount as String] as? String, !account.isEmpty,
+              let data = dict[kSecValueData as String] as? Data,
+              let token = String(data: data, encoding: .utf8), !token.isEmpty
+        else {
+            throw ZedAuthError.keychainItemIncomplete
+        }
+        return ZedCredentials(userId: account, accessToken: token)
+    }
+
+    // MARK: Pure parsing (this is what the fixtures hit)
+
+    /// Parse the JSON body of `users/me`. The plan block may be nested under
+    /// a top-level "plan" key, or the whole response may itself be the plan
+    /// block depending on Zed's version — accept both by preferring a "plan"
+    /// object when present and falling back to the top level.
+    public static func parse(_ data: Data) throws -> ZedUsageSnapshot {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ZedUsageParseError.invalidJSON
+        }
+
+        // Prefer an explicit "plan" object; otherwise treat the root as the
+        // plan block (tolerant of both documented layouts).
+        let plan = (root["plan"] as? [String: Any]) ?? root
+
+        var snap = ZedUsageSnapshot()
+        snap.planV3 = plan["plan_v3"] as? String
+        snap.hasOverdueInvoices = (plan["has_overdue_invoices"] as? Bool) ?? false
+        snap.isAccountTooYoung = (plan["is_account_too_young"] as? Bool) ?? false
+
+        if let usage = plan["usage"] as? [String: Any],
+           let edit = usage["edit_predictions"] as? [String: Any] {
+            var ep = ZedEditPredictionUsage()
+            if let used = edit["used"] as? Int {
+                ep.used = used
+            } else if let used = edit["used"] as? Double {
+                ep.used = Int(used)
+            }
+            // limit is Zed's UsageLimit enum, whose wire encoding is
+            // non-obvious: Limited(N) serializes as the OBJECT {"limited": N},
+            // and Unlimited serializes as the bare STRING "unlimited". A plain
+            // integer is NOT what this endpoint returns. Map both: an object
+            // with "limited" -> that number; "unlimited" (or absent) -> nil
+            // (unlimited). Accept a bare number too, defensively.
+            ep.limit = Self.parseUsageLimit(edit["limit"])
+            snap.editPredictions = ep
+        }
+
+        if let period = plan["subscription_period"] as? [String: Any] {
+            snap.periodEndsAt = parseDate(period["ended_at"])
+        }
+
+        return snap
+    }
+
+    /// Parse Zed's `UsageLimit` from `usage.edit_predictions.limit`. The wire
+    /// encoding is a serde externally-tagged enum:
+    ///   Limited(i32) -> {"limited": N}   (an OBJECT)
+    ///   Unlimited    -> "unlimited"       (a bare STRING)
+    /// Returns the numeric cap for Limited, or nil for Unlimited / absent /
+    /// unrecognised. Also accepts a bare number defensively.
+    public static func parseUsageLimit(_ value: Any?) -> Int? {
+        if let obj = value as? [String: Any] {
+            if let n = obj["limited"] as? Int { return n }
+            if let n = obj["limited"] as? Double { return Int(n) }
+            return nil
+        }
+        if let s = value as? String {
+            // "unlimited" -> nil. A numeric string (header-style) -> its value.
+            if s == "unlimited" { return nil }
+            return Int(s)
+        }
+        if let n = value as? Int { return n }
+        if let n = value as? Double { return Int(n) }
+        return nil
+    }
+
+    /// Parse a reset timestamp that may be an ISO-8601 string or a Unix epoch
+    /// integer, tolerating both since the wire format is not guaranteed.
+    private static func parseDate(_ value: Any?) -> Date? {
+        if let s = value as? String {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            return iso.date(from: s)
+        }
+        if let epoch = value as? Int { return Date(timeIntervalSince1970: TimeInterval(epoch)) }
+        if let epoch = value as? Double { return Date(timeIntervalSince1970: epoch) }
+        return nil
+    }
+}

--- a/app/ZedUsageStore.swift
+++ b/app/ZedUsageStore.swift
@@ -1,0 +1,267 @@
+// PR 5-BE — Zed UsageProvider conformer (dark code, feature-flag off).
+//
+// Fourth provider. Zed is the read-from-the-app's-own-Keychain template: it
+// holds no credential of its own, reading the token Zed itself stored. The
+// first read triggers a macOS SecurityAgent prompt the user must allow once.
+//
+// Feature posture: features.zed.enabled defaults false; nothing registers a
+// ZedUsageStore into the live registry yet (tile + toggle land in PR 5-UI).
+//
+// Auth: the Authorization header is "{user_id} {access_token}" — space
+// delimited, NOT Bearer. Credentials never reach a log line; only the HTTP
+// status code is logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class ZedUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "zed"
+    public let displayName: String = "Zed"
+    public let featureFlagKey: String = "features.zed.enabled"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: ZedUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// True when Zed's Keychain item was readable on the last attempt.
+    @Published public private(set) var hasKeychainAccess: Bool = false
+
+    private let transport: ZedUsageTransport
+    private let defaults: UserDefaults
+    // Injected so tests can supply credentials without touching the real
+    // Keychain. Production reads Zed's own item.
+    private let credentialReader: @Sendable () -> Result<ZedCredentials, Error>
+
+    public init(
+        transport: ZedUsageTransport = URLSessionZedTransport(),
+        defaults: UserDefaults = .standard,
+        credentialReader: @escaping @Sendable () -> Result<ZedCredentials, Error> = {
+            Result { try ZedUsageFetcher.readCredentials() }
+        }
+    ) {
+        self.transport = transport
+        self.defaults = defaults
+        self.credentialReader = credentialReader
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured means Zed's Keychain item is readable. Probing it here
+    /// would trigger the SecurityAgent prompt on every access, so we report
+    /// the result of the last fetch attempt instead of probing eagerly.
+    public var isConfigured: Bool {
+        hasKeychainAccess
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Before the first successful Keychain read, show an onboarding card
+        // explaining the one-time prompt.
+        if !hasKeychainAccess && snapshot == nil {
+            return [UsageTile(
+                id: "zed-needs-access",
+                title: "Zed",
+                kind: .needsAccess(
+                    path: "zed.dev (Keychain)",
+                    guidance: "Sign in to Zed, then click Refresh. macOS will ask once to let this app read Zed's saved login."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan tile — friendly label for the raw plan_v3 identifier.
+        out.append(UsageTile(
+            id: "zed-plan",
+            title: "Zed plan",
+            kind: .text(status: Self.planLabel(snap.planV3), subtitle: nil)
+        ))
+
+        // Edit-predictions counter. Shown when the plan reports the bucket.
+        if let ep = snap.editPredictions {
+            out.append(UsageTile(
+                id: "zed-edit-predictions",
+                title: "Edit predictions",
+                kind: .counter(
+                    used: ep.used,
+                    limit: ep.limit,          // nil renders as unlimited
+                    resetsAt: snap.periodEndsAt
+                )
+            ))
+        }
+
+        // Billing warning — only when there is a problem, so healthy accounts
+        // stay uncluttered.
+        if snap.hasOverdueInvoices || snap.isAccountTooYoung {
+            let reason = snap.hasOverdueInvoices
+                ? "You have overdue invoices on your Zed account."
+                : "Your Zed account is too new for this feature yet."
+            out.append(UsageTile(
+                id: "zed-billing",
+                title: "Zed billing",
+                kind: .text(status: "Attention needed", subtitle: reason)
+            ))
+        }
+
+        return out
+    }
+
+    /// Map Zed's raw plan_v3 identifier to a human label. Unknown values are
+    /// shown verbatim so a new plan tier is never hidden.
+    public static func planLabel(_ planV3: String?) -> String {
+        // plan_v3 values from Zed source (cloud_api_types Plan enum):
+        // zed_free, zed_pro, zed_pro_trial, zed_business, zed_vip, zed_student.
+        switch planV3 {
+        case "zed_free":       return "Free"
+        case "zed_pro":        return "Pro"
+        case "zed_pro_trial":  return "Pro (trial)"
+        case "zed_business":   return "Business"
+        case "zed_vip":        return "VIP"
+        case "zed_student":    return "Student"
+        case .some(let other): return other
+        case .none:            return "Unknown"
+        }
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: ZedUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try ZedUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+            } catch {
+                self.lastError = "Could not parse Zed usage"
+            }
+        case .unauthorized:
+            // Zed's stored token was rejected — the user must re-sign-in to
+            // Zed itself; we cannot refresh it.
+            self.lastError = "Zed session expired — sign in again in Zed."
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        let creds: ZedCredentials
+        switch credentialReader() {
+        case .success(let c):
+            creds = c
+            hasKeychainAccess = true
+        case .failure:
+            // Keychain item missing or the prompt was denied. Leave the
+            // onboarding card up; not an error state.
+            hasKeychainAccess = false
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchUser(credentials: creds) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Zed's Keychain item belongs to Zed, not to us — never delete it.
+        // Clearing only drops our in-memory state and the access flag.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        hasKeychainAccess = false
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum ZedUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+public protocol ZedUsageTransport: Sendable {
+    func fetchUser(
+        credentials: ZedCredentials,
+        completion: @escaping @Sendable (ZedUsageResult) -> Void
+    )
+}
+
+/// Production transport. Note the space-delimited Authorization value.
+public struct URLSessionZedTransport: ZedUsageTransport {
+    private let usersMeURL = URL(string: "https://cloud.zed.dev/client/users/me")!
+
+    public init() {}
+
+    public func fetchUser(
+        credentials: ZedCredentials,
+        completion: @escaping @Sendable (ZedUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: usersMeURL)
+        request.httpMethod = "GET"
+        // Zed's client auth: "{user_id} {access_token}", NOT Bearer.
+        request.setValue(credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (ZedUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("Zed users/me API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401, 403:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/build.sh
+++ b/app/build.sh
@@ -51,6 +51,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     DeepSeekUsageStore.swift \
     ZedUsageFetcher.swift \
     ZedUsageStore.swift \
+    XAIUsageFetcher.swift \
+    XAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -69,6 +71,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     DeepSeekUsageStore.swift \
     ZedUsageFetcher.swift \
     ZedUsageStore.swift \
+    XAIUsageFetcher.swift \
+    XAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -47,6 +47,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     AnthropicUsageStore.swift \
     CodexUsageFetcher.swift \
     CodexUsageStore.swift \
+    DeepSeekUsageFetcher.swift \
+    DeepSeekUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -61,6 +63,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     AnthropicUsageStore.swift \
     CodexUsageFetcher.swift \
     CodexUsageStore.swift \
+    DeepSeekUsageFetcher.swift \
+    DeepSeekUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -34,15 +34,19 @@ if [ -f "ClaudeUsageBar.icns" ]; then
 fi
 
 # Compile the Swift app for arm64.
-# Log.swift and AnthropicUsageFetcher.swift are compiled alongside
-# ClaudeUsageBar.swift; see the header comments in those files for why
-# the SwiftPM library boundary is drawn where it is.
+# Log.swift, AnthropicUsageFetcher.swift, UsageProvider.swift, and the
+# Codex provider files are compiled alongside ClaudeUsageBar.swift; see the
+# header comments in those files for why the SwiftPM library boundary is
+# drawn where it is. AnthropicUsageStore stays app-only (needs UsageManager);
+# the Codex files are also in the SwiftPM library for unit testing.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
     UsageProvider.swift \
     AnthropicUsageStore.swift \
+    CodexUsageFetcher.swift \
+    CodexUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -55,6 +59,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     AnthropicUsageFetcher.swift \
     UsageProvider.swift \
     AnthropicUsageStore.swift \
+    CodexUsageFetcher.swift \
+    CodexUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -34,11 +34,13 @@ if [ -f "ClaudeUsageBar.icns" ]; then
 fi
 
 # Compile the Swift app for arm64.
-# Log.swift is compiled alongside ClaudeUsageBar.swift; see the header
-# comment in Log.swift for why the split exists.
+# Log.swift and AnthropicUsageFetcher.swift are compiled alongside
+# ClaudeUsageBar.swift; see the header comments in those files for why
+# the SwiftPM library boundary is drawn where it is.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
+    AnthropicUsageFetcher.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -48,6 +50,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
     Log.swift \
+    AnthropicUsageFetcher.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -49,6 +49,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     CodexUsageStore.swift \
     DeepSeekUsageFetcher.swift \
     DeepSeekUsageStore.swift \
+    ZedUsageFetcher.swift \
+    ZedUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -65,6 +67,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     CodexUsageStore.swift \
     DeepSeekUsageFetcher.swift \
     DeepSeekUsageStore.swift \
+    ZedUsageFetcher.swift \
+    ZedUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -33,9 +33,12 @@ if [ -f "ClaudeUsageBar.icns" ]; then
     /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile ClaudeUsageBar" "$APP_PATH/Contents/Info.plist"
 fi
 
-# Compile the Swift app for arm64
+# Compile the Swift app for arm64.
+# Log.swift is compiled alongside ClaudeUsageBar.swift; see the header
+# comment in Log.swift for why the split exists.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
+    Log.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -44,6 +47,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 # Compile for x86_64 (Intel)
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
+    Log.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -41,6 +41,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
+    UsageProvider.swift \
+    AnthropicUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -51,6 +53,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
+    UsageProvider.swift \
+    AnthropicUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/create_dmg.sh
+++ b/app/create_dmg.sh
@@ -70,13 +70,18 @@ echo "✅ DMG created: ${DMG_NAME}.dmg"
 DEVELOPER_ID="Developer ID Application: Linkko Technology Pte Ltd (Q467HQ5432)"
 NOTARY_PROFILE="claudeusagebar-notary"
 
-# Sign the DMG itself (the .app inside was already signed in build.sh)
+# Sign the DMG itself (the .app inside was already signed in build.sh).
+# Fail-fast on sign failure: an unsigned DMG will be rejected by notarytool
+# anyway, and the 5–15 min wait for that rejection is worse than aborting
+# here with a clear error. Matches the fail-fast policy in build.sh.
 echo ""
 echo "🔏 Signing DMG with Developer ID..."
 if codesign --force --sign "$DEVELOPER_ID" "${DMG_NAME}.dmg" 2>/dev/null; then
     echo "✅ DMG signed"
 else
-    echo "⚠️  DMG signing failed (continuing — Gatekeeper may reject)"
+    echo "❌ DMG signing failed — aborting before notarization." >&2
+    echo "   Fix the underlying cause (often: cert missing / expired, or stale xattrs on the DMG) and re-run." >&2
+    exit 1
 fi
 
 # Notarize


### PR DESCRIPTION
## What

Add the fifth provider — xAI Developer — and the first two-credential provider. **Tier 1** (a required inference key) bootstraps `team_id` and the model catalogue from `api.x.ai` and yields plan info. **Tier 2** (an optional management key) reads the prepaid balance and daily usage from `management-api.x.ai`. Both keys live in the Keychain. Backend only; `features.xai.enabled` defaults **false** and nothing registers the store yet (two-key sheet + tiles land in PR 6-UI).

Refs #54 (Zed UI, previous PR).

## Shapes verified against xAI docs

The plan flagged a pre-ship check on the balance unit/sign; research against xAI's REST + management OpenAPI docs resolved it (and corrected the plan's assumption):

- **Prepaid balance `total.val`** is a **string-encoded int64 in USD CENTS** — *not* the `1e-10` "tick" unit (that applies only to per-token model pricing) — and is **negative when credit remains**. So `remaining = -val/100`, clamped to ≥0. All of this unit/sign logic is isolated in one documented function (`XAIBalance.remainingUSD`) so a live-account curl check can correct it in one line.
- **`/v1/language-models`** wraps its array in `"models"` (the `"data"` wrapper belongs to the separate OpenAI-compatible `/v1/models`). Token prices are stored verbatim (USD cents per 1e8 tokens; conversion deferred to the UI).
- **`/v1/api-key`** is a flat snake_case object (`team_id`, `acls[]`, `redacted_api_key`, `api_key_id`, …).
- The management key also carries the `xai-` prefix (it is **not** literally `xai-mgmt-`); it is a distinct, non-interchangeable key from the console's Management Keys section.
- Both hosts authenticate with `Authorization: Bearer`.

## Diff summary

- **`app/XAIUsageFetcher.swift`** (new). Sendable value type. Pure parsers: `parseApiKey`, `parseLanguageModels`, `parseBalance`, `parseUsage`; the balance-interpretation function; two Keychain key constants.
- **`app/XAIUsageStore.swift`** (new). `UsageProvider` conformer. Two-key management, tiles, `XAIUsageTransport` seam + `URLSessionXAITransport` (chains the four endpoints), `apply(_:)`.
- **`Package.swift`** + **`app/build.sh`** — both new files.
- **`Tests/TestRunner/main.swift`** — 46 new checks.

Total diff: `+748 −1` across 5 files.

## Tiles

- `xai-plan` — ACLs / key label.
- `xai-balance` — Tier 2 only, from the negative-cents credit.
- `xai-daily-usd` — Tier 2 only, recent-spend rollup.
- Missing inference key renders a `needsAccess` card. The transport chains `api-key → language-models → (balance → usage)`, building the snapshot immutably across the async boundaries (Sendable-clean). Balance/usage 404s degrade gracefully (Tier 1 still shown). The management key is only ever sent to `management-api.x.ai`.

## Credential posture

- Both keys reach only their respective hosts' `Authorization` headers and the Keychain — never a log line or error string. Only HTTP status codes are logged. Passes the static-grep guard.
- **Adversarially reviewed by Codex CLI** (`gpt-5.5`): balance sign/unit, two-key isolation (management key never sent to `api.x.ai`), single-fire multi-endpoint transport (completion delivered exactly once on every path, always on main), credential non-leakage, and graceful 404 degradation — all verified.

## Non-breaking guarantee

- [x] `features.xai.enabled` defaults false → no tiles, no fetch, no Keychain access.
- [x] Nothing registers a store into the live registry yet.
- [x] Anthropic, Codex, DeepSeek, Zed, status, updates unchanged.
- [x] `@preconcurrency` on the conformance; Swift 5 language mode retained; the transport is Sendable-clean (no captured-var mutation).

## Test plan

- [x] `swift build` clean; `swift run TestRunner` — 281/281 checks pass (46 new).
- [x] Legacy `build.sh` compile clean (arm64 + x86_64), warning-free.
- [x] Static-grep credential-leak guard passes.

New checks: parse (api-key, language-models incl. `data[]` wrapper tolerance, balance negative/zero/positive/missing, daily buckets in dollar and cents forms, array-top-level throw); store (off-by-default, `needsAccess`, two-key presence, Tier-1-only vs Tier-2 tiles, 401 → invalid key, clear-both-keys) through an in-memory `CredentialStore` + stub transport.

## Not doing (out of scope)

- Two-key paste UX + the small daily-usage chart — PR 6-UI.
- Registering the store — PR 6-UI.
- Live RPM/TPM (xAI does not document `x-ratelimit-*` headers) — show configured ceilings from the catalogue instead, later.
- OpenAI Platform (PR 7).

## Open questions

None. The one item requiring a live-account confirmation (balance unit/sign) is resolved against the docs and isolated in a single function; the Tier-2 balance tile stays behind the management-key gate until the UI PR.
