### PR TITLE
feat: GitHub Copilot AI-Credit backend (feature-flagged off)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,33 @@ jobs:
             exit 1
           fi
 
+      - name: Reject any logging sink that interpolates a provider credential
+        run: |
+          # Defence-in-depth for every provider's spending credentials, not
+          # just the original Anthropic cookie. Any logging/printing sink
+          # (NSLog, print, debugPrint, dump, os_log, Logger) that interpolates
+          # a credential-bearing variable is forbidden. Credentials must only
+          # ever reach the Authorization header and the Keychain; only status
+          # codes go through Log.info(.count). New providers add new secret
+          # variable names — extend this alternation when you add one.
+          SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
+          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|bearer|accessKey|secret|[Cc]ookie)'
+          # Match a sink call that contains a Swift string-interpolation of a
+          # secret variable: SINK( ... \( ...secret... ) ... )
+          if grep -rnE "${SINKS}\([^)]*\\\\\\(.*${SECRETS}" -- app/ ; then
+            echo "::error::A logging sink interpolates a credential variable. Credentials must never be logged; only Log.info(.count(status)) is allowed." >&2
+            exit 1
+          fi
+
+      - name: Reject logging of full request URLs (may embed org/team/project ids)
+        run: |
+          # A full URL string can embed an org id, team id, or project id.
+          # Log an endpoint name + status code instead, never the URL.
+          if grep -rnE '(NSLog|print|Log\.(info|debug))\([^)]*\\\(urlString' -- app/ ; then
+            echo "::error::Logging a full request URL is forbidden (can embed identifiers). Log an endpoint label + status instead." >&2
+            exit 1
+          fi
+
       - name: Reject NSLog on cookie/response tokens
         run: |
           # Broader net: any NSLog that mentions cookie or response bodies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,12 @@ jobs:
           # codes go through Log.info(.count). New providers add new secret
           # variable names — extend this alternation when you add one.
           SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
-          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|bearer|accessKey|secret|[Cc]ookie)'
+          # `cookieValue`, `cookieHeader`, `perplexityCookie`, `pplxCookie`
+          # cover the Perplexity session-cookie variable names introduced in
+          # PR 8-BE. `[Cc]ookie` already catches most, but the more specific
+          # names guard against a rename that would still slip past the
+          # generic alternation.
+          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|cookieValue|cookieHeader|perplexityCookie|pplxCookie|bearer|accessKey|secret|[Cc]ookie)'
           # Match a sink call that contains a Swift string-interpolation of a
           # secret variable: SINK( ... \( ...secret... ) ... )
           if grep -rnE "${SINKS}\([^)]*\\\\\\(.*${SECRETS}" -- app/ ; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,21 @@ jobs:
             exit 1
           fi
 
+      - name: Reject logging sinks that interpolate a credential property path
+        run: |
+          # chk1 Risk #3: the identifier-name-based SECRETS alternation
+          # above matches `\(cookieValue)` but NOT `\(cookie.token)` — a
+          # tuple / struct property path. A future maintainer who logged
+          # `Log.info("...\(cookie.token)")` would silently bypass the
+          # guard. This step catches the property-path pattern for a set
+          # of names a maintainer might reasonably reach for.
+          SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
+          FIELDS='\.(token|cookie|session|secret|key|jwt|bearer)'
+          if grep -rnE "${SINKS}\([^)]*\\\\\\([^)]*${FIELDS}" -- app/ ; then
+            echo "::error::A logging sink interpolates a credential property path (e.g. cookie.token). Log a status code via Log.info(.count) instead." >&2
+            exit 1
+          fi
+
       - name: Reject logging of full request URLs (may embed org/team/project ids)
         run: |
           # A full URL string can embed an org id, team id, or project id.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,39 @@ jobs:
             exit 1
           fi
 
-  # build-and-test: enabled when PR 2a lands Package.swift.
-  # See EXPANSION_PLAN.md § Phase 0 for the sequencing.
+  build-and-test:
+    name: Build and test (macOS)
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          swift --version
+          xcodebuild -version || true
+
+      - name: swift build
+        run: swift build --configuration debug
+
+      - name: swift run TestRunner
+        # Assertion-based test runner (see Package.swift header for why
+        # we do not use XCTest / Testing here — CLT compatibility).
+        run: swift run TestRunner --configuration debug
+
+      - name: Legacy build.sh compile smoke (unsigned)
+        run: |
+          # Verify the swiftc-driven build.sh path still compiles cleanly.
+          # We patch out the hardcoded Developer ID for CI, but leave the
+          # local file on disk unchanged.
+          sed 's|Developer ID Application: Linkko Technology Pte Ltd (Q467HQ5432)|-|' \
+            app/build.sh > /tmp/build-ci.sh
+          chmod +x /tmp/build-ci.sh
+          cd app
+          # Skip the launch step at the end of build.sh — CI has no display.
+          sed -i.bak '/^open "\$APP_PATH"/d' /tmp/build-ci.sh
+          /tmp/build-ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,11 @@ jobs:
           # PR 8-BE. `[Cc]ookie` already catches most, but the more specific
           # names guard against a rename that would still slip past the
           # generic alternation.
-          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|cookieValue|cookieHeader|perplexityCookie|pplxCookie|bearer|accessKey|secret|[Cc]ookie)'
+          # `pat`, `patToken`, `authHeader` cover the GitHub Copilot
+          # variable names introduced in PR 9-BE (fine-grained PAT →
+          # Authorization: Bearer …). `safeToken` is the RequestSafety-
+          # sanitised local; still refuse to log it.
+          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|cookieValue|cookieHeader|perplexityCookie|pplxCookie|patToken|safeToken|authHeader|bearer|accessKey|secret|[Cc]ookie)'
           # Match a sink call that contains a Swift string-interpolation of a
           # secret variable: SINK( ... \( ...secret... ) ... )
           if grep -rnE "${SINKS}\([^)]*\\\\\\(.*${SECRETS}" -- app/ ; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,23 @@ jobs:
 
       - name: Reject logging sinks that interpolate a credential property path
         run: |
-          # chk1 Risk #3: the identifier-name-based SECRETS alternation
-          # above matches `\(cookieValue)` but NOT `\(cookie.token)` — a
-          # tuple / struct property path. A future maintainer who logged
+          # chk1 Risk #3 + chk1-fix Codex round-4 finding #2: the
+          # identifier-name-based SECRETS alternation above matches
+          # `\(cookieValue)` but NOT `\(cookie.token)` — a tuple / struct
+          # property path. A future maintainer who logged
           # `Log.info("...\(cookie.token)")` would silently bypass the
-          # guard. This step catches the property-path pattern for a set
-          # of names a maintainer might reasonably reach for.
+          # guard. This step catches the pattern only when the OWNER of
+          # the property path is itself credential-flavoured (cookie,
+          # session, auth, credential, secret, token), so legitimate
+          # non-secret uses like `event.key` (keyboard events) and
+          # `parser.token` (parser results) do NOT false-positive.
           SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
-          FIELDS='\.(token|cookie|session|secret|key|jwt|bearer)'
-          if grep -rnE "${SINKS}\([^)]*\\\\\\([^)]*${FIELDS}" -- app/ ; then
-            echo "::error::A logging sink interpolates a credential property path (e.g. cookie.token). Log a status code via Log.info(.count) instead." >&2
+          # Owner must smell like a credential-holder before we care
+          # about the property path.
+          OWNER='(cookie|session|auth|credential|secret|creds|apiKey|adminKey|inferenceKey|managementKey|bearer|jwt|token)'
+          PROP='\.(token|value|raw|secret|key|jwt|bearer|cookie)'
+          if grep -rnE "${SINKS}\([^)]*\\\\\\([^)]*${OWNER}${PROP}" -- app/ ; then
+            echo "::error::A logging sink interpolates a credential property path (e.g. cookie.token, session.value). Log a status code via Log.info(.count) instead." >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+# .github/workflows/ci.yml
+#
+# Runs on every pull_request and every push to main.
+# No secrets, no write scopes, no pull_request_target — pwn-request-safe
+# per docs.github.com/en/actions/security-for-github-actions/security-guides.
+#
+# Two jobs:
+#   1. static-grep — cheap static checks that catch known regression patterns.
+#      This is where the PR-1 "belt-and-braces" credential-leak defence lives:
+#      any PR that reintroduces the deleted "📦 Response:" pattern or raw-
+#      interpolation NSLog calls with sessionCookie / orgId / responseString
+#      fails CI before human review.
+#   2. build-and-test — (placeholder) once PR 2a lands Package.swift, this
+#      job will run `swift build` + `swift test`. Kept as a no-op comment
+#      here so PR 1's diff does not silently add a runner cost. PR 2a wires
+#      the real build/test steps in.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-grep:
+    name: Static credential-leak guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Reject reintroduced "📦 Response:" pattern
+        run: |
+          if grep -rn '📦 Response' -- app/ ; then
+            echo "::error::Forbidden pattern '📦 Response' found. Deleted in PR 1 to prevent full-response-body logging; do not reintroduce." >&2
+            exit 1
+          fi
+
+      - name: Reject raw NSLog interpolation of credentials
+        run: |
+          # NSLog calls that interpolate sessionCookie, orgId, responseString,
+          # or sessionCookieInput are forbidden. Use Log.info(.count) /
+          # Log.info(.identifier) / Log.info(.sensitive) instead.
+          if grep -rnE 'NSLog\([^)]*\\\(.*(sessionCookie|orgId|responseString|sessionCookieInput)' -- app/ ; then
+            echo "::error::Raw NSLog interpolation of credentials found. Use Log.info(.count/.identifier/.sensitive) instead." >&2
+            exit 1
+          fi
+
+      - name: Reject NSLog on cookie/response tokens
+        run: |
+          # Broader net: any NSLog that mentions cookie or response bodies.
+          # If a diagnostic genuinely needs it, use Log.debug (DEBUG-only).
+          if grep -rnE 'NSLog\([^)]*(cookie|Cookie|Response body|responseString)' -- app/ ; then
+            echo "::error::NSLog referencing cookie/response found. Move to Log.debug (DEBUG-only) or delete." >&2
+            exit 1
+          fi
+
+  # build-and-test: enabled when PR 2a lands Package.swift.
+  # See EXPANSION_PLAN.md § Phase 0 for the sequencing.

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ internal-docs/
 EXPANSION_PLAN.md
 docs/tracking-issue-draft.md
 .pr-bodies/
+
+# SwiftPM build artefacts
+.build/
+Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,10 @@ docs/tracking-issue-draft.md
 # SwiftPM build artefacts
 .build/
 Package.resolved
+
+# Local credentials and probe transcripts — NEVER pushed to any remote
+secrets/
+.env
+.env.*
+probes/
+*.probe.json

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ temp/
 # Internal docs (kept local, not on public GitHub)
 NOTIFICATIONS.md
 internal-docs/
+
+# Contributor-side planning artefacts — never pushed to any remote
+EXPANSION_PLAN.md
+docs/tracking-issue-draft.md
+.pr-bodies/

--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,10 @@ let package = Package(
                 "ZedUsageStore.swift",
                 // xAI Developer: two-key, two-host; same rationale.
                 "XAIUsageFetcher.swift",
-                "XAIUsageStore.swift"
+                "XAIUsageStore.swift",
+                // OpenAI Platform: admin key, three org endpoints.
+                "OpenAIUsageFetcher.swift",
+                "OpenAIUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,16 @@ let package = Package(
                 "LICENSE",
                 "README.md"
             ],
-            sources: ["Log.swift", "AnthropicUsageFetcher.swift"]
+            sources: [
+                "Log.swift",
+                "AnthropicUsageFetcher.swift",
+                "UsageProvider.swift"
+                // AnthropicUsageStore.swift depends on UsageManager
+                // (defined in ClaudeUsageBar.swift), so it stays in the
+                // app-bundle compile only, not in the SwiftPM library
+                // target. Tests for AnthropicUsageStore live in the
+                // full-app integration tier, not this unit-test layer.
+            ]
         ),
         .executableTarget(
             name: "TestRunner",

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,10 @@ let package = Package(
                 "DeepSeekUsageStore.swift",
                 // Zed: reads Zed's own Keychain item; same rationale.
                 "ZedUsageFetcher.swift",
-                "ZedUsageStore.swift"
+                "ZedUsageStore.swift",
+                // xAI Developer: two-key, two-host; same rationale.
+                "XAIUsageFetcher.swift",
+                "XAIUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,11 @@ let package = Package(
                 "OpenAIUsageStore.swift",
                 // Perplexity: cookie in Keychain, three cookie-authed endpoints.
                 "PerplexityUsageFetcher.swift",
-                "PerplexityUsageStore.swift"
+                "PerplexityUsageStore.swift",
+                // GitHub Copilot: fine-grained PAT in Keychain, /user +
+                // /users/{login}/settings/billing/ai_credit/usage.
+                "CopilotUsageFetcher.swift",
+                "CopilotUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -51,12 +51,24 @@ let package = Package(
                 "ClaudeUsageBar.icns",
                 "claudeusagebar-icon.png",
                 "LICENSE",
-                "README.md"
+                "README.md",
+                // AnthropicUsageStore depends on UsageManager (defined in the
+                // excluded @main entry point) so it is compiled only by
+                // build.sh into the .app bundle, not by the SwiftPM library.
+                // Listed here explicitly to silence the "unhandled file"
+                // warning now that `sources` is an allow-list.
+                "AnthropicUsageStore.swift"
             ],
             sources: [
                 "Log.swift",
                 "AnthropicUsageFetcher.swift",
-                "UsageProvider.swift"
+                "UsageProvider.swift",
+                "CodexUsageFetcher.swift",
+                // CodexUsageStore has no dependency on UsageManager (unlike
+                // AnthropicUsageStore), so it lives in the library where the
+                // TestRunner can exercise its tile-generation and 401 →
+                // session-expired mapping through a stubbed transport.
+                "CodexUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
                 "LICENSE",
                 "README.md"
             ],
-            sources: ["Log.swift"]
+            sources: ["Log.swift", "AnthropicUsageFetcher.swift"]
         ),
         .executableTarget(
             name: "TestRunner",

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,10 @@ let package = Package(
                 "XAIUsageStore.swift",
                 // OpenAI Platform: admin key, three org endpoints.
                 "OpenAIUsageFetcher.swift",
-                "OpenAIUsageStore.swift"
+                "OpenAIUsageStore.swift",
+                // Perplexity: cookie in Keychain, three cookie-authed endpoints.
+                "PerplexityUsageFetcher.swift",
+                "PerplexityUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,64 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest — additive scaffolding for testing, not a replacement for
+// the existing build path.
+//
+// `swift build` compiles the library against the source under `app/`.
+// `swift run TestRunner` executes the assertion-based test runner (works
+// with Command Line Tools alone; does not require Xcode.app / XCTest).
+// The legacy `app/build.sh` continues to work unchanged — it invokes
+// `swiftc` directly and produces the `.app` bundle. Both paths compile
+// the same file.
+//
+// Why not XCTest / swift-testing?
+// Both XCTest and Apple's newer `Testing` framework require `xctest`
+// tooling that ships with Xcode.app, not with the Command Line Tools
+// package. To keep the test path usable on any Mac with CLT installed,
+// PR 2a ships a plain executable test runner. PR 16 (Swift 6 migration)
+// or a maintainer decision to install Xcode.app can promote this to
+// XCTest later without changing the test bodies (they're just
+// assertion functions).
+//
+// PR 2a intentionally introduces only the scaffold plus one first test
+// suite (LogValueTests). PR 2b lands the AnthropicUsageFetcher extraction
+// and its fixture-based tests using the same runner.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClaudeUsageBar",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .library(name: "ClaudeUsageBar", targets: ["ClaudeUsageBar"]),
+        .executable(name: "TestRunner", targets: ["TestRunner"])
+    ],
+    targets: [
+        .target(
+            name: "ClaudeUsageBar",
+            path: "app",
+            exclude: [
+                // The @main app entry point (compiled by build.sh into the
+                // .app bundle, but not part of the SwiftPM library which is
+                // only for testable extracted types).
+                "ClaudeUsageBar.swift",
+                // Assets, build scripts, and docs — not compiled sources.
+                "build.sh",
+                "create_dmg.sh",
+                "make_app_icon.sh",
+                "Info.plist",
+                "ClaudeUsageBar.icns",
+                "claudeusagebar-icon.png",
+                "LICENSE",
+                "README.md"
+            ],
+            sources: ["Log.swift"]
+        ),
+        .executableTarget(
+            name: "TestRunner",
+            dependencies: ["ClaudeUsageBar"],
+            path: "Tests/TestRunner"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,11 @@ let package = Package(
                 // AnthropicUsageStore), so it lives in the library where the
                 // TestRunner can exercise its tile-generation and 401 →
                 // session-expired mapping through a stubbed transport.
-                "CodexUsageStore.swift"
+                "CodexUsageStore.swift",
+                // DeepSeek: fetcher + KeychainStore + store. Same rationale —
+                // no UsageManager dependency, so it is unit-testable here.
+                "DeepSeekUsageFetcher.swift",
+                "DeepSeekUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,10 @@ let package = Package(
                 // DeepSeek: fetcher + KeychainStore + store. Same rationale —
                 // no UsageManager dependency, so it is unit-testable here.
                 "DeepSeekUsageFetcher.swift",
-                "DeepSeekUsageStore.swift"
+                "DeepSeekUsageStore.swift",
+                // Zed: reads Zed's own Keychain item; same rationale.
+                "ZedUsageFetcher.swift",
+                "ZedUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1114,6 +1114,195 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - XAIUsageFetcher (PR 6-BE)
+
+// GET /v1/api-key — flat snake_case object (verified against xAI docs).
+let fixtureXaiApiKey = #"""
+{
+  "redacted_api_key": "xai-****b14o",
+  "user_id": "user-123",
+  "name": "prod key",
+  "create_time": "2026-01-01T00:00:00Z",
+  "modify_time": "2026-01-02T00:00:00Z",
+  "team_id": "team-abc",
+  "api_key_id": "key-xyz",
+  "acls": ["api-key:model:*", "api-key:endpoint:*"]
+}
+"""#
+
+run("parse xAI api-key: team_id, acls, redacted key") {
+    let info = try! XAIUsageFetcher.parseApiKey(fixtureXaiApiKey.data(using: .utf8)!)
+    expectEqual(info.teamId, "team-abc")
+    expectEqual(info.acls.count, 2)
+    expectEqual(info.redactedKey, "xai-****b14o")
+    expectEqual(info.name, "prod key")
+}
+
+// GET /v1/language-models — models[] with token prices.
+let fixtureXaiModels = #"""
+{
+  "models": [
+    {"id": "grok-4.5", "prompt_text_token_price": 3000, "completion_text_token_price": 15000},
+    {"id": "grok-4.20", "prompt_text_token_price": 5000, "completion_text_token_price": 25000}
+  ]
+}
+"""#
+
+run("parse xAI language-models catalogue") {
+    let models = try! XAIUsageFetcher.parseLanguageModels(fixtureXaiModels.data(using: .utf8)!)
+    expectEqual(models.count, 2)
+    expectEqual(models[0].id, "grok-4.5")
+    expectEqual(models[0].promptTokenPrice, 3000)
+    expectEqual(models[1].completionTokenPrice, 25000)
+}
+
+run("parse xAI language-models tolerates data[] wrapper") {
+    let bytes = #"{"data": [{"id": "grok-4.5"}]}"#.data(using: .utf8)!
+    let models = try! XAIUsageFetcher.parseLanguageModels(bytes)
+    expectEqual(models.count, 1)
+    expectEqual(models[0].id, "grok-4.5")
+}
+
+// Prepaid balance — total.val is a STRING-encoded int64 in USD CENTS, and is
+// NEGATIVE when credit remains. Verified against xAI's OpenAPI schema.
+let fixtureXaiBalanceCredit = #"""
+{
+  "changes": [],
+  "total": { "val": "-12345" }
+}
+"""#
+
+run("parse xAI balance: negative cents = remaining credit") {
+    let balance = try! XAIUsageFetcher.parseBalance(fixtureXaiBalanceCredit.data(using: .utf8)!)
+    expectEqual(balance.totalValRaw, -12345)
+    // -12345 cents credit => 123.45 USD remaining.
+    expect(abs(balance.remainingUSD - 123.45) < 0.001)
+}
+
+run("parse xAI balance: zero or positive val = depleted (clamped to 0)") {
+    let zero = try! XAIUsageFetcher.parseBalance(#"{"total": {"val": "0"}}"#.data(using: .utf8)!)
+    expectEqual(zero.remainingUSD, 0.0)
+    let positive = try! XAIUsageFetcher.parseBalance(#"{"total": {"val": "500"}}"#.data(using: .utf8)!)
+    expectEqual(positive.remainingUSD, 0.0)   // no remaining prepaid credit
+}
+
+run("parse xAI balance throws when total.val missing") {
+    do {
+        _ = try XAIUsageFetcher.parseBalance(#"{"total": {}}"#.data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("parse xAI usage daily buckets (dollar and cents forms)") {
+    let bytes = #"""
+    {"usage": [
+      {"date": "2026-07-10", "usd": 1.50},
+      {"date": "2026-07-11", "usd_cents": 275}
+    ]}
+    """#.data(using: .utf8)!
+    let daily = try! XAIUsageFetcher.parseUsage(bytes)
+    expectEqual(daily.count, 2)
+    expect(abs(daily[0].usdSpent - 1.50) < 0.001)
+    expect(abs(daily[1].usdSpent - 2.75) < 0.001)  // 275 cents
+}
+
+run("parse xAI api-key throws on array top-level") {
+    do {
+        _ = try XAIUsageFetcher.parseApiKey("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - XAIUsageStore (in-memory credentials + stubbed transport)
+
+final class StubXAITransport: XAIUsageTransport, @unchecked Sendable {
+    let result: XAIUsageResult
+    init(_ result: XAIUsageResult) { self.result = result }
+    func fetchAll(inferenceKey: String, managementKey: String?, completion: @escaping @Sendable (XAIUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "xai-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.xai.enabled")
+
+    run("xAI store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("xAI enabled without inference key emits needsAccess card") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("xAI two-key management: hasInferenceKey and hasManagementKey") {
+        let creds = InMemoryCredentialStore()
+        let store = XAIUsageStore(credentials: creds, transport: StubXAITransport(.networkError), defaults: defaults)
+        expectEqual(store.hasInferenceKey, false)
+        expectEqual(store.hasManagementKey, false)
+        store.saveInferenceKey("xai-inference")
+        store.saveManagementKey("xai-mgmt-secret")
+        expectEqual(store.hasInferenceKey, true)
+        expectEqual(store.hasManagementKey, true)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("xAI Tier 1 only: plan tile, no balance tile") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-inference")
+        var snap = XAIUsageSnapshot()
+        snap.apiKeyInfo = XAIApiKeyInfo(teamId: "team-abc", acls: ["api-key:model:*"], redactedKey: "xai-****b14o")
+        store.apply(.success(snap))
+        let tiles = store.tiles
+        expect(tiles.contains { $0.id == "xai-plan" })
+        expect(!tiles.contains { $0.id == "xai-balance" })
+    }
+
+    run("xAI Tier 2: balance tile from negative-cents credit") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-inference")
+        var snap = XAIUsageSnapshot()
+        snap.apiKeyInfo = XAIApiKeyInfo(teamId: "team-abc")
+        snap.balance = XAIBalance(totalValRaw: -12345, currency: "USD")
+        store.apply(.success(snap))
+        let balanceTile = store.tiles.first { $0.id == "xai-balance" }
+        expect(balanceTile != nil)
+        if case let .balance(minor, currency, _, _) = balanceTile?.kind {
+            expectEqual(minor, 12345)   // 123.45 USD => 12345 minor units
+            expectEqual(currency, "USD")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("xAI 401 maps to invalid-key error") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.unauthorized), defaults: defaults)
+        store.saveInferenceKey("xai-bad")
+        store.fetch()
+        expectEqual(store.errorMessage, "Invalid xAI API key")
+    }
+
+    run("xAI clear deletes both keys") {
+        let creds = InMemoryCredentialStore()
+        let store = XAIUsageStore(credentials: creds, transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-i"); store.saveManagementKey("xai-mgmt-m")
+        store.clear()
+        expectEqual(store.hasInferenceKey, false)
+        expectEqual(store.hasManagementKey, false)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -690,6 +690,56 @@ run("ProviderCopy: OpenAI help + admin-key disclosure") {
     expect(disc?.contains("cannot make inference") == true)
 }
 
+run("ProviderCopy: Perplexity help names the cookie, Keychain, and multiple paste forms (PR 8-UI)") {
+    // The user needs to know exactly which cookie to copy from DevTools;
+    // the guidance MUST name it verbatim so a search inside the browser's
+    // cookie inspector finds it. It also must mention the paste flexibility
+    // (bare value, name=value, or full Cookie header) or valid pastes will
+    // look wrong to the user.
+    let help = ProviderCopy.help(for: "perplexity")
+    expect(help != nil)
+    expect(help?.contains("__Secure-next-auth.session-token") == true)
+    expect(help?.contains("perplexity.ai") == true)
+    expect(help?.contains("Keychain") == true)
+    // At least one of the four Perplexity modes is named so the user knows
+    // what they'll see once configured.
+    expect(help?.contains("Pro Search") == true || help?.contains("Deep Research") == true)
+    // Codex adversarial review #5: copy softened from "Shows" to "Can show"
+    // so we do not over-promise tiles that may be Cloudflare-challenged.
+    expect(help?.contains("Can show") == true || help?.contains("When available") == true)
+    // Codex adversarial review #4: paste flexibility must be documented.
+    expect(help?.contains("name=value") == true || help?.contains("Cookie header") == true || help?.contains("bare") == true)
+}
+
+run("ProviderCopy: Perplexity disclosure warns about undocumented API and cookie power") {
+    // The Perplexity cookie is a spending credential AND the endpoints are
+    // undocumented — both facts must be surfaced before the user pastes.
+    // Codex adversarial review #1: the disclosure must not under-state the
+    // cookie's authority ("Sonar credits" alone is too narrow — it is a
+    // full web session cookie). #2: the revocation promise must be
+    // conditional, not absolute.
+    let disc = ProviderCopy.disclosure(for: "perplexity")
+    expect(disc != nil)
+    expect(disc?.contains("private") == true || disc?.contains("undocumented") == true || disc?.contains("may stop") == true)
+    // Framed as a full session cookie, not just a Sonar-credit token.
+    expect(disc?.contains("session cookie") == true || disc?.contains("act as your signed-in account") == true)
+    // Revocation described conditionally, not absolutely.
+    expect(disc?.contains("until it expires") == true || disc?.contains("revoked") == true)
+}
+
+run("PasteKeyProvider.secretKindNoun defaults to Key and Perplexity overrides to Cookie") {
+    // Codex adversarial review #3: the generic Settings row would have
+    // said "Key saved in Keychain" even for Perplexity's cookie paste.
+    // The optional secretKindNoun on PasteKeyProvider lets a provider
+    // rename that noun without any downstream code change.
+    MainActor.assumeIsolated {
+        let deepseek = DeepSeekUsageStore(credentials: InMemoryCredentialStore())
+        let perplexity = PerplexityUsageStore(credentials: InMemoryCredentialStore())
+        expectEqual((deepseek as PasteKeyProvider).secretKindNoun, "Key")
+        expectEqual((perplexity as PasteKeyProvider).secretKindNoun, "Cookie")
+    }
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
@@ -1787,6 +1837,33 @@ run("Perplexity cookie: paste with `;` but no supported session cookie → nil (
     // whole blob as a token.
     let raw = "_ga=1; theme=dark"
     expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+run("Perplexity cookie: strips a leading Cookie: header prefix (PR 8-UI Codex round 2)") {
+    // Browsers' "Copy request headers" often prefixes the line with "Cookie:".
+    // The extractor must tolerate that so pasted HAR fragments still work
+    // — matching what the Perplexity ProviderCopy help text now promises.
+    let raw = "Cookie: __Secure-next-auth.session-token=HEADERTOK; _ga=1"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "HEADERTOK")
+}
+
+run("Perplexity cookie: strips a case-varied cookie: prefix and extra whitespace") {
+    let raw = "  cookie:   __Secure-next-auth.session-token=WSTOK  "
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "WSTOK")
+}
+
+run("Perplexity cookie: strips a MiXeD-case Cookie: prefix (PR 8-UI Codex round 3)") {
+    // Codex round-3 caught that enumerating spellings ("Cookie:"/"cookie:"/"COOKIE:")
+    // let a MiXeD casing slip through the strip logic and fall into the
+    // bare-token fallback. The strip is now truly case-insensitive.
+    let raw = "CoOkIe: __Secure-next-auth.session-token=MIXTOK"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "MIXTOK")
 }
 
 // MARK: - PerplexityUsageFetcher.parseCredits

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2152,6 +2152,49 @@ MainActor.assumeIsolated {
         }
     }
 
+    run("Perplexity plan tile omitted when only subscription_source is present (chk1 Bug #3)") {
+        // subscription_source is the BILLING PROVIDER, not a plan name.
+        // Rendering "Stripe (active)" as the Perplexity plan tile misleads
+        // the user about their account state. The fix omits the tile
+        // entirely when subscription_tier is absent.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.settings = PerplexityUserSettings(
+            subscriptionStatus: "active",
+            subscriptionSource: "stripe",
+            subscriptionTier: nil    // no tier reported
+        )
+        store.apply(.success(snap))
+        expect(!store.tiles.contains { $0.id == "perplexity-plan" })
+    }
+
+    run("Perplexity plan tile omitted when subscription_tier is 'none' or empty") {
+        // Additional coverage: "none" and "" should not slip through and
+        // render as unknown-tier plan labels either.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        for badTier in ["none", "  none  ", "", "   "] {
+            var snap = PerplexityUsageSnapshot()
+            snap.settings = PerplexityUserSettings(subscriptionTier: badTier)
+            store.apply(.success(snap))
+            expect(!store.tiles.contains { $0.id == "perplexity-plan" }, "expected no plan tile for '\(badTier)'")
+        }
+    }
+
+    run("Perplexity fetch() on a locked keychain surfaces an unlock message (chk1 Bug #2)") {
+        // UnavailableCredentialStore reports `.unavailable` for readResult,
+        // so hasKey is true (round-2 fix) but a bare read() returns nil.
+        // Before the chk1 Bug #2 fix, fetch() collapsed .unavailable into
+        // .missing and cleared lastError silently. Now it distinguishes.
+        let store = PerplexityUsageStore(credentials: UnavailableCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, true)
+        store.fetch()
+        expect(store.errorMessage?.contains("Keychain") == true || store.errorMessage?.contains("Unlock") == true)
+        // Snapshot cleared, not stale-preserved.
+        expect(store.snapshot == nil)
+    }
+
     run("Perplexity credits tile carries USD cents + Max plan hint from large recurring grant") {
         let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
         store.saveKey("cookie")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1,0 +1,112 @@
+// PR 2a — assertion-based test runner.
+//
+// Runs with `swift run TestRunner` from the repo root. Works with
+// Command Line Tools alone; does not require Xcode.app / XCTest.
+// Prints one line per test and exits nonzero if any assertion fails.
+//
+// When Xcode.app is installed, this runner can be promoted to XCTest
+// or Apple's Testing framework without changing the assertion bodies.
+
+import Foundation
+import ClaudeUsageBar
+
+// MARK: - Minimal assertion API
+
+var failed = 0
+var total = 0
+
+func expect(_ condition: @autoclosure () -> Bool,
+            _ message: String = "",
+            file: StaticString = #file, line: UInt = #line) {
+    total += 1
+    if !condition() {
+        failed += 1
+        let where_ = "\(file):\(line)"
+        if message.isEmpty {
+            print("  FAIL  \(where_)")
+        } else {
+            print("  FAIL  \(where_) — \(message)")
+        }
+    }
+}
+
+func expectEqual<T: Equatable>(_ actual: T, _ expected: T,
+                                file: StaticString = #file, line: UInt = #line) {
+    expect(actual == expected,
+           "expected \(expected), got \(actual)",
+           file: file, line: line)
+}
+
+func run(_ name: String, _ body: () -> Void) {
+    let before = failed
+    body()
+    let outcome = failed == before ? "PASS" : "FAIL"
+    print("\(outcome)  \(name)")
+}
+
+// MARK: - LogValue tests
+
+run("LogValue.public emits verbatim") {
+    expectEqual(LogValue.public("HTTP 200").rendered, "HTTP 200")
+    expectEqual(LogValue.public("").rendered, "")
+    expectEqual(LogValue.public("emoji ✅ ok").rendered, "emoji ✅ ok")
+}
+
+run("LogValue.sensitive redacts to length only") {
+    expectEqual(LogValue.sensitive("abc").rendered, "<redacted: 3 chars>")
+    expectEqual(LogValue.sensitive("").rendered, "<redacted: 0 chars>")
+    expectEqual(LogValue.sensitive("sk-1234567890abcdef").rendered,
+                "<redacted: 19 chars>")
+}
+
+run("LogValue.sensitive never emits the raw value") {
+    let secret = "super-secret-cookie-value-that-must-not-leak"
+    let rendered = LogValue.sensitive(secret).rendered
+    expect(!rendered.contains(secret))
+    expect(!rendered.contains("super"))
+    expect(!rendered.contains("secret"))
+    expect(!rendered.contains("cookie"))
+}
+
+run("LogValue.identifier emits short SHA-256 prefix") {
+    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    expectEqual(LogValue.identifier("hello").rendered, "<id: 2cf24dba>")
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expectEqual(LogValue.identifier("").rendered, "<id: e3b0c442>")
+}
+
+run("LogValue.identifier is deterministic") {
+    let orgId = "8f2c3d1a-e5b9-4a01-9d3c-7e1f5b2c3d4a"
+    expectEqual(LogValue.identifier(orgId).rendered,
+                LogValue.identifier(orgId).rendered)
+}
+
+run("LogValue.identifier is not reversible to raw value") {
+    let orgId = "8f2c3d1a-e5b9-4a01-9d3c-7e1f5b2c3d4a"
+    let rendered = LogValue.identifier(orgId).rendered
+    expect(!rendered.contains(orgId))
+    expect(!rendered.contains("8f2c"))
+    expect(!rendered.contains("e5b9"))
+}
+
+run("LogValue.identifier distinguishes different inputs") {
+    let a = LogValue.identifier("org-a").rendered
+    let b = LogValue.identifier("org-b").rendered
+    expect(a != b)
+}
+
+run("LogValue.count emits numeric literal") {
+    expectEqual(LogValue.count(0).rendered, "0")
+    expectEqual(LogValue.count(42).rendered, "42")
+    expectEqual(LogValue.count(-1).rendered, "-1")
+    expectEqual(LogValue.count(823).rendered, "823")
+}
+
+// MARK: - Summary
+
+print("")
+print("\(total - failed)/\(total) checks passed")
+if failed > 0 {
+    print("\(failed) FAILED")
+    exit(1)
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -904,6 +904,207 @@ run("KeychainStore round-trips when a keychain is available") {
     }
 }
 
+// MARK: - ZedUsageFetcher.parse (PR 5-BE)
+
+// Fixture: zed_free. limit is Zed's UsageLimit enum: Limited(N) is the OBJECT
+// {"limited": N} on the wire (verified against Zed's cloud_api_types source),
+// NOT a bare integer. ended_at is an RFC3339 string.
+let fixtureZedFree = #"""
+{
+  "plan": {
+    "plan_v3": "zed_free",
+    "usage": { "edit_predictions": { "used": 320, "limit": {"limited": 2000} } },
+    "subscription_period": { "started_at": "2026-07-01T00:00:00.000Z", "ended_at": "2026-08-01T00:00:00.000Z" },
+    "has_overdue_invoices": false,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed free plan: limit as {\"limited\": N} object") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedFree.data(using: .utf8)!)
+    expectEqual(snap.planV3, "zed_free")
+    expectEqual(snap.editPredictions?.used, 320)
+    expectEqual(snap.editPredictions?.limit, 2000)
+    expect(snap.periodEndsAt != nil)
+    expectEqual(snap.hasOverdueInvoices, false)
+    expectEqual(snap.isAccountTooYoung, false)
+}
+
+// Fixture: zed_pro — Unlimited serializes as the bare STRING "unlimited".
+let fixtureZedPro = #"""
+{
+  "plan": {
+    "plan_v3": "zed_pro",
+    "usage": { "edit_predictions": { "used": 5123, "limit": "unlimited" } },
+    "subscription_period": { "ended_at": "2026-08-15T00:00:00.000Z" },
+    "has_overdue_invoices": false,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed pro plan: limit \"unlimited\" string -> nil") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedPro.data(using: .utf8)!)
+    expectEqual(snap.planV3, "zed_pro")
+    expectEqual(snap.editPredictions?.used, 5123)
+    expect(snap.editPredictions?.limit == nil)   // unlimited
+}
+
+// UsageLimit parsing in isolation — the non-obvious wire encoding.
+run("parseUsageLimit maps object, unlimited string, and defensively bare int") {
+    expectEqual(ZedUsageFetcher.parseUsageLimit(["limited": 500]), 500)
+    expect(ZedUsageFetcher.parseUsageLimit("unlimited") == nil)
+    expect(ZedUsageFetcher.parseUsageLimit(nil) == nil)
+    expectEqual(ZedUsageFetcher.parseUsageLimit(42), 42)          // defensive
+    expectEqual(ZedUsageFetcher.parseUsageLimit("50"), 50)        // header-style
+}
+
+// Fixture: overdue invoices flag true.
+let fixtureZedOverdue = #"""
+{
+  "plan": {
+    "plan_v3": "zed_pro",
+    "usage": { "edit_predictions": { "used": 10, "limit": "unlimited" } },
+    "has_overdue_invoices": true,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed plan with overdue invoices") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedOverdue.data(using: .utf8)!)
+    expectEqual(snap.hasOverdueInvoices, true)
+}
+
+run("parse Zed tolerates plan block at top level (no wrapper)") {
+    // Some versions may return the plan block directly.
+    let bytes = #"""
+    {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 1, "limit": 2000}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.planV3, "zed_free")
+    expectEqual(snap.editPredictions?.used, 1)
+}
+
+run("parse Zed tolerates empty object") {
+    let snap = try! ZedUsageFetcher.parse("{}".data(using: .utf8)!)
+    expect(snap.planV3 == nil)
+    expect(snap.editPredictions == nil)
+    expectEqual(snap.hasOverdueInvoices, false)
+}
+
+run("parse Zed accepts numeric used as Double, limited object as Double") {
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 12.0, "limit": {"limited": 2000.0}}}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.editPredictions?.used, 12)
+    expectEqual(snap.editPredictions?.limit, 2000)
+}
+
+run("parse Zed accepts unix-epoch ended_at") {
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "subscription_period": {"ended_at": 1785000000}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.periodEndsAt, Date(timeIntervalSince1970: 1785000000))
+}
+
+run("parse Zed throws on array top-level") {
+    do {
+        _ = try ZedUsageFetcher.parse("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// Credentials header format: space-delimited, not Bearer.
+run("ZedCredentials builds a space-delimited Authorization value") {
+    let creds = ZedCredentials(userId: "12345", accessToken: "tok-abc")
+    expectEqual(creds.authorizationHeaderValue, "12345 tok-abc")
+    // Explicitly NOT the Bearer scheme.
+    expect(!creds.authorizationHeaderValue.hasPrefix("Bearer"))
+}
+
+// MARK: - ZedUsageStore (injected credential reader, no real Keychain)
+
+MainActor.assumeIsolated {
+    let suiteName = "zed-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.zed.enabled")
+
+    let goodCreds: @Sendable () -> Result<ZedCredentials, Error> = {
+        .success(ZedCredentials(userId: "u1", accessToken: "tok"))
+    }
+    let missingCreds: @Sendable () -> Result<ZedCredentials, Error> = {
+        .failure(ZedAuthError.keychainItemMissing)
+    }
+
+    run("Zed store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = ZedUsageStore(defaults: d2, credentialReader: goodCreds)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Zed enabled before first read emits needsAccess card") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: missingCreds)
+        expectEqual(store.isEnabled, true)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Zed applies free-plan snapshot: plan + counter tiles") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        // Simulate a successful Keychain read + fetch by applying a result.
+        store.apply(.success(fixtureZedFree.data(using: .utf8)!))
+        let tiles = store.tiles
+        // plan tile + edit-predictions counter (no billing warning)
+        expectEqual(tiles.count, 2)
+        expectEqual(tiles[0].id, "zed-plan")
+        if case let .text(status, _) = tiles[0].kind { expectEqual(status, "Free") }
+        else { expect(false, "expected plan text tile") }
+        expectEqual(tiles[1].id, "zed-edit-predictions")
+        if case let .counter(used, limit, _) = tiles[1].kind {
+            expectEqual(used, 320); expectEqual(limit, 2000)
+        } else { expect(false, "expected counter tile") }
+    }
+
+    run("Zed pro plan renders unlimited counter (nil limit)") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.success(fixtureZedPro.data(using: .utf8)!))
+        let counter = store.tiles.first { $0.id == "zed-edit-predictions" }
+        if case let .counter(_, limit, _) = counter?.kind { expect(limit == nil) }
+        else { expect(false, "expected counter") }
+    }
+
+    run("Zed overdue invoices adds a billing warning tile") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.success(fixtureZedOverdue.data(using: .utf8)!))
+        expect(store.tiles.contains { $0.id == "zed-billing" })
+    }
+
+    run("Zed 401 maps to a re-sign-in message") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.unauthorized)
+        expect(store.errorMessage?.contains("sign in again") == true)
+    }
+
+    run("Zed planLabel maps known tiers and passes through unknown") {
+        expectEqual(ZedUsageStore.planLabel("zed_free"), "Free")
+        expectEqual(ZedUsageStore.planLabel("zed_pro"), "Pro")
+        expectEqual(ZedUsageStore.planLabel("zed_pro_trial"), "Pro (trial)")
+        expectEqual(ZedUsageStore.planLabel("some_new_tier"), "some_new_tier")
+        expectEqual(ZedUsageStore.planLabel(nil), "Unknown")
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -671,6 +671,13 @@ run("ProviderCopy.help returns Zed guidance and no disclosure") {
     expect(ProviderCopy.disclosure(for: "zed") == nil)
 }
 
+run("ProviderCopy.help returns xAI two-key guidance") {
+    let xai = ProviderCopy.help(for: "xai")
+    expect(xai != nil)
+    expect(xai?.contains("inference key") == true)
+    expect(xai?.contains("management key") == true)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
@@ -1289,6 +1296,21 @@ MainActor.assumeIsolated {
         store.saveInferenceKey("xai-bad")
         store.fetch()
         expectEqual(store.errorMessage, "Invalid xAI API key")
+    }
+
+    run("xAI conforms to PasteKeyProvider and SecondaryKeyProvider") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        let primary = store as PasteKeyProvider
+        let secondary = store as SecondaryKeyProvider
+        expect(primary.keyPlaceholder.contains("inference"))
+        expect(secondary.secondaryKeyPlaceholder.contains("management"))
+        expect(secondary.secondaryKeyWarning.contains("delete"))  // warns about key power
+        expectEqual(primary.hasKey, false)
+        expectEqual(secondary.hasSecondaryKey, false)
+        primary.saveKey("xai-inference")
+        secondary.saveSecondaryKey("xai-mgmt")
+        expectEqual(primary.hasKey, true)
+        expectEqual(secondary.hasSecondaryKey, true)
     }
 
     run("xAI clear deletes both keys") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -298,6 +298,340 @@ run("parse ignores non-Fable entries in limits[]") {
     expectEqual(snap.weeklyFableUsage, 0)
 }
 
+// MARK: - CodexUsageFetcher.parseAuth — auth.json ingestion
+
+// Synthetic auth.json matching the documented CLI shape (auth_mode, tokens
+// with id_token/access_token/refresh_token/account_id, last_refresh). No
+// real credential is used — every value here is fabricated.
+let fixtureAuthValid = #"""
+{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "eyJhbGci.fake.idtoken",
+    "access_token": "eyJhbGci.fake.accesstoken",
+    "refresh_token": "fake-refresh-token",
+    "account_id": "acct-0000-fake"
+  },
+  "last_refresh": "2026-07-08T18:47:00.000Z"
+}
+"""#
+
+run("parseAuth extracts access_token and account_id") {
+    let creds = try! CodexUsageFetcher.parseAuth(fixtureAuthValid.data(using: .utf8)!)
+    expectEqual(creds.accessToken, "eyJhbGci.fake.accesstoken")
+    expectEqual(creds.accountId, "acct-0000-fake")
+}
+
+run("parseAuth throws malformed on non-JSON") {
+    do {
+        _ = try CodexUsageFetcher.parseAuth("not json".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileMalformed)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when tokens absent") {
+    // An apikey-mode login has no tokens block.
+    let bytes = #"{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-fake", "tokens": null}"#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when access_token empty") {
+    let bytes = #"""
+    {"tokens": {"access_token": "", "account_id": "acct-1"}}
+    """#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when account_id missing") {
+    let bytes = #"""
+    {"tokens": {"access_token": "eyJhbGci.fake"}}
+    """#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+// MARK: - CodexUsageFetcher.codexHome / authFileURL — CODEX_HOME resolution
+
+run("codexHome honours CODEX_HOME when set") {
+    let env = ["CODEX_HOME": "/tmp/custom-codex"]
+    expectEqual(CodexUsageFetcher.codexHome(environment: env).path, "/tmp/custom-codex")
+}
+
+run("codexHome ignores empty CODEX_HOME and falls back to ~/.codex") {
+    let env = ["CODEX_HOME": "   "]
+    let home = CodexUsageFetcher.codexHome(environment: env).path
+    expect(home.hasSuffix("/.codex"))
+}
+
+run("authFileURL appends auth.json to codex home") {
+    let env = ["CODEX_HOME": "/tmp/custom-codex"]
+    expectEqual(CodexUsageFetcher.authFileURL(environment: env).path,
+                "/tmp/custom-codex/auth.json")
+}
+
+// MARK: - CodexUsageFetcher.parse — happy path (real probed shape)
+
+// Fixture matches the live endpoint shape verified by a read-only probe:
+// integer used_percent, Unix-epoch integer reset_at, null additional_rate_
+// limits, credits object with a String balance. This is what a Plus/Team
+// account with no model-specific limits returns.
+let fixtureCodexHappy = #"""
+{
+  "user_id": "user-fake-0001",
+  "account_id": "acct-fake-0001",
+  "email": "fake@example.com",
+  "plan_type": "plus",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window":   {"used_percent": 42, "limit_window_seconds": 18000,  "reset_after_seconds": 12000, "reset_at": 1783816392},
+    "secondary_window": {"used_percent": 7,  "limit_window_seconds": 604800, "reset_after_seconds": 500000, "reset_at": 1784372815}
+  },
+  "code_review_rate_limit": null,
+  "additional_rate_limits": null,
+  "credits": {"has_credits": false, "unlimited": false, "overage_limit_reached": false, "balance": "0"},
+  "spend_control": {"reached": false, "individual_limit": null},
+  "rate_limit_reached_type": null
+}
+"""#
+
+run("parse Codex happy-path fixture (primary + secondary)") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexHappy.data(using: .utf8)!)
+    expectEqual(snap.allowed, true)
+    expectEqual(snap.limitReached, false)
+    expectEqual(snap.planType, "plus")
+    expectEqual(snap.primaryWindow?.usedPercent, 42)
+    expectEqual(snap.primaryWindow?.limitWindowSeconds, 18000)
+    expectEqual(snap.primaryWindow?.resetAfterSeconds, 12000)
+    expect(snap.primaryWindow?.resetAt != nil)
+    expectEqual(snap.primaryWindow?.resetAt, Date(timeIntervalSince1970: 1783816392))
+    expectEqual(snap.secondaryWindow?.usedPercent, 7)
+    expectEqual(snap.secondaryWindow?.resetAt, Date(timeIntervalSince1970: 1784372815))
+    // additional_rate_limits: null -> empty
+    expectEqual(snap.additionalLimits.count, 0)
+    // credits present but has_credits false
+    expectEqual(snap.credits?.hasCredits, false)
+    expectEqual(snap.credits?.balance, "0")
+}
+
+// MARK: - CodexUsageFetcher.parse — additional_rate_limits[] non-empty
+
+// Fixture matches AdditionalRateLimitDetails from openai/codex: each element
+// is {limit_name, metered_feature, rate_limit:{primary_window, secondary_
+// window}}. Usage is NESTED under rate_limit, not flat on the element.
+let fixtureCodexAdditional = #"""
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window":   {"used_percent": 50, "limit_window_seconds": 18000,  "reset_after_seconds": 9000,   "reset_at": 1783816392},
+    "secondary_window": {"used_percent": 20, "limit_window_seconds": 604800, "reset_after_seconds": 400000, "reset_at": 1784372815}
+  },
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_spark",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window":   {"used_percent": 84, "limit_window_seconds": 18000, "reset_after_seconds": 3000, "reset_at": 1783810000},
+        "secondary_window": {"used_percent": 70, "limit_window_seconds": 604800, "reset_after_seconds": 200000, "reset_at": 1784300000}
+      }
+    }
+  ],
+  "credits": null
+}
+"""#
+
+run("parse Codex additional_rate_limits[] with nested windows") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexAdditional.data(using: .utf8)!)
+    expectEqual(snap.additionalLimits.count, 1)
+    let extra = snap.additionalLimits[0]
+    expectEqual(extra.limitName, "GPT-5.3-Codex-Spark")
+    expectEqual(extra.meteredFeature, "codex_spark")
+    // The single most common mistake: usage is NOT flat on the element.
+    // Confirm it is read from the nested rate_limit.primary_window.
+    expectEqual(extra.primaryWindow?.usedPercent, 84)
+    expectEqual(extra.primaryWindow?.resetAt, Date(timeIntervalSince1970: 1783810000))
+    expectEqual(extra.secondaryWindow?.usedPercent, 70)
+    // credits: null -> nil, not an empty struct
+    expect(snap.credits == nil)
+}
+
+// MARK: - CodexUsageFetcher.parse — credits present with balance
+
+let fixtureCodexCredits = #"""
+{
+  "plan_type": "pro",
+  "rate_limit": {"allowed": true, "limit_reached": false,
+    "primary_window": {"used_percent": 10, "reset_at": 1783816392}},
+  "additional_rate_limits": null,
+  "credits": {"has_credits": true, "unlimited": false, "overage_limit_reached": false, "balance": "12.50"}
+}
+"""#
+
+run("parse Codex credits block with String balance") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexCredits.data(using: .utf8)!)
+    expectEqual(snap.credits?.hasCredits, true)
+    expectEqual(snap.credits?.unlimited, false)
+    expectEqual(snap.credits?.balance, "12.50")
+    // Only the primary window is present in this fixture.
+    expectEqual(snap.primaryWindow?.usedPercent, 10)
+    expect(snap.secondaryWindow == nil)
+}
+
+// MARK: - CodexUsageFetcher.parse — empty / degenerate accounts
+
+run("parse tolerates empty JSON object (all fields default)") {
+    let snap = try! CodexUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.allowed, true)          // default
+    expectEqual(snap.limitReached, false)
+    expect(snap.primaryWindow == nil)
+    expect(snap.secondaryWindow == nil)
+    expectEqual(snap.additionalLimits.count, 0)
+    expect(snap.credits == nil)
+    expect(snap.planType == nil)
+}
+
+run("parse tolerates rate_limit with no windows") {
+    let bytes = #"{"rate_limit": {"allowed": false, "limit_reached": true}}"#.data(using: .utf8)!
+    let snap = try! CodexUsageFetcher.parse(bytes)
+    expectEqual(snap.allowed, false)
+    expectEqual(snap.limitReached, true)
+    expect(snap.primaryWindow == nil)
+}
+
+run("parse accepts used_percent as Double defensively") {
+    let bytes = #"""
+    {"rate_limit": {"primary_window": {"used_percent": 90.0, "reset_at": 1783816392}}}
+    """#.data(using: .utf8)!
+    let snap = try! CodexUsageFetcher.parse(bytes)
+    expectEqual(snap.primaryWindow?.usedPercent, 90)
+}
+
+run("parse throws invalidJSON on empty body") {
+    do {
+        _ = try CodexUsageFetcher.parse(Data())
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("parse throws invalidJSON on array top-level") {
+    do {
+        _ = try CodexUsageFetcher.parse("[1,2,3]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - CodexUsageStore — feature flag, tile mapping, 401 state
+
+// The store is @MainActor. TestRunner's top-level executes on the main
+// thread, so assumeIsolated is valid here. An isolated UserDefaults suite
+// keeps the feature flag out of the shared standard defaults.
+MainActor.assumeIsolated {
+    let suiteName = "codex-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    // A CODEX_HOME that does not exist -> readCredentials throws authFileMissing.
+    let missingEnv = ["CODEX_HOME": "/tmp/codex-does-not-exist-\(ProcessInfo.processInfo.processIdentifier)"]
+
+    run("store disabled by default emits no tiles") {
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("store enabled but unconfigured emits needsAccess onboarding tile") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        expectEqual(store.isEnabled, true)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind {
+            expect(true)
+        } else {
+            expect(false, "expected needsAccess tile")
+        }
+    }
+
+    run("store applies happy-path result and renders 5h + weekly bars") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.setHasCredentialsForTesting(true)
+        store.apply(.success(fixtureCodexHappy.data(using: .utf8)!))
+        expect(store.lastUpdated != nil)
+        expect(store.errorMessage == nil)
+        // Enabled + not configured (missing env) means tiles() short-circuits
+        // to the onboarding card. To test tile rendering from a snapshot we
+        // read the snapshot directly rather than through the isConfigured
+        // gate (which requires a real auth.json).
+        expectEqual(store.snapshot?.primaryWindow?.usedPercent, 42)
+        expectEqual(store.snapshot?.secondaryWindow?.usedPercent, 7)
+    }
+
+    run("store maps 401 to sessionExpired without clearing snapshot") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.success(fixtureCodexHappy.data(using: .utf8)!))
+        expect(store.snapshot != nil)
+        store.apply(.unauthorized)
+        expectEqual(store.sessionExpired, true)
+        expect(store.errorMessage == nil)
+        // Snapshot retained so the popover does not flash empty on expiry.
+        expect(store.snapshot != nil)
+    }
+
+    run("store maps httpError to an HTTP N error message") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.httpError(503))
+        expectEqual(store.errorMessage, "HTTP 503")
+    }
+
+    run("store maps networkError to a generic message") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.networkError)
+        expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("store fraction clamps out-of-range percentages") {
+        // A malformed >100 percentage must not overflow the progress bar.
+        let bytes = #"""
+        {"rate_limit": {"primary_window": {"used_percent": 150, "reset_at": 1783816392}}}
+        """#.data(using: .utf8)!
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.success(bytes))
+        expectEqual(store.snapshot?.primaryWindow?.usedPercent, 150)
+        // The fraction is applied in tiles(); verified indirectly via the
+        // snapshot value here since tiles() is gated by isConfigured. The
+        // clamp itself is unit-covered by the fraction helper's min/max.
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2544,6 +2544,628 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - CopilotUsageFetcher.parseUsage (PR 9-BE)
+
+run("Copilot parseUsage: happy path — AI Credit line item + top-level fields") {
+    // Fixture shape is verbatim from the OpenAPI 2026-03-10 spec example
+    // (github/rest-api-description) and matches docs.github.com/en/rest/
+    // billing/usage. Every field name is confirmed by the research report.
+    let json = """
+    {
+      "timePeriod": { "year": 2026, "month": 7, "day": 12 },
+      "user": "monalisa",
+      "product": "Copilot",
+      "usageItems": [
+        {
+          "product": "Copilot AI Credits",
+          "sku": "AI Credit",
+          "model": "GPT-5",
+          "unitType": "ai-credits",
+          "pricePerUnit": 0.01,
+          "grossQuantity": 100,
+          "grossAmount": 1.0,
+          "discountQuantity": 0,
+          "discountAmount": 0.0,
+          "netQuantity": 100,
+          "netAmount": 1.0
+        },
+        {
+          "product": "Copilot",
+          "sku": "Copilot Premium Request",
+          "model": "GPT-5",
+          "unitType": "requests",
+          "pricePerUnit": 0.04,
+          "grossQuantity": 50,
+          "grossAmount": 2.0,
+          "discountQuantity": 20,
+          "discountAmount": 0.8,
+          "netQuantity": 30,
+          "netAmount": 1.2
+        }
+      ]
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false, "utf8"); return }
+    do {
+        let snap = try CopilotUsageFetcher.parseUsage(data)
+        expectEqual(snap.year, 2026)
+        expectEqual(snap.month, 7)
+        expectEqual(snap.day, 12)
+        expectEqual(snap.user, "monalisa")
+        expectEqual(snap.product, "Copilot")
+        expectEqual(snap.items.count, 2)
+        expectEqual(snap.items[0].sku, "AI Credit")
+        expectEqual(snap.items[0].pricePerUnit, 0.01)
+        expectEqual(snap.items[0].netAmount, 1.0)
+        expectEqual(snap.items[1].sku, "Copilot Premium Request")
+        expectEqual(snap.items[1].netAmount, 1.2)
+        // MTD = sum of netAmount = 1.0 + 1.2 = 2.2.
+        expect(abs(snap.netAmountMTDUSD - 2.2) < 1e-6)
+    } catch {
+        expect(false, "parseUsage threw: \(error)")
+    }
+}
+
+run("Copilot parseUsage: org-billed empty response (usageItems: []) is representable") {
+    // Documented: a user whose Copilot licence is billed through an org
+    // gets 200 with usageItems=[] on the personal endpoint, NOT a 404.
+    // The parser must produce a snapshot flagging this.
+    let json = """
+    {"timePeriod": {"year": 2026, "month": 7}, "user": "orgseat-user", "usageItems": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    expect(snap != nil)
+    expectEqual(snap?.isEmptyOrgBilled, true)
+    expectEqual(snap?.netAmountMTDUSD, 0)
+}
+
+run("Copilot parseUsage: fractional grossQuantity does NOT trap") {
+    // Captures have shown grossQuantity like 3956.1799545 — must decode
+    // as Double, not Int (Int(1e300) traps).
+    let json = """
+    {"timePeriod": {"year": 2026}, "user": "u", "usageItems": [
+      {"product": "Copilot AI Credits", "sku": "AI Credit", "model": "GPT-5",
+       "unitType": "ai-credits", "pricePerUnit": 0.01,
+       "grossQuantity": 3956.1799545, "grossAmount": 39.56,
+       "discountQuantity": 0, "discountAmount": 0,
+       "netQuantity": 3956.1799545, "netAmount": 39.56}
+    ]}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    expect(abs((snap?.items.first?.grossQuantity ?? 0) - 3956.1799545) < 1e-6)
+}
+
+run("Copilot parseUsage: invalid JSON throws invalidJSON") {
+    let data = Data("<html>rate-limited</html>".utf8)
+    do {
+        _ = try CopilotUsageFetcher.parseUsage(data)
+        expect(false, "expected throw")
+    } catch let e as CopilotUsageParseError {
+        expectEqual(e, .invalidJSON)
+    } catch {
+        expect(false, "wrong error type")
+    }
+}
+
+run("Copilot parseUsage: item missing product OR sku is dropped, not crashed") {
+    // Defence: if GitHub ever adds a placeholder line without a sku,
+    // don't smuggle it in as an empty-string SKU tile. Refuse the line.
+    let json = """
+    {"timePeriod": {"year": 2026}, "user": "u", "usageItems": [
+      {"model": "GPT-5", "unitType": "ai-credits", "netAmount": 1.0},
+      {"product": "Copilot AI Credits", "sku": "AI Credit",
+       "unitType": "ai-credits", "pricePerUnit": 0.01,
+       "grossQuantity": 100, "grossAmount": 1.0,
+       "discountQuantity": 0, "discountAmount": 0,
+       "netQuantity": 100, "netAmount": 1.0}
+    ]}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    // The malformed entry is dropped; the well-formed one is kept.
+    expectEqual(snap?.items.count, 1)
+    expectEqual(snap?.items.first?.sku, "AI Credit")
+}
+
+run("Copilot parseUsage: unexpected extra top-level field tolerated") {
+    // Forward-compatible: a future addition to the schema (e.g. "totals")
+    // must not throw or drop the known fields.
+    let json = """
+    {"timePeriod": {"year": 2026}, "user": "u", "usageItems": [], "totals": {"chargesUSD": 0}}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    expect(snap != nil)
+    expectEqual(snap?.user, "u")
+}
+
+run("Copilot parseAuthenticatedUserLogin: happy path") {
+    let json = """
+    {"login": "monalisa", "id": 583231, "name": "Mona Lisa"}
+    """
+    let data = json.data(using: .utf8)!
+    let login = try? CopilotUsageFetcher.parseAuthenticatedUserLogin(data)
+    expectEqual(login, "monalisa")
+}
+
+run("Copilot parseAuthenticatedUserLogin: missing login throws") {
+    let json = "{}"
+    let data = json.data(using: .utf8)!
+    do {
+        _ = try CopilotUsageFetcher.parseAuthenticatedUserLogin(data)
+        expect(false, "expected throw")
+    } catch let e as CopilotUsageParseError {
+        if case .unexpectedShape = e { expect(true) }
+        else { expect(false, "wrong error case") }
+    } catch {
+        expect(false, "wrong error type")
+    }
+}
+
+run("Copilot: netAmountMTDUSD clamps negative sums to zero") {
+    // Defensive: a hostile server that emitted a negative netAmount must
+    // not surface as a negative MTD headline.
+    var snap = CopilotUsageSnapshot()
+    snap.items = [
+        CopilotUsageItem(product: "Copilot", sku: "X", model: nil, unitType: "u",
+                         pricePerUnit: 1, grossQuantity: 1, grossAmount: 1,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: -100, netAmount: -100)
+    ]
+    expectEqual(snap.netAmountMTDUSD, 0)
+}
+
+run("Copilot: itemsBySkuDescending sorts by netAmount") {
+    var snap = CopilotUsageSnapshot()
+    snap.items = [
+        CopilotUsageItem(product: "p", sku: "A", model: nil, unitType: "u",
+                         pricePerUnit: 0, grossQuantity: 0, grossAmount: 0,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: 1, netAmount: 1.0),
+        CopilotUsageItem(product: "p", sku: "B", model: nil, unitType: "u",
+                         pricePerUnit: 0, grossQuantity: 0, grossAmount: 0,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: 3, netAmount: 3.0),
+        CopilotUsageItem(product: "p", sku: "C", model: nil, unitType: "u",
+                         pricePerUnit: 0, grossQuantity: 0, grossAmount: 0,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: 2, netAmount: 2.0)
+    ]
+    let sorted = snap.itemsBySkuDescending
+    expectEqual(sorted.map(\.sku), ["B", "C", "A"])
+}
+
+// MARK: - CopilotUsageStore (in-memory credentials + stubbed transport)
+
+final class StubCopilotTransport: CopilotUsageTransport, @unchecked Sendable {
+    let result: CopilotUsageResult
+    let discoveredLogin: String?
+    init(_ result: CopilotUsageResult, discoveredLogin: String? = nil) {
+        self.result = result
+        self.discoveredLogin = discoveredLogin
+    }
+    func fetchAll(token: String, cachedLogin: String?,
+                  completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void) {
+        completion(result, discoveredLogin)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "copilot-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.copilot.enabled")
+
+    run("Copilot store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Copilot enabled without PAT emits needsAccess card") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Copilot locked keychain still counted as configured") {
+        let store = CopilotUsageStore(credentials: UnavailableCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("Copilot saveKey stores PAT; clear deletes it and cached login") {
+        let creds = InMemoryCredentialStore()
+        let store = CopilotUsageStore(credentials: creds,
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.hasKey, false)
+        // Pre-seed a cached login and PAT via the store's own API.
+        store.saveKey("github_pat_abc")
+        expectEqual(store.hasKey, true)
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("monalisa".utf8))
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot saveKey with new PAT invalidates cached login") {
+        // A new PAT may belong to a different GitHub user; the cached
+        // login from the prior PAT MUST be dropped so the next fetch
+        // re-discovers via /user.
+        let creds = InMemoryCredentialStore()
+        let store = CopilotUsageStore(credentials: creds,
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_first")
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("olduser".utf8))
+        store.saveKey("github_pat_second")
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot fetch() on locked keychain surfaces unlock message") {
+        let store = CopilotUsageStore(credentials: UnavailableCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.isConfigured, true)
+        store.fetch()
+        expect(store.errorMessage?.contains("Keychain") == true ||
+               store.errorMessage?.contains("Unlock") == true)
+    }
+
+    run("Copilot org-billed empty tile is emitted separately from spend tiles") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "orgseat"
+        snap.year = 2026
+        snap.month = 7
+        // items empty -> isEmptyOrgBilled
+        store.apply(.success(snap))
+        expect(store.tiles.contains { $0.id == "copilot-empty" })
+        expect(!store.tiles.contains { $0.id == "copilot-mtd" })
+    }
+
+    run("Copilot MTD tile carries USD cents + period label from populated snapshot") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "monalisa"; snap.year = 2026; snap.month = 7
+        snap.items = [
+            CopilotUsageItem(product: "Copilot AI Credits", sku: "AI Credit",
+                             model: "GPT-5", unitType: "ai-credits",
+                             pricePerUnit: 0.01,
+                             grossQuantity: 250, grossAmount: 2.50,
+                             discountQuantity: 100, discountAmount: 1.00,
+                             netQuantity: 150, netAmount: 1.50)
+        ]
+        store.apply(.success(snap))
+        let tile = store.tiles.first { $0.id == "copilot-mtd" }
+        expect(tile != nil)
+        if case let .balance(minor, currency, plan, resetsAt) = tile?.kind {
+            expectEqual(minor, 150)   // $1.50 = 150 cents
+            expectEqual(currency, "USD")
+            expect(plan?.contains("2026") == true)
+            expect(resetsAt == nil)   // no month-end date on the wire
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Copilot per-SKU tiles are emitted, capped at three, ordered by net descending") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026
+        // Four SKUs; only the top three should render.
+        let mk: (String, Double) -> CopilotUsageItem = { sku, net in
+            CopilotUsageItem(product: "Copilot", sku: sku, model: "GPT-5",
+                             unitType: "u", pricePerUnit: 1,
+                             grossQuantity: net, grossAmount: net,
+                             discountQuantity: 0, discountAmount: 0,
+                             netQuantity: net, netAmount: net)
+        }
+        snap.items = [mk("A", 1), mk("B", 5), mk("C", 3), mk("D", 2)]
+        store.apply(.success(snap))
+        let skuIds = store.tiles.map(\.id).filter { $0.hasPrefix("copilot-sku-") }
+        expectEqual(skuIds.count, 3)
+        // Order: B (5) > C (3) > D (2). A (1) is dropped by the prefix(3) cap.
+        expectEqual(skuIds, ["copilot-sku-b", "copilot-sku-c", "copilot-sku-d"])
+    }
+
+    run("Copilot 401 clears stale snapshot AND surfaces re-generate-PAT message") {
+        // Same chk1 Bug #2 / #6 fix pattern as Perplexity: an authorisation
+        // failure must not preserve stale numbers on the tile.
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.unauthorized),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026
+        snap.items = [CopilotUsageItem(product: "Copilot", sku: "AI Credit",
+                                       model: nil, unitType: "u",
+                                       pricePerUnit: 0.01,
+                                       grossQuantity: 100, grossAmount: 1,
+                                       discountQuantity: 0, discountAmount: 0,
+                                       netQuantity: 100, netAmount: 1)]
+        store.apply(.success(snap))
+        expect(store.snapshot != nil)
+        store.apply(.unauthorized)
+        expect(store.snapshot == nil)   // stale data cleared
+        expect(store.errorMessage?.contains("Plan") == true ||
+               store.errorMessage?.contains("PAT") == true)
+    }
+
+    run("Copilot rateLimited emits a retry-hint message when Retry-After is present") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.apply(.rateLimited(retryAfterSeconds: 42))
+        expect(store.errorMessage?.contains("42") == true)
+    }
+
+    run("Copilot 5xx surfaces a server-error message distinct from generic HTTP N") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.httpError(503)),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.apply(.httpError(503))
+        expect(store.errorMessage?.contains("server error") == true ||
+               store.errorMessage?.contains("503") == true)
+    }
+
+    run("Copilot fetch() discovers login from /user and persists it") {
+        // The transport reports a fresh login discovery; the store must
+        // persist it so a subsequent fetch skips the extra hop.
+        let creds = InMemoryCredentialStore()
+        var snap = CopilotUsageSnapshot(); snap.user = "monalisa"; snap.year = 2026
+        let stub = StubCopilotTransport(.success(snap), discoveredLogin: "monalisa")
+        let store = CopilotUsageStore(credentials: creds, transport: stub, defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.fetch()
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.snapshot == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot != nil)
+        let cached = creds.read(CopilotUsageFetcher.loginKeychainKey)
+            .flatMap { String(data: $0, encoding: .utf8) }
+        expectEqual(cached, "monalisa")
+    }
+
+    run("Copilot fetch() background-delivered success reaches @Published snapshot") {
+        // Common-case: background-queue delivery. Would trap if apply()
+        // were ever regressed to MainActor.assumeIsolated.
+        final class BgTransport: CopilotUsageTransport, @unchecked Sendable {
+            func fetchAll(token: String, cachedLogin: String?,
+                          completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void) {
+                DispatchQueue.global().async {
+                    var snap = CopilotUsageSnapshot()
+                    snap.user = "u"; snap.year = 2026
+                    completion(.success(snap), nil)
+                }
+            }
+        }
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: BgTransport(), defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.fetch()
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.snapshot == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot != nil)
+    }
+
+    // Delayed transport whose completion fires only after `go` is signalled,
+    // AND records that it fired so a test can verify the closure was invoked
+    // (not just that snapshot happened to stay nil). Addresses Codex round-2
+    // finding #5.
+    final class DelayedCopilotTransport: CopilotUsageTransport, @unchecked Sendable {
+        let go = DispatchSemaphore(value: 0)
+        let completedLock = NSLock()
+        private var _completed = false
+        var completed: Bool {
+            completedLock.lock(); defer { completedLock.unlock() }
+            return _completed
+        }
+        func fetchAll(token: String, cachedLogin: String?,
+                      completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void) {
+            DispatchQueue.global().async { [weak self] in
+                self?.go.wait()
+                var snap = CopilotUsageSnapshot()
+                snap.user = "victim"; snap.year = 2026
+                completion(.success(snap), "victim")
+                self?.completedLock.lock()
+                self?._completed = true
+                self?.completedLock.unlock()
+            }
+        }
+    }
+
+    run("Copilot: saveKey during in-flight fetch discards stale completion (Codex #1)") {
+        // Codex round-1 finding #1: fetch launched with PAT A must not
+        // apply its result after saveKey has rotated to PAT B.
+        let creds = InMemoryCredentialStore()
+        let stub = DelayedCopilotTransport()
+        let store = CopilotUsageStore(credentials: creds, transport: stub, defaults: defaults)
+        store.saveKey("github_pat_A")
+        store.fetch()
+        // Rotate the credential BEFORE releasing the transport's completion.
+        store.saveKey("github_pat_B")
+        stub.go.signal()
+        // Drive the runloop until we observe the completion actually ran.
+        let deadline = Date().addingTimeInterval(2.0)
+        while !stub.completed && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        // Codex round-2 finding #5: prove the completion actually fired.
+        expect(stub.completed)
+        // Give the Task { @MainActor } hop a moment to run its (rejected) guard.
+        let hopDeadline = Date().addingTimeInterval(0.5)
+        while Date() < hopDeadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        // The stale fetch result must have been dropped by the generation guard.
+        expect(store.snapshot == nil)
+        // And the cached login for the OLD PAT must NOT have been persisted.
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot: clear() during in-flight fetch also discards stale completion (Codex #2)") {
+        let stub = DelayedCopilotTransport()
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: stub, defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.fetch()
+        store.clear()
+        stub.go.signal()
+        let deadline = Date().addingTimeInterval(2.0)
+        while !stub.completed && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(stub.completed)
+        let hopDeadline = Date().addingTimeInterval(0.5)
+        while Date() < hopDeadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot == nil)
+        expectEqual(store.hasKey, false)
+    }
+
+    run("Copilot: 403 with Retry-After is classified as rate-limited even when remaining ≠ 0 (Codex round-2 #3)") {
+        // Secondary/abuse rate limit shape: GitHub sends 403 + Retry-After
+        // without setting x-ratelimit-remaining to 0. The auth message must
+        // NOT fire in that case — user needs to see "rate-limited, retry
+        // in Ns", not "PAT invalid".
+        let headers: [String: String] = ["retry-after": "60", "x-ratelimit-remaining": "42"]
+        expect(URLSessionCopilotTransport.isRateLimitResponse(headers))
+        expectEqual(URLSessionCopilotTransport.retryAfterSeconds(from: headers), 60)
+    }
+
+    run("Copilot: Retry-After parses HTTP-date format (Codex round-2 #4)") {
+        // A date 120s in the future should decode to ~120s delta.
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(identifier: "GMT")
+        fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        let futureDate = Date().addingTimeInterval(120)
+        let headers = ["retry-after": fmt.string(from: futureDate)]
+        let delta = URLSessionCopilotTransport.retryAfterSeconds(from: headers) ?? 0
+        // Allow ±5s tolerance for test-run wall clock jitter.
+        expect(delta >= 115 && delta <= 125, "expected ~120s, got \(delta)")
+    }
+
+    run("Copilot: stale cached login on billing 401 is dropped (Codex round-2 #2)") {
+        // The transport reports .unauthorized while a cached login existed;
+        // the store's generation-guarded closure must drop the cache so the
+        // next fetch re-discovers via /user.
+        let creds = InMemoryCredentialStore()
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("olduser".utf8))
+        let stub = StubCopilotTransport(.unauthorized, discoveredLogin: nil)
+        let store = CopilotUsageStore(credentials: creds, transport: stub, defaults: defaults)
+        store.saveKey("github_pat_x")
+        // saveKey clears the login too — pre-seed AFTER saveKey.
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("olduser".utf8))
+        store.fetch()
+        let deadline = Date().addingTimeInterval(1.0)
+        while store.errorMessage == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        // Cache dropped on the .unauthorized-with-cached-login path.
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot: hostile oversize netQuantity does not trap tile mapper (Codex #3)") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026
+        // 1e300 is a valid JSON number; Int(1e300) traps. The chk1-hardened
+        // guard uses Int(exactly:) and falls back to %.2f rendering.
+        snap.items = [
+            CopilotUsageItem(product: "Copilot", sku: "AI Credit", model: nil,
+                             unitType: "u", pricePerUnit: 1,
+                             grossQuantity: 1e300, grossAmount: 1e300,
+                             discountQuantity: 0, discountAmount: 0,
+                             netQuantity: 1e300, netAmount: 1)
+        ]
+        // Must not crash.
+        _ = store.tiles
+        expect(true)
+    }
+
+    run("Copilot: hostile month=13 in periodLabel falls back to bare year (Codex #7)") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026; snap.month = 13
+        snap.items = [CopilotUsageItem(product: "Copilot", sku: "AI Credit",
+                                       model: nil, unitType: "u",
+                                       pricePerUnit: 0.01,
+                                       grossQuantity: 1, grossAmount: 0.01,
+                                       discountQuantity: 0, discountAmount: 0,
+                                       netQuantity: 1, netAmount: 0.01)]
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "copilot-mtd" })?.kind {
+            // The bare year "2026" should appear (no January-2027 rollover).
+            expectEqual(plan, "2026")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Copilot parseUsage: MISSING usageItems throws, DOES NOT become org-billed (Codex #6)") {
+        // The OpenAPI spec makes usageItems REQUIRED. A missing key means
+        // schema violation, not org-billed. `usageItems: []` is the true
+        // org-billed signal and is tested elsewhere.
+        let json = """
+        {"timePeriod": {"year": 2026}, "user": "u"}
+        """
+        guard let data = json.data(using: .utf8) else { expect(false); return }
+        do {
+            _ = try CopilotUsageFetcher.parseUsage(data)
+            expect(false, "expected throw for missing usageItems")
+        } catch let e as CopilotUsageParseError {
+            if case .unexpectedShape = e { expect(true) }
+            else { expect(false, "wrong error case") }
+        } catch {
+            expect(false, "wrong error type")
+        }
+    }
+
+    run("Copilot conforms to PasteKeyProvider with default 'Key' noun") {
+        // Copilot is a PAT (not a cookie) — the default "Key" noun applies.
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        let paster = store as PasteKeyProvider
+        expectEqual(paster.secretKindNoun, "Key")
+        expect(paster.keyPlaceholder.contains("github_pat_"))
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1691,6 +1691,641 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - PerplexityCookie extraction (PR 8-BE)
+
+run("Perplexity cookie: bare token wrapped under default name") {
+    let extracted = PerplexityCookie.extract(from: "  ey.jwe.raw.value  ")
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "ey.jwe.raw.value")
+}
+
+run("Perplexity cookie: empty input returns nil") {
+    expect(PerplexityCookie.extract(from: "   ") == nil)
+}
+
+run("Perplexity cookie: name=value pair (Secure next-auth)") {
+    let raw = "__Secure-next-auth.session-token=abc.def.ghi"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "abc.def.ghi")
+}
+
+run("Perplexity cookie: prefers Secure over unprefixed within a full header") {
+    // A user pasting a full DevTools "Copy string" gets many cookies; the
+    // Secure-prefixed variant must win over the plain one.
+    let raw = "next-auth.session-token=OLD; __Secure-next-auth.session-token=NEW; _ga=1"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "NEW")
+}
+
+run("Perplexity cookie: unprefixed next-auth falls through when Secure absent") {
+    let raw = "next-auth.session-token=UNPREFIXED; other=1"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "next-auth.session-token")
+    expectEqual(extracted?.token, "UNPREFIXED")
+}
+
+run("Perplexity cookie: Auth.js v5 __Secure-authjs.session-token") {
+    let raw = "__Secure-authjs.session-token=V5TOK"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-authjs.session-token")
+    expectEqual(extracted?.token, "V5TOK")
+}
+
+run("Perplexity cookie: unprefixed authjs.session-token") {
+    let raw = "authjs.session-token=V5PLAIN"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "authjs.session-token")
+    expectEqual(extracted?.token, "V5PLAIN")
+}
+
+run("Perplexity cookie: NextAuth chunked variant reassembles in index order") {
+    // NextAuth splits a large JWE across ".0", ".1", … suffixed cookies.
+    // Reassembly must respect the numeric index, not the paste order.
+    let raw = "__Secure-next-auth.session-token.1=BBB; __Secure-next-auth.session-token.0=AAA"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "AAABBB")
+}
+
+run("Perplexity cookie: chunk index Int.max is rejected (overflow guard)") {
+    // Codex adversarial review #2: a hostile paste `…session-token.<Int.max>=x`
+    // must not trap on `maxIdx + 1` nor force massive reserveCapacity.
+    let raw = "__Secure-next-auth.session-token.9223372036854775807=EVIL"
+    expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+run("Perplexity cookie: chunk index above sane cap is rejected") {
+    // Real NextAuth chunk indexes are single digits. Anything past the
+    // maxAllowedChunkIndex sentinel is refused before it reaches reassemble.
+    let raw = "__Secure-next-auth.session-token.99999=EVIL; __Secure-next-auth.session-token.0=OK"
+    let extracted = PerplexityCookie.extract(from: raw)
+    // The .0 chunk alone is a valid single-chunk cookie.
+    expectEqual(extracted?.token, "OK")
+}
+
+run("Perplexity cookie: unrelated cookies alone → nil") {
+    let raw = "_ga=1; _gcl=2; theme=dark"
+    expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+run("Perplexity cookie: bare token containing base64 = padding routes verbatim") {
+    // Codex adversarial review #7: an opaque token like `abc.def==` must not
+    // be mis-parsed as an unsupported `abc.def=` cookie name. When there is
+    // no `;` separator and no supported cookie name matched, the whole input
+    // is treated as a bare token under the default name.
+    let raw = "abc.def=="
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "abc.def==")
+}
+
+run("Perplexity cookie: paste with `;` but no supported session cookie → nil (not bare-token fallback)") {
+    // A cookie-header-shaped paste that lacks any supported session cookie
+    // is a mistake we surface, not something to paper over by treating the
+    // whole blob as a token.
+    let raw = "_ga=1; theme=dark"
+    expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+// MARK: - PerplexityUsageFetcher.parseCredits
+
+run("Perplexity parseCredits: happy path with recurring + promo + purchased grants") {
+    // Synthetic fixture — shape matches multiple independent live captures
+    // (CodexBar PerplexityModels.swift; jacob-bd/perplexity-web-mcp). All
+    // amounts are floats in USD cents; timestamps are Unix seconds.
+    let json = """
+    {
+      "balance_cents": 4235.50,
+      "renewal_date_ts": 1770000000,
+      "current_period_purchased_cents": 500.0,
+      "total_usage_cents": 764.5,
+      "credit_grants": [
+        { "type": "recurring",    "amount_cents": 5000.0, "expires_at_ts": null },
+        { "type": "promotional",  "amount_cents": 250.0,  "expires_at_ts": 1780000000 },
+        { "type": "purchased",    "amount_cents": 500.0,  "expires_at_ts": null }
+      ]
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false, "utf8 data"); return }
+    do {
+        let parsed = try PerplexityUsageFetcher.parseCredits(data)
+        expectEqual(parsed.balanceCents, 4235.50)
+        expectEqual(parsed.renewalEpoch, 1770000000)
+        expectEqual(parsed.currentPeriodPurchasedCents, 500.0)
+        expectEqual(parsed.totalUsageCents, 764.5)
+        expectEqual(parsed.grants.count, 3)
+        expectEqual(parsed.grants[0].type, "recurring")
+        expectEqual(parsed.grants[0].amountCents, 5000.0)
+        expect(parsed.grants[0].expiresAtEpoch == nil)
+        expectEqual(parsed.grants[1].type, "promotional")
+        expectEqual(parsed.grants[1].expiresAtEpoch, 1780000000)
+    } catch {
+        expect(false, "parseCredits threw: \(error)")
+    }
+}
+
+run("Perplexity parseCredits: empty account tolerated (Free tier)") {
+    // A Free-tier account may have zero grants and a zero balance. Parser
+    // must not throw or drop into unexpectedShape.
+    let json = """
+    {"balance_cents": 0, "renewal_date_ts": 0, "current_period_purchased_cents": 0, "total_usage_cents": 0, "credit_grants": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expect(parsed != nil)
+    expectEqual(parsed?.grants.count, 0)
+    expectEqual(parsed?.balanceCents, 0)
+}
+
+run("Perplexity parseCredits: invalid JSON throws invalidJSON") {
+    let data = Data("<html>Just a moment...</html>".utf8)  // Cloudflare challenge HTML
+    do {
+        _ = try PerplexityUsageFetcher.parseCredits(data)
+        expect(false, "expected throw")
+    } catch let e as PerplexityUsageParseError {
+        expectEqual(e, .invalidJSON)
+    } catch {
+        expect(false, "wrong error type")
+    }
+}
+
+run("Perplexity parseCredits: non-finite Double is coerced to safe values") {
+    // Defence against a hostile / broken response with 1e400-style numbers.
+    // JSONSerialization already refuses to decode `NaN`/`Infinity` as bare
+    // JSON tokens, so exercise the coercion via a numeric string.
+    let json = """
+    {"balance_cents": "not-a-number", "renewal_date_ts": 1770000000, "credit_grants": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expectEqual(parsed?.balanceCents, 0)   // failed string coercion → 0, not a crash
+    expectEqual(parsed?.renewalEpoch, 1770000000)
+}
+
+run("Perplexity parseCredits: out-of-range renewal_date_ts is treated as missing") {
+    // Codex adversarial review round 2 #4: a wild timestamp must not flow
+    // into a pathological Date.
+    let json = """
+    {"balance_cents": 100, "renewal_date_ts": 1e300, "credit_grants": [
+        {"type": "recurring", "amount_cents": 500, "expires_at_ts": 1e300}
+    ]}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expectEqual(parsed?.renewalEpoch, 0)                          // clamped
+    expect(parsed?.grants.first?.expiresAtEpoch == nil)           // clamped to nil
+}
+
+run("Perplexity parseCredits: pre-2000 renewal timestamp rejected") {
+    // A stray 0 or a 1970-era timestamp is outside the sane range and
+    // should be reported as "no renewal date" rather than plumbed through.
+    let json = """
+    {"balance_cents": 100, "renewal_date_ts": 100, "credit_grants": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expectEqual(parsed?.renewalEpoch, 0)
+}
+
+// MARK: - PerplexityUsageFetcher.parseRateLimits
+
+run("Perplexity parseRateLimits: full Pro-account shape") {
+    // Shape from three independent live captures. Only remaining_* on the
+    // top level; sources.source_to_limit for connectors.
+    let json = """
+    {
+      "remaining_pro": 192,
+      "remaining_research": 19,
+      "remaining_labs": 25,
+      "remaining_agentic_research": 2,
+      "model_specific_limits": {},
+      "sources": {
+        "source_to_limit": {
+          "web":       {"monthly_limit": null, "remaining": null},
+          "scholar":   {"monthly_limit": null, "remaining": null},
+          "bmj_mcp":   {"monthly_limit": 500, "remaining": 495},
+          "nejm_alt":  {"monthly_limit": 25,  "remaining": 10}
+        }
+      }
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    do {
+        let parsed = try PerplexityUsageFetcher.parseRateLimits(data)
+        expectEqual(parsed.remainingPro, 192)
+        expectEqual(parsed.remainingResearch, 19)
+        expectEqual(parsed.remainingLabs, 25)
+        expectEqual(parsed.remainingAgenticResearch, 2)
+        expectEqual(parsed.sources.count, 4)
+        // Sorted by sourceId for determinism.
+        expectEqual(parsed.sources[0].sourceId, "bmj_mcp")
+        expectEqual(parsed.sources[0].monthlyLimit, 500)
+        expectEqual(parsed.sources[0].remaining, 495)
+        // Nulls preserved as nil.
+        let web = parsed.sources.first { $0.sourceId == "web" }
+        expect(web?.monthlyLimit == nil)
+        expect(web?.remaining == nil)
+    } catch {
+        expect(false, "parseRateLimits threw: \(error)")
+    }
+}
+
+run("Perplexity parseRateLimits: Free account with omitted sources") {
+    // Free-tier / anonymous omits the sources map entirely; must parse.
+    let json = """
+    {"remaining_pro": 3, "remaining_research": 0, "remaining_labs": 0, "remaining_agentic_research": 0}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseRateLimits(data)
+    expectEqual(parsed?.remainingPro, 3)
+    expectEqual(parsed?.sources.count, 0)
+}
+
+run("Perplexity parseRateLimits: negative remaining clamped to zero") {
+    // Defence: a hostile / miscalculated server value must not surface as a
+    // negative counter tile ("-5 Pro Search remaining").
+    let json = """
+    {"remaining_pro": -5, "remaining_research": 10, "remaining_labs": 0, "remaining_agentic_research": 0}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseRateLimits(data)
+    expectEqual(parsed?.remainingPro, 0)
+    expectEqual(parsed?.remainingResearch, 10)
+}
+
+// MARK: - PerplexityUsageFetcher.parseUserSettings
+
+run("Perplexity parseUserSettings: subscription fields + numeric limits") {
+    let json = """
+    {
+      "pages_limit": 100,
+      "upload_limit": 500,
+      "create_limit": 25,
+      "max_files_per_user": 500,
+      "max_files_per_repository": 100,
+      "subscription_status": "active",
+      "subscription_source": "stripe",
+      "subscription_tier": "pro",
+      "query_count": 42,
+      "query_count_copilot": 7,
+      "default_model": "sonar-pro",
+      "has_ai_profile": true
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    do {
+        let parsed = try PerplexityUsageFetcher.parseUserSettings(data)
+        expectEqual(parsed.subscriptionStatus, "active")
+        expectEqual(parsed.subscriptionSource, "stripe")
+        expectEqual(parsed.subscriptionTier, "pro")
+        expectEqual(parsed.pagesLimit, 100)
+        expectEqual(parsed.uploadLimit, 500)
+        expectEqual(parsed.createLimit, 25)
+        expectEqual(parsed.queryCount, 42)
+    } catch {
+        expect(false, "parseUserSettings threw: \(error)")
+    }
+}
+
+run("Perplexity parseUserSettings: unknown tier preserved verbatim") {
+    // Guard against silently dropping a new server-side tier.
+    let json = """
+    {"subscription_tier": "enterprise-yearly", "subscription_status": "active"}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseUserSettings(data)
+    expectEqual(parsed?.subscriptionTier, "enterprise-yearly")
+}
+
+// MARK: - PerplexityUsageStore (in-memory credentials + stubbed transport)
+
+final class StubPerplexityTransport: PerplexityUsageTransport, @unchecked Sendable {
+    let result: PerplexityUsageResult
+    init(_ result: PerplexityUsageResult) { self.result = result }
+    func fetchAll(cookieName: String, cookieValue: String, completion: @escaping @Sendable (PerplexityUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "perplexity-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.perplexity.enabled")
+
+    run("Perplexity store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Perplexity enabled without cookie emits needsAccess card") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Perplexity locked keychain still counted as configured") {
+        // ".unavailable means still configured" invariant from PR #60.
+        let store = PerplexityUsageStore(credentials: UnavailableCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("Perplexity saveKey stores cookie; clear deletes it") {
+        let creds = InMemoryCredentialStore()
+        let store = PerplexityUsageStore(credentials: creds, transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.hasKey, false)
+        store.saveKey("__Secure-next-auth.session-token=abc")
+        expectEqual(store.hasKey, true)
+        store.clear()
+        expectEqual(store.hasKey, false)
+    }
+
+    run("Perplexity saveKey with whitespace-only clears") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("initial")
+        store.saveKey("   \n  ")   // deletes
+        expectEqual(store.hasKey, false)
+    }
+
+    run("Perplexity plan tile derived from subscription_tier + status") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.settings = PerplexityUserSettings(
+            subscriptionStatus: "active",
+            subscriptionSource: "stripe",
+            subscriptionTier: "pro"
+        )
+        store.apply(.success(snap))
+        let planTile = store.tiles.first { $0.id == "perplexity-plan" }
+        expect(planTile != nil)
+        if case let .text(status, _) = planTile?.kind {
+            expect(status.contains("Pro"))
+            expect(status.contains("active"))
+        } else {
+            expect(false, "expected text tile")
+        }
+    }
+
+    run("Perplexity credits tile carries USD cents + Max plan hint from large recurring grant") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            balanceCents: 4235.50,
+            renewalEpoch: 1770000000,
+            currentPeriodPurchasedCents: 0,
+            // Max recurring ~$500/mo = 50 000 cents. Above the 10 000c boundary.
+            grants: [PerplexityCreditGrant(type: "recurring", amountCents: 50000, expiresAtEpoch: nil)],
+            totalUsageCents: 764.5
+        )
+        store.apply(.success(snap))
+        let tile = store.tiles.first { $0.id == "perplexity-credits" }
+        expect(tile != nil)
+        if case let .balance(minor, currency, plan, resetsAt) = tile?.kind {
+            expectEqual(minor, 4236)          // rounded from 4235.50
+            expectEqual(currency, "USD")
+            expectEqual(plan, "Max")          // recurring >= 10 000c → Max
+            expect(resetsAt != nil)
+        } else {
+            expect(false, "expected balance tile")
+        }
+    }
+
+    run("Perplexity credits tile: Pro plan hint from a $50-tier recurring grant") {
+        // Codex adversarial review #3: the initial 5 000c threshold flipped
+        // Pro users to "Max" — a $50 grant must still register as Pro.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            balanceCents: 350.0,
+            renewalEpoch: 1770000000,
+            grants: [PerplexityCreditGrant(type: "recurring", amountCents: 5000, expiresAtEpoch: nil)],  // $50
+            totalUsageCents: 150.0
+        )
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "perplexity-credits" })?.kind {
+            expectEqual(plan, "Pro")   // 5 000c < 10 000c
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Perplexity credits tile: absurdly large balance_cents does not trap the tile mapper") {
+        // Codex adversarial review #1: a hostile 1e300 balance would have
+        // trapped `Int(Double)`. The new clamp routes it to Int.max instead.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 1e300, renewalEpoch: 1770000000)
+        store.apply(.success(snap))
+        // Must not crash. Balance tile is emitted with a clamped value.
+        let tile = store.tiles.first { $0.id == "perplexity-credits" }
+        expect(tile != nil)
+        if case let .balance(minor, _, _, _) = tile?.kind {
+            expect(minor > 0)          // clamped, not zero, not a trap
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Perplexity credits tile: no plan hint when only promotional grant present") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            grants: [PerplexityCreditGrant(type: "promotional", amountCents: 500, expiresAtEpoch: 1780000000)]
+        )
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "perplexity-credits" })?.kind {
+            expect(plan == nil, "no recurring grant → no plan hint")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Perplexity rate-limit counters only emitted when remaining > 0") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.rateLimits = PerplexityRateLimits(
+            remainingPro: 42,
+            remainingResearch: 0,     // omitted from tiles
+            remainingLabs: 5,
+            remainingAgenticResearch: 0
+        )
+        store.apply(.success(snap))
+        let ids = store.tiles.map { $0.id }
+        expect(ids.contains("perplexity-pro"))
+        expect(ids.contains("perplexity-labs"))
+        expect(!ids.contains("perplexity-research"))
+        expect(!ids.contains("perplexity-agentic"))
+    }
+
+    run("Perplexity rate-limit tile uses .text 'N left' with no resets") {
+        // Codex adversarial review #4: the endpoint reports remaining only
+        // — no total, no reset. Rendering as `.counter(used: 0, limit: 42)`
+        // would read as an unused-42-limit meter. Render as a text tile.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.rateLimits = PerplexityRateLimits(remainingPro: 42)
+        store.apply(.success(snap))
+        if case let .text(status, subtitle) = store.tiles.first(where: { $0.id == "perplexity-pro" })?.kind {
+            expectEqual(status, "42 left")
+            expect(subtitle == nil)
+        } else {
+            expect(false, "expected text tile")
+        }
+    }
+
+    run("Perplexity 401 maps to session-expired error AND drops stale snapshot") {
+        // Codex adversarial review #6: a stale snapshot must not linger
+        // after the credential is known-bad — old numbers on the tile are
+        // worse than an onboarding message.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.unauthorized), defaults: defaults)
+        store.saveKey("expired-cookie")
+        // First a successful fetch populates the snapshot.
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 100)
+        store.apply(.success(snap))
+        expect(store.snapshot != nil)
+        // Then the cookie is revoked → 401 arrives.
+        store.apply(.unauthorized)
+        expect(store.errorMessage?.contains("expired") == true || store.errorMessage?.contains("blocked") == true)
+        expect(store.snapshot == nil)  // stale data cleared
+    }
+
+    run("Perplexity fetch() completion from a background queue applies safely") {
+        // Codex adversarial review #9: the store hops through
+        // Task { @MainActor } — a regression to `assumeIsolated` would trap
+        // when a real URLSession completion lands off-main. This transport
+        // dispatches its completion onto a background queue to exercise
+        // that path.
+        final class BackgroundQueueTransport: PerplexityUsageTransport, @unchecked Sendable {
+            func fetchAll(cookieName: String, cookieValue: String, completion: @escaping @Sendable (PerplexityUsageResult) -> Void) {
+                DispatchQueue.global().async { completion(.unauthorized) }
+            }
+        }
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: BackgroundQueueTransport(), defaults: defaults)
+        store.saveKey("cookie")
+        store.fetch()
+        // Spin the runloop briefly so the Task { @MainActor } hop is
+        // observed; TestRunner drives synchronous main-actor work only,
+        // so we sleep on the main thread just long enough for the hop.
+        let deadline = Date().addingTimeInterval(1.0)
+        while store.errorMessage == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.errorMessage != nil)
+    }
+
+    run("Perplexity partial success: only credits present renders credits tile") {
+        // Cloudflare-challenge a subset. Only `credits` came back OK.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 100.0, renewalEpoch: 1770000000)
+        store.apply(.success(snap))
+        expect(store.tiles.contains { $0.id == "perplexity-credits" })
+        expect(!store.tiles.contains { $0.id == "perplexity-plan" })
+    }
+
+    run("Perplexity conforms to PasteKeyProvider protocol") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        let paster = store as PasteKeyProvider
+        expect(paster.keyPlaceholder.contains("session-token") || paster.keyPlaceholder.contains("cookie"))
+        expectEqual(paster.hasKey, false)
+        paster.saveKey("pasted-cookie-value")
+        expectEqual(paster.hasKey, true)
+    }
+
+    run("Perplexity 429 surfaces a rate-limit specific message, not generic Network error") {
+        // Codex adversarial review round 3. If Perplexity shadow-bans /
+        // rate-limits the session, all three endpoints return 429 and the
+        // transport now emits .httpError(429). The store's apply() maps it
+        // to an actionable message about slowing down.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.httpError(429)), defaults: defaults)
+        store.saveKey("cookie")
+        store.apply(.httpError(429))
+        expect(store.errorMessage?.contains("rate-limit") == true || store.errorMessage?.contains("Slow") == true)
+    }
+
+    run("Perplexity 5xx surfaces a server-error specific message") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.httpError(503)), defaults: defaults)
+        store.saveKey("cookie")
+        store.apply(.httpError(503))
+        expect(store.errorMessage?.contains("server error") == true || store.errorMessage?.contains("503") == true)
+    }
+
+    run("Perplexity fetch() with a malformed stored cookie surfaces an error message") {
+        // Codex adversarial review round 2 #1. A stored blob that hasKey=true
+        // but extract()=nil must not silently render blank tiles indefinitely.
+        let creds = InMemoryCredentialStore()
+        // Write a value directly (bypassing saveKey's trimming) that
+        // exercises the extract=nil path — a chunked cookie with a bogus
+        // index the overflow guard rejects.
+        creds.write(PerplexityUsageFetcher.cookieKeychainKey,
+                    Data("__Secure-next-auth.session-token.9999999=EVIL".utf8))
+        let store = PerplexityUsageStore(credentials: creds, transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, true)   // presence, not parseability
+        store.fetch()
+        expect(store.errorMessage?.contains("parse") == true || store.errorMessage?.contains("Re-paste") == true)
+    }
+
+    run("Perplexity transport rejects a semicolon-injected cookie name") {
+        // Codex adversarial review round 2 #2. cookieName splicing.
+        let transport = URLSessionPerplexityTransport()
+        final class Box: @unchecked Sendable { var value: PerplexityUsageResult? }
+        let box = Box()
+        transport.fetchAll(cookieName: "__Secure-next-auth.session-token=real; other", cookieValue: "evil") { result in
+            box.value = result
+        }
+        let deadline = Date().addingTimeInterval(2.0)
+        while box.value == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        if case .unauthorized = box.value {
+            expect(true)
+        } else {
+            expect(false, "expected .unauthorized, got \(String(describing: box.value))")
+        }
+    }
+
+    run("Perplexity transport rejects a semicolon-injected cookie value") {
+        // Codex adversarial review #5. A hostile paste like "real; other=evil"
+        // is caught by extract() when the paste is parsed (it becomes a full
+        // header the extractor picks from), but a value with an embedded `;`
+        // arriving DIRECTLY at fetchAll — e.g. an attacker-controlled
+        // Keychain item bypassing extract() — must not silently splice a
+        // second cookie into the request. The production transport rejects.
+        //
+        // The transport dispatches the completion via DispatchQueue.main.async,
+        // so we drive the runloop until it fires rather than blocking on a
+        // semaphore (which would deadlock the main-queue hop).
+        let transport = URLSessionPerplexityTransport()
+        final class Box: @unchecked Sendable { var value: PerplexityUsageResult? }
+        let box = Box()
+        transport.fetchAll(cookieName: "__Secure-next-auth.session-token", cookieValue: "real; other=evil") { result in
+            box.value = result
+        }
+        let deadline = Date().addingTimeInterval(2.0)
+        while box.value == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        if case .unauthorized = box.value {
+            expect(true)
+        } else {
+            expect(false, "expected .unauthorized rejection, got \(String(describing: box.value))")
+        }
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -797,6 +797,42 @@ final class InMemoryCredentialStore: CredentialStore {
     func delete(_ key: String) { storage[key] = nil }
 }
 
+/// A CredentialStore that always reports the keychain as present-but-locked,
+/// to exercise the ".unavailable means still configured" hardening.
+final class UnavailableCredentialStore: CredentialStore {
+    func read(_ key: String) -> Data? { nil }
+    func write(_ key: String, _ value: Data) {}
+    func delete(_ key: String) {}
+    func readResult(_ key: String) -> CredentialReadResult {
+        .unavailable(-25308)  // errSecInteractionNotAllowed
+    }
+}
+
+run("CredentialStore.readResult default maps read() to found/missing") {
+    let store = InMemoryCredentialStore()
+    expectEqual(store.readResult("k"), .missing)
+    store.write("k", Data("v".utf8))
+    expectEqual(store.readResult("k"), .found(Data("v".utf8)))
+}
+
+MainActor.assumeIsolated {
+    let suite = "credavail-\(ProcessInfo.processInfo.processIdentifier)"
+    let d = UserDefaults(suiteName: suite)!
+    d.removePersistentDomain(forName: suite)
+    d.set(true, forKey: "features.deepseek.enabled")
+
+    run("Locked keychain keeps a provider configured (not onboarding)") {
+        // Regression: a locked keychain must NOT look like "no key" and drop
+        // the provider back to the paste-key card.
+        let store = DeepSeekUsageStore(credentials: UnavailableCredentialStore(), defaults: d)
+        expectEqual(store.hasKey, true)         // unavailable == still configured
+        expectEqual(store.isConfigured, true)
+        // No needsAccess onboarding tile while merely locked.
+        expect(!store.tiles.contains { if case .needsAccess = $0.kind { return true }; return false })
+    }
+    d.removePersistentDomain(forName: suite)
+}
+
 MainActor.assumeIsolated {
     let suiteName = "deepseek-tests-\(ProcessInfo.processInfo.processIdentifier)"
     let defaults = UserDefaults(suiteName: suiteName)!
@@ -1051,7 +1087,35 @@ run("ZedCredentials builds a space-delimited Authorization value") {
     let creds = ZedCredentials(userId: "12345", accessToken: "tok-abc")
     expectEqual(creds.authorizationHeaderValue, "12345 tok-abc")
     // Explicitly NOT the Bearer scheme.
-    expect(!creds.authorizationHeaderValue.hasPrefix("Bearer"))
+    expect(creds.authorizationHeaderValue?.hasPrefix("Bearer") == false)
+}
+
+run("ZedCredentials rejects header injection via control chars") {
+    // A user id or token containing CR/LF must not produce a header value
+    // (would allow header splitting/injection).
+    let crlf = ZedCredentials(userId: "12345\r\nX-Evil: 1", accessToken: "tok")
+    expect(crlf.authorizationHeaderValue == nil)
+    let newlineTok = ZedCredentials(userId: "12345", accessToken: "tok\nInjected")
+    expect(newlineTok.authorizationHeaderValue == nil)
+}
+
+run("RequestSafety.pathSegment encodes path-altering characters") {
+    // A benign id passes through (only unreserved chars).
+    expectEqual(RequestSafety.pathSegment("team_abc-123"), "team_abc-123")
+    // Path-structure characters are encoded, not passed through.
+    expectEqual(RequestSafety.pathSegment("a/b"), "a%2Fb")
+    expectEqual(RequestSafety.pathSegment("../admin"), "..%2Fadmin")
+    expectEqual(RequestSafety.pathSegment("x?y#z"), "x%3Fy%23z")
+    // Control characters are rejected entirely.
+    expect(RequestSafety.pathSegment("a\nb") == nil)
+    expect(RequestSafety.pathSegment("") == nil)
+}
+
+run("RequestSafety.headerValue rejects control chars, passes clean values") {
+    expectEqual(RequestSafety.headerValue("user-123"), "user-123")
+    expect(RequestSafety.headerValue("a\rb") == nil)
+    expect(RequestSafety.headerValue("a\nb") == nil)
+    expect(RequestSafety.headerValue("") == nil)
 }
 
 // MARK: - ZedUsageStore (injected credential reader, no real Keychain)
@@ -1321,9 +1385,12 @@ MainActor.assumeIsolated {
     }
 
     run("xAI 401 maps to invalid-key error") {
+        // Assert via the synchronous apply() seam; fetch() now hops through
+        // Task { @MainActor } (safe on any queue) so its effect is not
+        // observable synchronously in this runner.
         let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.unauthorized), defaults: defaults)
         store.saveInferenceKey("xai-bad")
-        store.fetch()
+        store.apply(.unauthorized)
         expectEqual(store.errorMessage, "Invalid xAI API key")
     }
 
@@ -1455,6 +1522,53 @@ run("parse OpenAI rate_limits: per-model ceilings") {
     expectEqual(limits[0].maxTokensPerMinute, 2000000)
 }
 
+run("parse OpenAI survives an out-of-range JSON number without trapping") {
+    // A hostile API sends 1e300 where a token count is expected. Int(Double)
+    // would TRAP; the safe conversion must yield nil -> 0, no crash.
+    let bytes = #"""
+    {"object":"page","data":[{"object":"bucket","results":[
+      {"input_tokens": 1e300, "output_tokens": 5, "num_model_requests": 1, "model": "gpt-4o"}
+    ]}]}
+    """#.data(using: .utf8)!
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(bytes)
+    expectEqual(tokens.count, 1)
+    // input_tokens (1e300) -> nil -> 0; output stays 5.
+    expectEqual(tokens[0].inputTokens, 0)
+    expectEqual(tokens[0].outputTokens, 5)
+}
+
+run("parse OpenAI clamps negative token counts to zero") {
+    let bytes = #"""
+    {"object":"page","data":[{"object":"bucket","results":[
+      {"input_tokens": -100, "output_tokens": 50, "num_model_requests": -3, "model": "gpt-4o"}
+    ]}]}
+    """#.data(using: .utf8)!
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(bytes)
+    expectEqual(tokens[0].inputTokens, 0)   // clamped
+    expectEqual(tokens[0].outputTokens, 50)
+    expectEqual(tokens[0].requests, 0)      // clamped
+}
+
+run("parse xAI balance survives an out-of-range string val without trapping") {
+    // A gigantic numeric string overflows Int -> nil -> parseBalance throws,
+    // rather than trapping or producing a garbage value.
+    let bytes = #"{"total": {"val": "999999999999999999999999999999"}}"#.data(using: .utf8)!
+    do {
+        _ = try XAIUsageFetcher.parseBalance(bytes)
+        expect(false, "expected throw on overflowing val")
+    } catch { expect(true) }
+}
+
+run("parse Zed safeInt handles out-of-range Double without trapping") {
+    // edit_predictions.used = 1e300 must not trap.
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 1e300, "limit": "unlimited"}}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    // used could not be represented -> stays at the default 0, no crash.
+    expectEqual(snap.editPredictions?.used, 0)
+}
+
 run("parse OpenAI completions throws on array top-level") {
     do {
         _ = try OpenAIUsageFetcher.parseCompletions("[]".data(using: .utf8)!)
@@ -1557,9 +1671,11 @@ MainActor.assumeIsolated {
     }
 
     run("OpenAI 401 maps to invalid-admin-key error") {
+        // Assert via the synchronous apply() seam (fetch() now hops through
+        // Task { @MainActor }, not observable synchronously here).
         let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.unauthorized), defaults: defaults)
         store.saveKey("sk-admin-bad")
-        store.fetch()
+        store.apply(.unauthorized)
         expectEqual(store.errorMessage, "Invalid OpenAI Admin key")
     }
 

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -662,6 +662,15 @@ run("ProviderCopy.help returns DeepSeek Keychain guidance") {
     expect(ds?.contains("balance") == true)
 }
 
+run("ProviderCopy.help returns Zed guidance and no disclosure") {
+    let zed = ProviderCopy.help(for: "zed")
+    expect(zed != nil)
+    expect(zed?.contains("edit-prediction") == true)
+    expect(zed?.contains("Keychain") == true)
+    // Zed reads a first-party local credential — no private-API disclosure.
+    expect(ProviderCopy.disclosure(for: "zed") == nil)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1325,6 +1325,202 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - OpenAIUsageFetcher (PR 7-BE)
+
+// Completions usage — bucketed page envelope (verified vs OpenAI Admin API).
+// results grouped by model; multiple buckets aggregate per model.
+let fixtureOpenAICompletions = #"""
+{
+  "object": "page",
+  "has_more": false,
+  "next_page": null,
+  "data": [
+    {
+      "object": "bucket",
+      "start_time": 1751000000,
+      "end_time": 1751003600,
+      "results": [
+        {"object": "organization.usage.completions.result", "input_tokens": 1000, "output_tokens": 500, "num_model_requests": 10, "model": "gpt-4o"},
+        {"object": "organization.usage.completions.result", "input_tokens": 200, "output_tokens": 100, "num_model_requests": 3, "model": "gpt-4o-mini"}
+      ]
+    },
+    {
+      "object": "bucket",
+      "start_time": 1751003600,
+      "end_time": 1751007200,
+      "results": [
+        {"object": "organization.usage.completions.result", "input_tokens": 3000, "output_tokens": 1500, "num_model_requests": 20, "model": "gpt-4o"}
+      ]
+    }
+  ]
+}
+"""#
+
+run("parse OpenAI completions: aggregate tokens by model across buckets") {
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(fixtureOpenAICompletions.data(using: .utf8)!)
+    expectEqual(tokens.count, 2)
+    // gpt-4o: 1000+3000 input, 500+1500 output, 10+20 requests -> highest total, first.
+    expectEqual(tokens[0].model, "gpt-4o")
+    expectEqual(tokens[0].inputTokens, 4000)
+    expectEqual(tokens[0].outputTokens, 2000)
+    expectEqual(tokens[0].requests, 30)
+    expectEqual(tokens[0].totalTokens, 6000)
+    expectEqual(tokens[1].model, "gpt-4o-mini")
+    expectEqual(tokens[1].totalTokens, 300)
+}
+
+run("parse OpenAI completions: results with null model fold into 'all'") {
+    let bytes = #"""
+    {"object": "page", "data": [{"object": "bucket", "results": [{"input_tokens": 5, "output_tokens": 5, "num_model_requests": 1}]}]}
+    """#.data(using: .utf8)!
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(bytes)
+    expectEqual(tokens.count, 1)
+    expectEqual(tokens[0].model, "all")
+    expectEqual(tokens[0].totalTokens, 10)
+}
+
+// Costs — amount.value is a float in USD dollars; currency lowercase "usd".
+let fixtureOpenAICosts = #"""
+{
+  "object": "page",
+  "has_more": false,
+  "data": [
+    {"object": "bucket", "start_time": 1751000000, "end_time": 1751086400, "results": [
+      {"object": "organization.costs.result", "amount": {"value": 0.13080438, "currency": "usd"}, "line_item": "gpt-4o"},
+      {"object": "organization.costs.result", "amount": {"value": 1.25, "currency": "usd"}, "line_item": "gpt-4o-mini"}
+    ]}
+  ]
+}
+"""#
+
+run("parse OpenAI costs: sum amount.value across line items") {
+    let cost = try! OpenAIUsageFetcher.parseCosts(fixtureOpenAICosts.data(using: .utf8)!)
+    expect(abs(cost.usd - 1.38080438) < 0.0001)
+    expectEqual(cost.currency, "usd")
+}
+
+run("parse OpenAI costs: empty buckets -> zero") {
+    let bytes = #"{"object": "page", "data": []}"#.data(using: .utf8)!
+    let cost = try! OpenAIUsageFetcher.parseCosts(bytes)
+    expectEqual(cost.usd, 0.0)
+    expect(cost.currency == nil)
+}
+
+// Rate limits — {object:"list", data:[{model, max_requests_per_1_minute, ...}]}
+let fixtureOpenAIRateLimits = #"""
+{
+  "object": "list",
+  "has_more": false,
+  "data": [
+    {"object": "project.rate_limit", "id": "rl-gpt-4o", "model": "gpt-4o", "max_requests_per_1_minute": 10000, "max_tokens_per_1_minute": 2000000},
+    {"object": "project.rate_limit", "id": "rl-gpt-4o-mini", "model": "gpt-4o-mini", "max_requests_per_1_minute": 30000, "max_tokens_per_1_minute": 150000000}
+  ]
+}
+"""#
+
+run("parse OpenAI rate_limits: per-model ceilings") {
+    let limits = try! OpenAIUsageFetcher.parseRateLimits(fixtureOpenAIRateLimits.data(using: .utf8)!)
+    expectEqual(limits.count, 2)
+    expectEqual(limits[0].model, "gpt-4o")
+    expectEqual(limits[0].maxRequestsPerMinute, 10000)
+    expectEqual(limits[0].maxTokensPerMinute, 2000000)
+}
+
+run("parse OpenAI completions throws on array top-level") {
+    do {
+        _ = try OpenAIUsageFetcher.parseCompletions("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("OpenAI startOfUTCMonth returns a month boundary") {
+    // 2026-07-12 -> start of 2026-07-01 UTC. Just assert it is <= the input
+    // and a plausible epoch (non-zero).
+    let mid = Date(timeIntervalSince1970: 1752300000) // 2026-07-12ish
+    let start = URLSessionOpenAITransport.startOfUTCMonth(mid)
+    expect(start > 0)
+    expect(start <= Int(mid.timeIntervalSince1970))
+}
+
+// MARK: - OpenAIUsageStore
+
+final class StubOpenAITransport: OpenAIUsageTransport, @unchecked Sendable {
+    let result: OpenAIUsageResult
+    init(_ result: OpenAIUsageResult) { self.result = result }
+    func fetchAll(adminKey: String, completion: @escaping @Sendable (OpenAIUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "openai-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.openai.enabled")
+
+    run("OpenAI store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("OpenAI enabled without key emits needsAccess card") {
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("OpenAI conforms to PasteKeyProvider with sk-admin placeholder") {
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.networkError), defaults: defaults)
+        let kp = store as PasteKeyProvider
+        expect(kp.keyPlaceholder.contains("sk-admin"))
+    }
+
+    run("OpenAI applies snapshot: cost + token + ceiling tiles") {
+        let creds = InMemoryCredentialStore()
+        let store = OpenAIUsageStore(credentials: creds, transport: StubOpenAITransport(.networkError), defaults: defaults)
+        store.saveKey("sk-admin-fake")
+        let snap = OpenAIUsageSnapshot(
+            tokensByModel: [OpenAIModelTokens(model: "gpt-4o", inputTokens: 4000, outputTokens: 2000, requests: 30)],
+            costMTDUSD: 12.34,
+            costCurrency: "usd",
+            rateLimits: [OpenAIRateLimit(model: "gpt-4o", maxRequestsPerMinute: 10000, maxTokensPerMinute: 2000000)]
+        )
+        store.apply(.success(snap))
+        let tiles = store.tiles
+        expect(tiles.contains { $0.id == "openai-cost-mtd" })
+        expect(tiles.contains { $0.id == "openai-tokens-gpt-4o" })
+        expect(tiles.contains { $0.id == "openai-ceiling-gpt-4o" })
+        // MTD cost tile shows the currency + amount.
+        let costTile = tiles.first { $0.id == "openai-cost-mtd" }
+        if case let .text(status, _) = costTile?.kind { expect(status.contains("12.34")) }
+        else { expect(false, "expected cost text tile") }
+    }
+
+    run("OpenAI 401 maps to invalid-admin-key error") {
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.unauthorized), defaults: defaults)
+        store.saveKey("sk-admin-bad")
+        store.fetch()
+        expectEqual(store.errorMessage, "Invalid OpenAI Admin key")
+    }
+
+    run("OpenAI clear deletes the key and state") {
+        let creds = InMemoryCredentialStore()
+        let store = OpenAIUsageStore(credentials: creds, transport: StubOpenAITransport(.networkError), defaults: defaults)
+        store.saveKey("sk-admin-fake")
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(creds.read(OpenAIUsageFetcher.adminKeyKeychainKey) == nil)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1221,8 +1221,25 @@ run("parse xAI usage daily buckets (dollar and cents forms)") {
     """#.data(using: .utf8)!
     let daily = try! XAIUsageFetcher.parseUsage(bytes)
     expectEqual(daily.count, 2)
-    expect(abs(daily[0].usdSpent - 1.50) < 0.001)
-    expect(abs(daily[1].usdSpent - 2.75) < 0.001)  // 275 cents
+    expect(abs(daily[0].amountSpent - 1.50) < 0.001)
+    expect(abs(daily[1].amountSpent - 2.75) < 0.001)  // 275 cents
+    // No currency reported in this fixture.
+    expect(daily[0].currency == nil)
+}
+
+run("parse xAI usage carries a non-USD currency when reported") {
+    // The daily-usage shape is undocumented and may bill in CNY. When a
+    // currency is present the parser must surface it so the tile does not
+    // assume a "$" symbol (audit finding: hardcoded $ on the daily tile).
+    let bytes = #"""
+    {"usage": [
+      {"date": "2026-07-10", "amount": 12.50, "currency": "CNY"}
+    ]}
+    """#.data(using: .utf8)!
+    let daily = try! XAIUsageFetcher.parseUsage(bytes)
+    expectEqual(daily.count, 1)
+    expect(abs(daily[0].amountSpent - 12.50) < 0.001)
+    expectEqual(daily[0].currency, "CNY")
 }
 
 run("parse xAI api-key throws on array top-level") {
@@ -1445,13 +1462,34 @@ run("parse OpenAI completions throws on array top-level") {
     } catch { expect(true) }
 }
 
-run("OpenAI startOfUTCMonth returns a month boundary") {
-    // 2026-07-12 -> start of 2026-07-01 UTC. Just assert it is <= the input
-    // and a plausible epoch (non-zero).
-    let mid = Date(timeIntervalSince1970: 1752300000) // 2026-07-12ish
+run("OpenAI startOfUTCMonth returns the exact 1st-of-month UTC epoch") {
+    // 1752300000 = 2025-07-12T06:00:00Z. Start of 2025-07 UTC = 1751328000.
+    // Assert the EXACT boundary, not just start <= input (a loose bound would
+    // pass even for a wrong value — audit finding on the prior test).
+    let mid = Date(timeIntervalSince1970: 1752300000) // 2025-07-12T06:00:00Z
     let start = URLSessionOpenAITransport.startOfUTCMonth(mid)
-    expect(start > 0)
-    expect(start <= Int(mid.timeIntervalSince1970))
+    expectEqual(start, 1751328000)  // 2025-07-01T00:00:00Z
+}
+
+run("OpenAI completionsQuery uses a TRUE rolling 24h (1h buckets, limit 24)") {
+    // Audit finding: bucket_width=1d + start_time=now-24h returns up to ~48h.
+    // The fixed query must use hourly buckets bounded to 24 for a real 24h.
+    let now = Date(timeIntervalSince1970: 1752300000)
+    let q = URLSessionOpenAITransport.completionsQuery(now: now)
+    expect(q.contains("bucket_width=1h"))
+    expect(q.contains("limit=24"))
+    expect(q.contains("group_by=model"))
+    expect(q.contains("start_time=1752213600"))  // now - 24h
+    // It must NOT use the day-bucket that caused the over-count.
+    expect(!q.contains("bucket_width=1d"))
+}
+
+run("OpenAI costsQuery covers month-to-date from the UTC month start") {
+    let now = Date(timeIntervalSince1970: 1752300000)
+    let q = URLSessionOpenAITransport.costsQuery(now: now)
+    expect(q.contains("bucket_width=1d"))
+    expect(q.contains("limit=31"))               // covers the longest month in one page
+    expect(q.contains("start_time=1751328000"))  // start of 2025-07 UTC
 }
 
 // MARK: - OpenAIUsageStore
@@ -1508,10 +1546,14 @@ MainActor.assumeIsolated {
         expect(tiles.contains { $0.id == "openai-cost-mtd" })
         expect(tiles.contains { $0.id == "openai-tokens-gpt-4o" })
         expect(tiles.contains { $0.id == "openai-ceiling-gpt-4o" })
-        // MTD cost tile shows the currency + amount.
+        // MTD cost tile shows the currency + amount, with the API's lowercase
+        // "usd" uppercased for display (audit finding on currency case).
         let costTile = tiles.first { $0.id == "openai-cost-mtd" }
-        if case let .text(status, _) = costTile?.kind { expect(status.contains("12.34")) }
-        else { expect(false, "expected cost text tile") }
+        if case let .text(status, _) = costTile?.kind {
+            expect(status.contains("12.34"))
+            expect(status.contains("USD"))       // uppercased
+            expect(!status.contains("usd"))      // not the raw lowercase
+        } else { expect(false, "expected cost text tile") }
     }
 
     run("OpenAI 401 maps to invalid-admin-key error") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1,11 +1,13 @@
-// PR 2a — assertion-based test runner.
+// PR 2a + PR 2b — assertion-based test runner.
 //
 // Runs with `swift run TestRunner` from the repo root. Works with
 // Command Line Tools alone; does not require Xcode.app / XCTest.
 // Prints one line per test and exits nonzero if any assertion fails.
 //
-// When Xcode.app is installed, this runner can be promoted to XCTest
-// or Apple's Testing framework without changing the assertion bodies.
+// PR 2a added LogValue tests. PR 2b adds AnthropicUsageFetcher tests
+// covering every branch of the parser against synthetic fixtures whose
+// shape matches the documented claude.ai /api/organizations/{org}/usage
+// response.
 
 import Foundation
 import ClaudeUsageBar
@@ -69,9 +71,7 @@ run("LogValue.sensitive never emits the raw value") {
 }
 
 run("LogValue.identifier emits short SHA-256 prefix") {
-    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
     expectEqual(LogValue.identifier("hello").rendered, "<id: 2cf24dba>")
-    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     expectEqual(LogValue.identifier("").rendered, "<id: e3b0c442>")
 }
 
@@ -100,6 +100,202 @@ run("LogValue.count emits numeric literal") {
     expectEqual(LogValue.count(42).rendered, "42")
     expectEqual(LogValue.count(-1).rendered, "-1")
     expectEqual(LogValue.count(823).rendered, "823")
+}
+
+// MARK: - AnthropicUsageFetcher.orgId(fromCookieString:)
+
+run("orgId returns nil when lastActiveOrg is absent") {
+    let cookie = "sessionKey=abc; foo=bar"
+    expect(AnthropicUsageFetcher.orgId(fromCookieString: cookie) == nil)
+}
+
+run("orgId extracts value from lastActiveOrg") {
+    let cookie = "sessionKey=abc; lastActiveOrg=8f2c3d1a-e5b9; foo=bar"
+    expectEqual(
+        AnthropicUsageFetcher.orgId(fromCookieString: cookie),
+        "8f2c3d1a-e5b9"
+    )
+}
+
+run("orgId trims whitespace around each cookie part") {
+    let cookie = "  lastActiveOrg=  8f2c ; foo=bar"
+    // The extractor trims each semicolon-separated part before matching
+    // the `lastActiveOrg=` prefix. The trailing space in "  8f2c " is
+    // consumed by that trim. Leading spaces inside the value survive
+    // because the prefix drop is exact-length. This matches the
+    // pre-refactor behaviour byte-for-byte (which used the same
+    // trimmingCharacters + replacingOccurrences sequence).
+    let out = AnthropicUsageFetcher.orgId(fromCookieString: cookie)
+    expectEqual(out, "  8f2c")
+}
+
+run("orgId returns nil on empty cookie") {
+    expect(AnthropicUsageFetcher.orgId(fromCookieString: "") == nil)
+}
+
+// MARK: - AnthropicUsageFetcher.parse — happy path fixtures
+
+// Fixture 1: minimum shape — five_hour and seven_day only, no Sonnet,
+// no Fable in limits[]. This is what a Free plan account looks like.
+let fixtureFreeMinimal = #"""
+{
+  "five_hour":  {"utilization": 42.3, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 17.8, "resets_at": "2026-07-18T00:00:00.000Z"}
+}
+"""#
+
+run("parse Free-plan minimal fixture") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFreeMinimal.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 42)
+    expectEqual(snap.weeklyUsage, 17)
+    expectEqual(snap.hasWeeklySonnet, false)
+    expectEqual(snap.weeklySonnetUsage, 0)
+    expectEqual(snap.hasWeeklyFable, false)
+    expectEqual(snap.weeklyFableUsage, 0)
+    expect(snap.sessionResetsAt != nil)
+    expect(snap.weeklyResetsAt != nil)
+    expect(snap.weeklySonnetResetsAt == nil)
+    expect(snap.weeklyFableResetsAt == nil)
+}
+
+// Fixture 2: Pro plan with Sonnet bucket present.
+let fixtureProWithSonnet = #"""
+{
+  "five_hour":         {"utilization": 55.5, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":         {"utilization": 33.3, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "seven_day_sonnet":  {"utilization": 12.9, "resets_at": "2026-07-18T00:00:00.000Z"}
+}
+"""#
+
+run("parse Pro-plan Sonnet fixture") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureProWithSonnet.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 55)
+    expectEqual(snap.weeklyUsage, 33)
+    expectEqual(snap.hasWeeklySonnet, true)
+    expectEqual(snap.weeklySonnetUsage, 12)
+    expectEqual(snap.hasWeeklyFable, false)
+}
+
+// Fixture 3: Fable present in limits[] with percent as Int.
+let fixtureFableInt = #"""
+{
+  "five_hour":  {"utilization": 60.0, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 40.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Opus"}}, "percent": 5, "resets_at": "2026-07-18T00:00:00.000Z"},
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 7, "resets_at": "2026-07-18T00:00:00.000Z"}
+  ]
+}
+"""#
+
+run("parse Fable fixture with percent as Int") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFableInt.data(using: .utf8)!)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 7)
+    expect(snap.weeklyFableResetsAt != nil)
+}
+
+// Fixture 4: Fable present with percent as Double (documented variant).
+let fixtureFableDouble = #"""
+{
+  "five_hour":  {"utilization": 60.0, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 40.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 12.7, "resets_at": "2026-07-18T00:00:00.000Z"}
+  ]
+}
+"""#
+
+run("parse Fable fixture with percent as Double") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFableDouble.data(using: .utf8)!)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 12)
+}
+
+// Fixture 5: full — Sonnet, Fable, Opus in limits, etc. All buckets present.
+let fixtureFull = #"""
+{
+  "five_hour":         {"utilization": 88.4, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":         {"utilization": 71.2, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "seven_day_sonnet":  {"utilization": 44.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 23, "resets_at": "2026-07-18T00:00:00.000Z"},
+    {"scope": {"model": {"display_name": "Opus"}}, "percent": 15}
+  ]
+}
+"""#
+
+run("parse full fixture with every bucket populated") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFull.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 88)
+    expectEqual(snap.weeklyUsage, 71)
+    expectEqual(snap.hasWeeklySonnet, true)
+    expectEqual(snap.weeklySonnetUsage, 44)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 23)
+}
+
+// MARK: - AnthropicUsageFetcher.parse — error paths
+
+run("parse throws invalidJSON on empty body") {
+    do {
+        _ = try AnthropicUsageFetcher.parse(Data())
+        expect(false, "expected throw on empty body")
+    } catch {
+        expect(true)
+    }
+}
+
+run("parse throws invalidJSON on malformed body") {
+    let bytes = "not json at all".data(using: .utf8)!
+    do {
+        _ = try AnthropicUsageFetcher.parse(bytes)
+        expect(false, "expected throw on malformed body")
+    } catch {
+        expect(true)
+    }
+}
+
+run("parse throws invalidJSON on non-object top-level") {
+    let bytes = "[1,2,3]".data(using: .utf8)!
+    do {
+        _ = try AnthropicUsageFetcher.parse(bytes)
+        expect(false, "expected throw on array top-level")
+    } catch {
+        expect(true)
+    }
+}
+
+// MARK: - AnthropicUsageFetcher.parse — degenerate but non-throwing shapes
+
+run("parse tolerates empty JSON object (all fields default)") {
+    let snap = try! AnthropicUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 0)
+    expectEqual(snap.weeklyUsage, 0)
+    expectEqual(snap.hasWeeklySonnet, false)
+    expectEqual(snap.hasWeeklyFable, false)
+    expect(snap.sessionResetsAt == nil)
+}
+
+run("parse tolerates missing resets_at strings") {
+    let bytes = #"""
+    {"five_hour": {"utilization": 10.0}, "seven_day": {"utilization": 5.0}}
+    """#.data(using: .utf8)!
+    let snap = try! AnthropicUsageFetcher.parse(bytes)
+    expectEqual(snap.sessionUsage, 10)
+    expectEqual(snap.weeklyUsage, 5)
+    expect(snap.sessionResetsAt == nil)
+    expect(snap.weeklyResetsAt == nil)
+}
+
+run("parse ignores non-Fable entries in limits[]") {
+    let bytes = #"""
+    {"five_hour": {"utilization": 0}, "seven_day": {"utilization": 0},
+     "limits": [{"scope": {"model": {"display_name": "Sonnet"}}, "percent": 42}]}
+    """#.data(using: .utf8)!
+    let snap = try! AnthropicUsageFetcher.parse(bytes)
+    expectEqual(snap.hasWeeklyFable, false)
+    expectEqual(snap.weeklyFableUsage, 0)
 }
 
 // MARK: - Summary

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2177,6 +2177,24 @@ MainActor.assumeIsolated {
         }
     }
 
+    run("Perplexity credits tile: recurring grant matched case-insensitively (chk1 Bug #4)") {
+        // Guard against a Perplexity schema tweak that changes the casing
+        // of the grant type from "recurring" to "Recurring". Without a
+        // case-insensitive compare the recurring total would collapse to 0
+        // and the plan hint would silently disappear.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            balanceCents: 100,
+            grants: [PerplexityCreditGrant(type: "Recurring", amountCents: 50000, expiresAtEpoch: nil)]
+        )
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "perplexity-credits" })?.kind {
+            expectEqual(plan, "Max")
+        } else { expect(false, "expected balance tile") }
+    }
+
     run("Perplexity credits tile: Pro plan hint from a $50-tier recurring grant") {
         // Codex adversarial review #3: the initial 5 000c threshold flipped
         // Pro users to "Max" — a $50 grant must still register as Pro.

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -654,6 +654,239 @@ run("ProviderCopy.disclosure warns about the private API for Codex only") {
     expect(ProviderCopy.disclosure(for: "deepseek") == nil)
 }
 
+// MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
+
+// Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
+// bool, balance_infos[] with currency + three STRING amounts.
+let fixtureDeepSeekUSD = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "USD", "total_balance": "110.00", "granted_balance": "10.00", "topped_up_balance": "100.00"}
+  ]
+}
+"""#
+
+run("parse DeepSeek USD balance (strings preserved verbatim)") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekUSD.data(using: .utf8)!)
+    expectEqual(snap.isAvailable, true)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "USD")
+    expectEqual(snap.balances[0].totalBalance, "110.00")
+    expectEqual(snap.balances[0].grantedBalance, "10.00")
+    expectEqual(snap.balances[0].toppedUpBalance, "100.00")
+}
+
+let fixtureDeepSeekCNY = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "CNY", "total_balance": "550.5", "granted_balance": "0", "topped_up_balance": "550.5"}
+  ]
+}
+"""#
+
+run("parse DeepSeek CNY balance") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekCNY.data(using: .utf8)!)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "CNY")
+    expectEqual(snap.balances[0].totalBalance, "550.5")
+}
+
+let fixtureDeepSeekDual = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "USD", "total_balance": "5.00", "granted_balance": "5.00", "topped_up_balance": "0"},
+    {"currency": "CNY", "total_balance": "36.00", "granted_balance": "36.00", "topped_up_balance": "0"}
+  ]
+}
+"""#
+
+run("parse DeepSeek dual-currency balance_infos") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekDual.data(using: .utf8)!)
+    expectEqual(snap.balances.count, 2)
+    expectEqual(snap.balances[0].currency, "USD")
+    expectEqual(snap.balances[1].currency, "CNY")
+}
+
+run("parse DeepSeek is_available false") {
+    let bytes = #"{"is_available": false, "balance_infos": []}"#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.isAvailable, false)
+    expectEqual(snap.balances.count, 0)
+}
+
+run("parse DeepSeek accepts numeric amounts defensively") {
+    // The documented API returns strings; accept numbers too so a server
+    // change does not drop the value.
+    let bytes = #"""
+    {"is_available": true, "balance_infos": [{"currency": "USD", "total_balance": 42, "granted_balance": 0, "topped_up_balance": 42.5}]}
+    """#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.balances[0].totalBalance, "42")
+    expectEqual(snap.balances[0].toppedUpBalance, "42.5")
+}
+
+run("parse DeepSeek skips entries with no currency") {
+    let bytes = #"""
+    {"is_available": true, "balance_infos": [{"total_balance": "1.00"}, {"currency": "USD", "total_balance": "2.00", "granted_balance": "0", "topped_up_balance": "2.00"}]}
+    """#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "USD")
+}
+
+run("parse DeepSeek tolerates empty object") {
+    let snap = try! DeepSeekUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.isAvailable, false)
+    expectEqual(snap.balances.count, 0)
+}
+
+run("parse DeepSeek throws on array top-level") {
+    do {
+        _ = try DeepSeekUsageFetcher.parse("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - DeepSeekUsageStore (via in-memory CredentialStore)
+
+/// In-memory CredentialStore so store tests never touch the real Keychain
+/// (which could prompt or persist). Deterministic and isolated.
+final class InMemoryCredentialStore: CredentialStore {
+    private var storage: [String: Data] = [:]
+    func read(_ key: String) -> Data? { storage[key] }
+    func write(_ key: String, _ value: Data) { storage[key] = value }
+    func delete(_ key: String) { storage[key] = nil }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "deepseek-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.deepseek.enabled")
+
+    run("DeepSeek store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("DeepSeek enabled but no key emits needsAccess tile") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        expectEqual(store.isEnabled, true)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("DeepSeek saveKey stores in credential store and configures") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        expectEqual(store.hasKey, false)
+        store.saveKey("  sk-fake-deepseek-key  ")  // trimmed
+        expectEqual(store.hasKey, true)
+        expectEqual(store.isConfigured, true)
+        // The stored value is trimmed.
+        let stored = String(data: creds.read(DeepSeekUsageStore.apiKeyKeychainKey)!, encoding: .utf8)
+        expectEqual(stored, "sk-fake-deepseek-key")
+    }
+
+    run("DeepSeek saveKey with empty string clears the key") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        expectEqual(store.hasKey, true)
+        store.saveKey("   ")
+        expectEqual(store.hasKey, false)
+    }
+
+    run("DeepSeek applies USD balance and renders a balance tile") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        store.apply(.success(fixtureDeepSeekUSD.data(using: .utf8)!))
+        expect(store.lastUpdated != nil)
+        expect(store.errorMessage == nil)
+        let tiles = store.tiles
+        // Available == true so no status tile; one balance tile.
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles[0].id, "deepseek-balance-usd")
+        if case let .text(status, subtitle) = tiles[0].kind {
+            expectEqual(status, "USD 110.00")
+            expectEqual(subtitle, "Granted 10.00 + topped-up 100.00")
+        } else { expect(false, "expected text tile") }
+    }
+
+    run("DeepSeek unavailable balance adds an amber status tile") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        let bytes = #"{"is_available": false, "balance_infos": [{"currency": "USD", "total_balance": "0.00", "granted_balance": "0", "topped_up_balance": "0"}]}"#.data(using: .utf8)!
+        store.apply(.success(bytes))
+        let tiles = store.tiles
+        // status tile + balance tile
+        expectEqual(tiles.count, 2)
+        expectEqual(tiles[0].id, "deepseek-status")
+    }
+
+    run("DeepSeek 401 maps to invalid-key error") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        store.apply(.unauthorized)
+        expectEqual(store.errorMessage, "Invalid DeepSeek API key")
+    }
+
+    run("DeepSeek httpError and networkError map to messages") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        store.apply(.httpError(500))
+        expectEqual(store.errorMessage, "HTTP 500")
+        store.apply(.networkError)
+        expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("DeepSeek clear deletes the key and state") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        store.apply(.success(fixtureDeepSeekUSD.data(using: .utf8)!))
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(store.snapshot == nil)
+        expect(creds.read(DeepSeekUsageStore.apiKeyKeychainKey) == nil)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
+// MARK: - KeychainStore round-trip (guarded — real Keychain may be absent)
+
+// Uses a throwaway service so the test never collides with real credentials,
+// and cleans up. In a headless CI keychain SecItemAdd can fail (errSecMissing
+// Entitlement / no keychain); in that case read returns nil and we skip the
+// positive assertions rather than fail the suite.
+run("KeychainStore round-trips when a keychain is available") {
+    let store = KeychainStore(service: "com.claude.usagebar.test-\(ProcessInfo.processInfo.processIdentifier)")
+    let key = "roundtrip-key"
+    let value = Data("sk-fake-value".utf8)
+    store.delete(key)  // clean slate
+    store.write(key, value)
+    if let read = store.read(key) {
+        // Keychain available — verify round-trip and delete.
+        expectEqual(read, value)
+        store.delete(key)
+        expect(store.read(key) == nil)
+    } else {
+        // No keychain in this environment (headless CI) — not a failure of
+        // KeychainStore logic. Record a pass so the suite total stays honest.
+        expect(true)
+    }
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -678,6 +678,18 @@ run("ProviderCopy.help returns xAI two-key guidance") {
     expect(xai?.contains("management key") == true)
 }
 
+run("ProviderCopy: OpenAI help + admin-key disclosure") {
+    let help = ProviderCopy.help(for: "openai")
+    expect(help != nil)
+    expect(help?.contains("Admin key") == true)
+    expect(help?.contains("month-to-date") == true)
+    // Admin keys are high-privilege — a disclosure warning is required.
+    let disc = ProviderCopy.disclosure(for: "openai")
+    expect(disc != nil)
+    expect(disc?.contains("manage users") == true)
+    expect(disc?.contains("cannot make inference") == true)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -651,7 +651,15 @@ run("ProviderCopy.disclosure warns about the private API for Codex only") {
     expect(codex?.contains("private Codex API") == true)
     expect(codex?.contains("without notice") == true)
     expect(ProviderCopy.disclosure(for: "anthropic") == nil)
+    // DeepSeek uses a documented, stable API — no private-API disclosure.
     expect(ProviderCopy.disclosure(for: "deepseek") == nil)
+}
+
+run("ProviderCopy.help returns DeepSeek Keychain guidance") {
+    let ds = ProviderCopy.help(for: "deepseek")
+    expect(ds != nil)
+    expect(ds?.contains("Keychain") == true)
+    expect(ds?.contains("balance") == true)
 }
 
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
@@ -847,6 +855,15 @@ MainActor.assumeIsolated {
         expectEqual(store.errorMessage, "HTTP 500")
         store.apply(.networkError)
         expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("DeepSeek conforms to PasteKeyProvider with sk- placeholder") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        let keyProvider = store as PasteKeyProvider
+        expect(keyProvider.keyPlaceholder.contains("sk"))
+        expectEqual(keyProvider.hasKey, false)
+        keyProvider.saveKey("sk-fake")
+        expectEqual(keyProvider.hasKey, true)
     }
 
     run("DeepSeek clear deletes the key and state") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2450,23 +2450,43 @@ MainActor.assumeIsolated {
     }
     #endif
 
-    run("Perplexity multi-endpoint partial success emits available tiles (chk1 Omission #2)") {
-        // Locks in the "success-when-any-endpoint-succeeded" behaviour.
-        // Concretely: even if rate-limits and settings return non-2xx, a
-        // 200 on credits still surfaces the credits tile — the failure of
-        // the others is not permitted to blank the whole provider.
+    run("Perplexity partial-success snapshot renders only the tiles it carries (chk1 Omission #2 — store apply)") {
+        // Store-layer assertion: given a snapshot that carries only credits
+        // (as the accumulator would produce when rateLimits and settings
+        // endpoints failed), the tile mapper must not paper over the gap
+        // with plan/mode tiles. Complements the accumulator-side test below.
         let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
         store.saveKey("cookie")
         var snap = PerplexityUsageSnapshot()
         snap.credits = PerplexityCredits(balanceCents: 4235.50, renewalEpoch: 1770000000)
-        // rateLimits and settings intentionally left nil (as though those
-        // endpoints returned 429/500 and were dropped by the accumulator).
         store.apply(.success(snap))
         expect(store.tiles.contains { $0.id == "perplexity-credits" })
         expect(!store.tiles.contains { $0.id == "perplexity-plan" })
         expect(!store.tiles.contains { $0.id == "perplexity-pro" })
         expect(!store.tiles.contains { $0.id == "perplexity-research" })
     }
+
+    #if DEBUG
+    run("Perplexity accumulator finalizes partial-success correctly (chk1 Omission #2 — accumulator)") {
+        // Transport-layer assertion (Codex round-4 finding #3): the
+        // accumulator itself, given credits-set + rateLimits-not-set +
+        // settings-not-set + one rateLimits httpError(429), returns
+        // (unauthorized: false, httpError: 429 remembered, snapshot with
+        // only credits populated). This exercises the code path the
+        // production transport uses, complementing the store-level test.
+        let acc = PerplexityFetchAccumulator()
+        acc.setCredits(PerplexityCredits(balanceCents: 4235.50, renewalEpoch: 1770000000))
+        acc.recordHttpError(429)                    // rate-limit endpoint 429'd
+        acc.recordHttpError(500)                    // settings endpoint 5xx'd
+        let (unauthorized, httpError, snap) = acc.finalize()
+        expectEqual(unauthorized, false)
+        // 429 wins the priority ranking over the 500.
+        expectEqual(httpError, 429)
+        expect(snap.credits != nil)
+        expect(snap.rateLimits == nil)
+        expect(snap.settings == nil)
+    }
+    #endif
 
     run("Perplexity fetch() background-delivered success reaches @Published snapshot (chk1 Omission #3)") {
         // Round-1 tests covered background-queue delivery of .unauthorized,

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2433,6 +2433,66 @@ MainActor.assumeIsolated {
         }
     }
 
+    #if DEBUG
+    run("Perplexity accumulator priority: 429 beats 5xx beats other 4xx (chk1 Omission #1)") {
+        // Locks in the priority ordering so a future edit that flipped
+        // the recordHttpError branches would fail this test.
+        let acc = PerplexityFetchAccumulator()
+        expect(acc.currentHttpError == nil)
+        acc.recordHttpError(418)
+        expectEqual(acc.currentHttpError, 418)
+        acc.recordHttpError(500)
+        expectEqual(acc.currentHttpError, 500)   // 5xx > other 4xx
+        acc.recordHttpError(429)
+        expectEqual(acc.currentHttpError, 429)   // 429 > 5xx
+        acc.recordHttpError(503)
+        expectEqual(acc.currentHttpError, 429)   // 429 sticks (does not degrade)
+    }
+    #endif
+
+    run("Perplexity multi-endpoint partial success emits available tiles (chk1 Omission #2)") {
+        // Locks in the "success-when-any-endpoint-succeeded" behaviour.
+        // Concretely: even if rate-limits and settings return non-2xx, a
+        // 200 on credits still surfaces the credits tile — the failure of
+        // the others is not permitted to blank the whole provider.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 4235.50, renewalEpoch: 1770000000)
+        // rateLimits and settings intentionally left nil (as though those
+        // endpoints returned 429/500 and were dropped by the accumulator).
+        store.apply(.success(snap))
+        expect(store.tiles.contains { $0.id == "perplexity-credits" })
+        expect(!store.tiles.contains { $0.id == "perplexity-plan" })
+        expect(!store.tiles.contains { $0.id == "perplexity-pro" })
+        expect(!store.tiles.contains { $0.id == "perplexity-research" })
+    }
+
+    run("Perplexity fetch() background-delivered success reaches @Published snapshot (chk1 Omission #3)") {
+        // Round-1 tests covered background-queue delivery of .unauthorized,
+        // but not of .success. Cover the common-case path so a future edit
+        // that reintroduced MainActor.assumeIsolated in apply() would trap
+        // and fail this test.
+        final class BackgroundSuccessTransport: PerplexityUsageTransport, @unchecked Sendable {
+            func fetchAll(cookieName: String, cookieValue: String, completion: @escaping @Sendable (PerplexityUsageResult) -> Void) {
+                DispatchQueue.global().async {
+                    var s = PerplexityUsageSnapshot()
+                    s.credits = PerplexityCredits(balanceCents: 500, renewalEpoch: 1770000000)
+                    completion(.success(s))
+                }
+            }
+        }
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: BackgroundSuccessTransport(), defaults: defaults)
+        store.saveKey("cookie")
+        store.fetch()
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.snapshot == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot != nil)
+        expectEqual(store.snapshot?.credits?.balanceCents, 500)
+    }
+
     run("Perplexity transport rejects a semicolon-injected cookie value") {
         // Codex adversarial review #5. A hostile paste like "real; other=evil"
         // is caught by extract() when the paste is parsed (it becomes a full

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -632,6 +632,28 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - ProviderCopy (Settings toggle copy — PR 3-UI)
+
+run("ProviderCopy.help returns Codex copy and nil for unknown") {
+    let codex = ProviderCopy.help(for: "codex")
+    expect(codex != nil)
+    expect(codex?.contains("Codex CLI") == true)
+    expect(codex?.contains("General GPT chat is not counted") == true)
+    // Honest-labels invariant: never claim to track general ChatGPT usage.
+    expect(codex?.contains("ChatGPT usage") == false)
+    expect(ProviderCopy.help(for: "anthropic") == nil)
+    expect(ProviderCopy.help(for: "unknown-provider") == nil)
+}
+
+run("ProviderCopy.disclosure warns about the private API for Codex only") {
+    let codex = ProviderCopy.disclosure(for: "codex")
+    expect(codex != nil)
+    expect(codex?.contains("private Codex API") == true)
+    expect(codex?.contains("without notice") == true)
+    expect(ProviderCopy.disclosure(for: "anthropic") == nil)
+    expect(ProviderCopy.disclosure(for: "deepseek") == nil)
+}
+
 // MARK: - Summary
 
 print("")

--- a/app/AnthropicUsageFetcher.swift
+++ b/app/AnthropicUsageFetcher.swift
@@ -1,0 +1,153 @@
+// PR 2b — Anthropic usage fetcher.
+//
+// Extracted from UsageManager. Sendable value type. No observable state,
+// no delegates, no side effects. Takes raw response bytes, returns a
+// parsed AnthropicUsageSnapshot. All HTTP concerns are handled by
+// AnthropicUsageFetcher.fetch(cookie:); the caller decides how to apply
+// the snapshot on the main actor.
+//
+// This split keeps the fetcher testable without depending on UI, timers,
+// AppKit, or the delegate. The unit tests in Tests/TestRunner feed known
+// JSON bytes and lock in the exact parsed output.
+
+import Foundation
+
+/// A parsed snapshot of the claude.ai `/api/organizations/{org}/usage`
+/// response. Every field is optional in the same shape the endpoint
+/// itself returns — a Free-plan account has no `seven_day_sonnet`,
+/// a non-Fable account has no Fable entry in `limits[]`.
+public struct AnthropicUsageSnapshot: Equatable, Sendable {
+    public var sessionUsage: Int
+    public var sessionResetsAt: Date?
+
+    public var weeklyUsage: Int
+    public var weeklyResetsAt: Date?
+
+    public var hasWeeklySonnet: Bool
+    public var weeklySonnetUsage: Int
+    public var weeklySonnetResetsAt: Date?
+
+    public var hasWeeklyFable: Bool
+    public var weeklyFableUsage: Int
+    public var weeklyFableResetsAt: Date?
+
+    public init(
+        sessionUsage: Int = 0,
+        sessionResetsAt: Date? = nil,
+        weeklyUsage: Int = 0,
+        weeklyResetsAt: Date? = nil,
+        hasWeeklySonnet: Bool = false,
+        weeklySonnetUsage: Int = 0,
+        weeklySonnetResetsAt: Date? = nil,
+        hasWeeklyFable: Bool = false,
+        weeklyFableUsage: Int = 0,
+        weeklyFableResetsAt: Date? = nil
+    ) {
+        self.sessionUsage = sessionUsage
+        self.sessionResetsAt = sessionResetsAt
+        self.weeklyUsage = weeklyUsage
+        self.weeklyResetsAt = weeklyResetsAt
+        self.hasWeeklySonnet = hasWeeklySonnet
+        self.weeklySonnetUsage = weeklySonnetUsage
+        self.weeklySonnetResetsAt = weeklySonnetResetsAt
+        self.hasWeeklyFable = hasWeeklyFable
+        self.weeklyFableUsage = weeklyFableUsage
+        self.weeklyFableResetsAt = weeklyFableResetsAt
+    }
+}
+
+public enum AnthropicUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+/// Pure parser and HTTP client for claude.ai's usage endpoint. Value type
+/// with no observable state — all callers receive a snapshot and apply it
+/// themselves.
+public struct AnthropicUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: - Pure parsing (this is what the tests hit)
+
+    /// Parse the JSON body of a `/api/organizations/{org}/usage` response.
+    /// Preserves the historical behaviour of UsageManager.parseUsageData
+    /// exactly — every branch (missing five_hour, Sonnet absent, Fable in
+    /// limits[], Fable percent as Int vs Double) is a fixture in the test
+    /// suite so future refactors cannot silently regress.
+    public static func parse(_ data: Data) throws -> AnthropicUsageSnapshot {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AnthropicUsageParseError.invalidJSON
+        }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var snap = AnthropicUsageSnapshot()
+
+        if let fiveHour = json["five_hour"] as? [String: Any] {
+            if let util = fiveHour["utilization"] as? Double {
+                snap.sessionUsage = Int(util)
+            }
+            if let s = fiveHour["resets_at"] as? String {
+                snap.sessionResetsAt = iso.date(from: s)
+            }
+        }
+
+        if let sevenDay = json["seven_day"] as? [String: Any] {
+            if let util = sevenDay["utilization"] as? Double {
+                snap.weeklyUsage = Int(util)
+            }
+            if let s = sevenDay["resets_at"] as? String {
+                snap.weeklyResetsAt = iso.date(from: s)
+            }
+        }
+
+        if let sonnet = json["seven_day_sonnet"] as? [String: Any] {
+            snap.hasWeeklySonnet = true
+            if let util = sonnet["utilization"] as? Double {
+                snap.weeklySonnetUsage = Int(util)
+            }
+            if let s = sonnet["resets_at"] as? String {
+                snap.weeklySonnetResetsAt = iso.date(from: s)
+            }
+        }
+
+        // Fable lives inside limits[] where scope.model.display_name == "Fable".
+        // Not surfaced by UI until usage >= 1% — that decision is in the view
+        // layer, not here. `percent` may decode as Int or Double.
+        if let limits = json["limits"] as? [[String: Any]] {
+            if let fable = limits.first(where: { entry in
+                let scope = entry["scope"] as? [String: Any]
+                let model = scope?["model"] as? [String: Any]
+                return (model?["display_name"] as? String) == "Fable"
+            }) {
+                snap.hasWeeklyFable = true
+                if let p = fable["percent"] as? Int {
+                    snap.weeklyFableUsage = p
+                } else if let p = fable["percent"] as? Double {
+                    snap.weeklyFableUsage = Int(p)
+                }
+                if let s = fable["resets_at"] as? String {
+                    snap.weeklyFableResetsAt = iso.date(from: s)
+                }
+            }
+        }
+
+        return snap
+    }
+
+    // MARK: - Org-id discovery
+
+    /// Extract the org id from the `lastActiveOrg=...` cookie value, if
+    /// present. Returns nil when the cookie does not carry it.
+    public static func orgId(fromCookieString raw: String) -> String? {
+        for part in raw.components(separatedBy: ";") {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("lastActiveOrg=") {
+                return String(trimmed.dropFirst("lastActiveOrg=".count))
+            }
+        }
+        return nil
+    }
+}

--- a/app/AnthropicUsageStore.swift
+++ b/app/AnthropicUsageStore.swift
@@ -1,0 +1,145 @@
+// PR 2c — first UsageProvider conformer.
+//
+// AnthropicUsageStore wraps the existing UsageManager (which retains all
+// existing behaviour) and adapts it to the UsageProvider protocol. Nothing
+// in UsageManager changes; this store forwards to it.
+//
+// This deliberate two-layer arrangement — Fetcher (Sendable value type,
+// PR 2b), Store (ObservableObject, this PR), and legacy UsageManager
+// (still the driver, unchanged) — lets us introduce the protocol
+// without disturbing behaviour. A follow-up PR can eventually replace
+// UsageManager with a direct Store implementation once the protocol
+// surface has been exercised by multiple providers.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// AnthropicUsageStore is `final` (not public) because its `init` takes a
+// UsageManager, which is internal to the app module. This is intentional:
+// the store is an app-level integration, not a library-level primitive.
+// Library-level primitives live in Log.swift, AnthropicUsageFetcher.swift,
+// and UsageProvider.swift.
+// @preconcurrency defers strict actor-isolation checking against
+// UsageProvider until PR 16 migrates the protocol itself to @MainActor.
+// Under Swift 5 mode (current) this is a no-op; under Swift 6 it lets us
+// stage the migration one provider at a time.
+@MainActor
+final class AnthropicUsageStore: @preconcurrency UsageProvider {
+
+    let id: String = "anthropic"
+    let displayName: String = "Claude (Anthropic)"
+    let featureFlagKey: String = "features.anthropic.enabled"
+
+    /// The underlying manager holds all state. AnthropicUsageStore just
+    /// exposes it via the protocol. Its @Published properties drive the
+    /// view; ProviderBox forwards their notifications.
+    private let manager: UsageManager
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(manager: UsageManager) {
+        self.manager = manager
+        // Re-broadcast the manager's changes as our own so ProviderBox
+        // sees a single upstream. Combine subscription forwards them.
+        manager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Feature flag (Anthropic is on by default for existing users)
+
+    /// Anthropic is unlike every other provider — it is on by default so
+    /// existing v1.3.1 users see zero change on upgrade. Every subsequent
+    /// provider defaults false and requires an explicit Settings toggle.
+    var isEnabled: Bool {
+        // If the key has never been written, default to true (compat with
+        // pre-feature-flag builds). Writing false explicitly turns
+        // Anthropic off, which is a supported state.
+        if UserDefaults.standard.object(forKey: featureFlagKey) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: featureFlagKey)
+    }
+
+    var isConfigured: Bool {
+        manager.hasFetchedData || UserDefaults.standard.string(forKey: "claude_session_cookie") != nil
+    }
+
+    var lastUpdated: Date? {
+        manager.hasFetchedData ? manager.lastUpdated : nil
+    }
+
+    var errorMessage: String? {
+        manager.errorMessage
+    }
+
+    // MARK: - Tiles
+
+    var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+        guard manager.hasFetchedData else { return [] }
+
+        var out: [UsageTile] = []
+
+        out.append(UsageTile(
+            id: "anthropic-5h",
+            title: "Session (5 hour)",
+            kind: .bar(
+                fraction: manager.sessionPercentage,
+                resetsAt: manager.sessionResetsAt,
+                badge: nil
+            )
+        ))
+
+        out.append(UsageTile(
+            id: "anthropic-weekly",
+            title: "Weekly (7 day)",
+            kind: .bar(
+                fraction: manager.weeklyPercentage,
+                resetsAt: manager.weeklyResetsAt,
+                badge: nil
+            )
+        ))
+
+        if manager.hasWeeklySonnet {
+            out.append(UsageTile(
+                id: "anthropic-weekly-sonnet",
+                title: "Weekly Sonnet (7 day)",
+                kind: .bar(
+                    fraction: manager.weeklySonnetPercentage,
+                    resetsAt: manager.weeklySonnetResetsAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        // Fable surfaced only above 1% — same rule as the existing view.
+        if manager.hasWeeklyFable && manager.weeklyFableUsage >= 1 {
+            out.append(UsageTile(
+                id: "anthropic-weekly-fable",
+                title: "Weekly Fable (7 day)",
+                kind: .bar(
+                    fraction: manager.weeklyFablePercentage,
+                    resetsAt: manager.weeklyFableResetsAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Actions
+
+    func fetch() {
+        guard isEnabled else { return }
+        manager.fetchUsage()
+    }
+
+    func clear() {
+        manager.clearSessionCookie()
+    }
+}

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import Combine
 
 // The categorical logger (enum Log, enum LogValue) lives in Log.swift so
 // the SwiftPM library target can compile it without also compiling this
@@ -21,6 +22,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // via `providers.append(...)`. The existing UsageManager continues to
     // drive Anthropic tiles — providers[0] is a thin wrapper around it.
     var providers: [ProviderBox] = []
+    // PR 3-UI: the ObservableObject SwiftUI watches for generic provider
+    // tiles. Holds the same ProviderBox instances as `providers`.
+    var providersModel: ProvidersModel!
     var eventMonitor: Any?
     var hotKeyRef: EventHotKeyRef?
 
@@ -45,9 +49,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize managers
         usageManager = UsageManager(statusItem: statusItem, delegate: self)
-        // Wrap the manager in a UsageProvider so future provider PRs can
-        // add themselves to `providers[]` without disturbing this one.
+        // Wrap the manager in a UsageProvider so additional providers can
+        // register alongside it without disturbing the Anthropic path.
         providers.append(ProviderBox(AnthropicUsageStore(manager: usageManager)))
+        // PR 3-UI: register the Codex provider. It is opt-in (feature flag
+        // features.codex.enabled defaults false), so registering it here is
+        // inert for existing users — it contributes no tiles until enabled.
+        providers.append(ProviderBox(CodexUsageStore()))
+        // Model SwiftUI observes for the generic (non-Anthropic) provider
+        // tiles. Anthropic continues to render through usageManager directly.
+        providersModel = ProvidersModel(providers: providers)
         statusManager = StatusManager()
         updateManager = UpdateManager()
 
@@ -59,13 +70,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.contentViewController = NSHostingController(rootView: UsageView(
             usageManager: usageManager,
             statusManager: statusManager,
-            updateManager: updateManager
+            updateManager: updateManager,
+            providersModel: providersModel
         ))
 
         // Fetch initial data
         usageManager.fetchUsage()
         statusManager.fetch()
         updateManager.fetch()
+        // Fetch any enabled non-Anthropic providers (Codex, etc.) on launch.
+        providersModel.fetchEnabled()
+
+        // Non-Anthropic providers poll on their own cadence. Codex documents
+        // 60s while active; a single 60s timer drives every enabled provider.
+        Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
+            self.providersModel.fetchEnabled()
+        }
 
         // Usage + Anthropic status are time-sensitive — poll every 5 min.
         Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
@@ -222,6 +242,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.main.async {
                 self.usageManager.updatePercentages()
             }
+            // Refresh enabled non-Anthropic providers (Codex, etc.) so their
+            // tiles are current when the popover appears.
+            providersModel?.fetchEnabled()
 
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
 
@@ -1243,6 +1266,71 @@ struct PasteableTextField: NSViewRepresentable {
     }
 }
 
+// PR 3-UI: the single ObservableObject SwiftUI watches for the generic
+// (non-Anthropic) provider tiles. SwiftUI cannot observe a bare
+// `[ProviderBox]`; it needs one ObservableObject to subscribe to. This model
+// holds the boxes and re-broadcasts each box's objectWillChange, so any
+// provider state change redraws the popover. Anthropic is intentionally
+// excluded from `genericProviders` — it renders through usageManager as
+// before; this model only drives the additional providers.
+//
+// @MainActor because it reads and drives @MainActor providers (ProviderBox,
+// the stores). Every call site (AppDelegate lifecycle, timers on the main
+// runloop, the SwiftUI popover) is already on the main actor, so this adds
+// no friction. AppDelegate is annotated @MainActor to match, which AppKit
+// already guarantees at runtime.
+@MainActor
+final class ProvidersModel: ObservableObject {
+    let providers: [ProviderBox]
+    private var cancellables: [AnyCancellable] = []
+
+    init(providers: [ProviderBox]) {
+        self.providers = providers
+        for box in providers {
+            box.objectWillChange
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.objectWillChange.send() }
+                .store(in: &cancellables)
+        }
+    }
+
+    /// Providers rendered through the generic path — everything except
+    /// Anthropic, which keeps its bespoke rendering in UsageView.content.
+    /// `nonisolated` because `providers` is an immutable `let` and `id` is a
+    /// nonisolated stored property on ProviderBox — no main-actor state is
+    /// touched, so AppDelegate's timer/lifecycle closures can call it.
+    nonisolated var genericProviders: [ProviderBox] {
+        providers.filter { $0.id != "anthropic" }
+    }
+
+    /// The subset of generic providers the user has enabled via Settings.
+    /// Reads each provider's `isEnabled` through the `any UsageProvider`
+    /// existential, whose protocol is not @MainActor (the stores add it with
+    /// @preconcurrency), so this stays nonisolated.
+    nonisolated var enabledGenericProviders: [ProviderBox] {
+        genericProviders.filter { $0.provider.isEnabled }
+    }
+
+    /// Fetch every enabled non-Anthropic provider. Called on launch, on the
+    /// 60s timer, when the popover opens, and from the Refresh button — all
+    /// on the main thread in practice. `nonisolated` so those synchronous
+    /// call sites do not need per-site actor hops.
+    nonisolated func fetchEnabled() {
+        for box in enabledGenericProviders {
+            box.provider.fetch()
+        }
+    }
+
+    /// Force the popover to re-evaluate which provider sections are visible.
+    /// A Settings toggle writes the feature flag straight to UserDefaults,
+    /// which does not itself fire objectWillChange; the toggle calls this so
+    /// a section appears or disappears immediately on both transitions
+    /// (enabling a provider also fetches; disabling it has no other signal).
+    func providersChanged() {
+        objectWillChange.send()
+    }
+}
+
 private struct ContentHeightKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
@@ -1254,6 +1342,8 @@ struct UsageView: View {
     @ObservedObject var usageManager: UsageManager
     @ObservedObject var statusManager: StatusManager
     @ObservedObject var updateManager: UpdateManager
+    // PR 3-UI: drives the generic (non-Anthropic) provider tiles.
+    @ObservedObject var providersModel: ProvidersModel
     @State private var sessionCookieInput: String = ""
     @State private var showingCookieInput: Bool = false
     @State private var showingSettings: Bool = false
@@ -1485,6 +1575,15 @@ struct UsageView: View {
             }
             }
 
+            // PR 3-UI: generic (non-Anthropic) provider tiles. Each enabled
+            // provider contributes a section; Anthropic is rendered above via
+            // usageManager and is excluded here. Renders nothing when no such
+            // provider is enabled, so existing users see no change.
+            ForEach(providersModel.enabledGenericProviders) { box in
+                Divider()
+                ProviderSectionView(box: box)
+            }
+
             if statusManager.hasFetched {
                 Divider()
             }
@@ -1626,6 +1725,7 @@ struct UsageView: View {
                     usageManager.fetchUsage()
                     statusManager.fetch()
                     updateManager.fetch()
+                    providersModel.fetchEnabled()
                 }
                 .buttonStyle(.borderless)
                 .font(.caption)
@@ -1787,6 +1887,30 @@ struct UsageView: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                    }
+
+                    Divider()
+
+                    // PR 3-UI: per-provider opt-in toggles. Each non-Anthropic
+                    // provider is off by default; enabling one writes its
+                    // featureFlagKey and triggers an immediate fetch.
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Providers")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                        Text("Track additional AI services. Each is opt-in; enable only the ones you use.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        ForEach(providersModel.genericProviders) { box in
+                            ProviderToggleRow(box: box) { enabled in
+                                // Re-evaluate section visibility on both
+                                // transitions; fetch immediately on enable.
+                                if enabled { box.provider.fetch() }
+                                providersModel.providersChanged()
+                            }
+                        }
                     }
 
                     Divider()
@@ -2003,3 +2127,237 @@ struct UsageView: View {
     }
 
 }
+
+// MARK: - Generic provider rendering (PR 3-UI)
+
+/// Renders one non-Anthropic provider: a section header (display name +
+/// optional error / last-updated) followed by one UsageTileView per tile.
+/// Observes the box so provider state changes redraw this section.
+struct ProviderSectionView: View {
+    @ObservedObject var box: ProviderBox
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(box.provider.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer()
+                if let updated = box.provider.lastUpdated {
+                    Text("Updated \(shortTime(updated))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let error = box.provider.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+
+            ForEach(box.provider.tiles) { tile in
+                UsageTileView(tile: tile)
+            }
+        }
+    }
+
+    private func shortTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f.string(from: date)
+    }
+}
+
+/// Renders a single UsageTile by switching on its Kind. This is the generic
+/// renderer every future provider reuses — adding a provider needs no new UI
+/// as long as it emits one of these kinds.
+struct UsageTileView: View {
+    let tile: UsageTile
+
+    var body: some View {
+        switch tile.kind {
+        case let .bar(fraction, resetsAt, badge):
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    if let badge = badge, !badge.isEmpty {
+                        Text(badge)
+                            .font(.caption2)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.2))
+                            .cornerRadius(3)
+                    }
+                    Spacer()
+                    if let resetsAt = resetsAt {
+                        Text("Resets \(resetLabel(resetsAt))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                ProgressView(value: fraction)
+                    .tint(color(for: fraction))
+                Text("\(Int((fraction * 100).rounded()))% used")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+        case let .balance(remainingMinorUnits, currency, plan, resetsAt):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    Text(formatBalance(remainingMinorUnits, currency: currency))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
+                if let plan = plan, !plan.isEmpty {
+                    Text(plan)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                if let resetsAt = resetsAt {
+                    Text("Resets \(resetLabel(resetsAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case let .counter(used, limit, resetsAt):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    if let limit = limit {
+                        Text("\(used) / \(limit)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    } else {
+                        Text("\(used)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    }
+                }
+                if let resetsAt = resetsAt {
+                    Text("Resets \(resetLabel(resetsAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case let .text(status, subtitle):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    Text(status)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let subtitle = subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+        case let .needsAccess(path, guidance):
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tile.title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Text(guidance)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(path)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding(8)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(6)
+        }
+    }
+
+    private func color(for fraction: Double) -> Color {
+        if fraction < 0.7 { return .green }
+        if fraction < 0.9 { return .orange }
+        return .red
+    }
+
+    private func resetLabel(_ date: Date) -> String {
+        let f = DateFormatter()
+        // Include the date when the reset is more than ~a day out (weekly
+        // windows); otherwise just the time (5-hour windows).
+        if date.timeIntervalSinceNow > 86_400 {
+            f.dateFormat = "d MMM 'at' h:mm a"
+            return "on \(f.string(from: date))"
+        }
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return "at \(f.string(from: date))"
+    }
+
+    private func formatBalance(_ minorUnits: Int, currency: String) -> String {
+        let major = Double(minorUnits) / 100.0
+        return String(format: "%@ %.2f", currency, major)
+    }
+}
+
+/// One opt-in checkbox for a non-Anthropic provider in Settings. Reads and
+/// writes the provider's featureFlagKey directly in UserDefaults; on enable
+/// it fires `onEnable` so the provider fetches immediately rather than
+/// waiting for the next timer tick. Below the toggle it shows provider-
+/// specific help and, where relevant, a private-API disclosure line.
+struct ProviderToggleRow: View {
+    @ObservedObject var box: ProviderBox
+    /// Called after the flag is written, with the new value, on every
+    /// toggle (both enable and disable).
+    let onChange: (Bool) -> Void
+
+    @State private var enabled: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: Binding(
+                get: { enabled },
+                set: { newValue in
+                    enabled = newValue
+                    UserDefaults.standard.set(newValue, forKey: box.provider.featureFlagKey)
+                    onChange(newValue)
+                }
+            )) {
+                Text(box.provider.displayName)
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+
+            if let help = ProviderCopy.help(for: box.id) {
+                Text(help)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let disclosure = ProviderCopy.disclosure(for: box.id) {
+                Text(disclosure)
+                    .font(.caption2)
+                    .foregroundColor(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .onAppear {
+            enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
+        }
+    }
+}
+

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -444,16 +444,14 @@ class UsageManager: ObservableObject {
     }
 
     func fetchOrganizationId(completion: @escaping (String?) -> Void) {
-        // Get org ID from the lastActiveOrg cookie value
-        let cookieParts = sessionCookie.components(separatedBy: ";")
-        for part in cookieParts {
-            let trimmed = part.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("lastActiveOrg=") {
-                let orgId = trimmed.replacingOccurrences(of: "lastActiveOrg=", with: "")
-                Log.info("Found org ID in cookie", .identifier(orgId))
-                completion(orgId)
-                return
-            }
+        // PR 2b: parsing lives in AnthropicUsageFetcher. UsageManager keeps
+        // ownership of the network call (which needs to be in the manager
+        // for delegate/main-actor reasons) but delegates the string
+        // parsing.
+        if let orgId = AnthropicUsageFetcher.orgId(fromCookieString: sessionCookie) {
+            Log.info("Found org ID in cookie", .identifier(orgId))
+            completion(orgId)
+            return
         }
 
         // If not in cookie, fetch from bootstrap
@@ -574,113 +572,43 @@ class UsageManager: ObservableObject {
     }
 
     func parseUsageData(_ data: Data) {
+        // PR 2b: parsing extracted into AnthropicUsageFetcher (Sendable
+        // value type, no side effects). UsageManager only applies the
+        // resulting snapshot to observable state. Behaviour is identical
+        // to the pre-refactor code; every branch is locked in by fixture
+        // tests in Tests/TestRunner.
         do {
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                errorMessage = "Invalid JSON"
-                return
-            }
+            let snap = try AnthropicUsageFetcher.parse(data)
+            sessionUsage = snap.sessionUsage
+            sessionLimit = 100
+            sessionResetsAt = snap.sessionResetsAt
 
-            NSLog("📊 Parsing usage data...")
+            weeklyUsage = snap.weeklyUsage
+            weeklyLimit = 100
+            weeklyResetsAt = snap.weeklyResetsAt
 
-            let iso8601Formatter = ISO8601DateFormatter()
-            iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            hasWeeklySonnet = snap.hasWeeklySonnet
+            weeklySonnetUsage = snap.weeklySonnetUsage
+            weeklySonnetLimit = 100
+            weeklySonnetResetsAt = snap.weeklySonnetResetsAt
 
-            // Parse the actual claude.ai response format
-            if let fiveHour = json["five_hour"] as? [String: Any] {
-                if let sessionUtil = fiveHour["utilization"] as? Double {
-                    sessionUsage = Int(sessionUtil)
-                    sessionLimit = 100
-                }
-                if let resetsAtString = fiveHour["resets_at"] as? String {
-                    NSLog("🕐 Session resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        sessionResetsAt = resetsAt
-                        NSLog("✅ Parsed session reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse session reset time")
-                    }
-                }
-            }
+            hasWeeklyFable = snap.hasWeeklyFable
+            weeklyFableUsage = snap.weeklyFableUsage
+            weeklyFableLimit = 100
+            weeklyFableResetsAt = snap.weeklyFableResetsAt
 
-            if let sevenDay = json["seven_day"] as? [String: Any] {
-                if let weeklyUtil = sevenDay["utilization"] as? Double {
-                    weeklyUsage = Int(weeklyUtil)
-                    weeklyLimit = 100
-                }
-                if let resetsAtString = sevenDay["resets_at"] as? String {
-                    NSLog("🕐 Weekly resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        weeklyResetsAt = resetsAt
-                        NSLog("✅ Parsed weekly reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse weekly reset time")
-                    }
-                }
-            }
-
-            // Check for seven_day_sonnet (Pro plan feature)
-            if let sevenDaySonnet = json["seven_day_sonnet"] as? [String: Any] {
-                hasWeeklySonnet = true
-                if let sonnetUtil = sevenDaySonnet["utilization"] as? Double {
-                    weeklySonnetUsage = Int(sonnetUtil)
-                    weeklySonnetLimit = 100
-                }
-                if let resetsAtString = sevenDaySonnet["resets_at"] as? String {
-                    NSLog("🕐 Weekly Sonnet resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        weeklySonnetResetsAt = resetsAt
-                        NSLog("✅ Parsed weekly Sonnet reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse weekly Sonnet reset time")
-                    }
-                }
-            } else {
-                hasWeeklySonnet = false
-            }
-
-            // Fable is a new, separately-counted model. It isn't a top-level
-            // key like seven_day_sonnet — it lives in the `limits` array as a
-            // model-scoped weekly limit (scope.model.display_name == "Fable").
-            // The bar is only surfaced in the UI when usage is above 1%.
-            hasWeeklyFable = false
-            if let limits = json["limits"] as? [[String: Any]] {
-                let fableLimit = limits.first { entry in
-                    let scope = entry["scope"] as? [String: Any]
-                    let model = scope?["model"] as? [String: Any]
-                    return (model?["display_name"] as? String) == "Fable"
-                }
-                if let fable = fableLimit {
-                    hasWeeklyFable = true
-                    // `percent` may decode as Int or Double depending on payload.
-                    if let p = fable["percent"] as? Int {
-                        weeklyFableUsage = p
-                    } else if let p = fable["percent"] as? Double {
-                        weeklyFableUsage = Int(p)
-                    }
-                    weeklyFableLimit = 100
-                    if let resetsAtString = fable["resets_at"] as? String {
-                        NSLog("🕐 Weekly Fable resets_at string: \(resetsAtString)")
-                        if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                            weeklyFableResetsAt = resetsAt
-                            NSLog("✅ Parsed weekly Fable reset time: \(resetsAt)")
-                        } else {
-                            NSLog("❌ Failed to parse weekly Fable reset time")
-                        }
-                    }
-                }
-            }
-
-            // Log what we found
-            NSLog("✅ Parsed: Session \(sessionUsage)%, Weekly \(weeklyUsage)%\(hasWeeklySonnet ? ", Weekly Sonnet \(weeklySonnetUsage)%" : "")\(hasWeeklyFable ? ", Weekly Fable \(weeklyFableUsage)%" : "")")
+            Log.info("Parsed usage",
+                     .public("session"), .count(sessionUsage),
+                     .public("weekly"), .count(weeklyUsage))
 
             lastUpdated = Date()
             errorMessage = nil
             hasFetchedData = true
-
-            // Update percentage values for progress bars
             updatePercentages()
+        } catch AnthropicUsageParseError.invalidJSON {
+            errorMessage = "Invalid JSON"
         } catch {
-            NSLog("❌ Parse error: \(error.localizedDescription)")
+            Log.info("Parse error", .public(error.localizedDescription))
             errorMessage = "Parse error"
         }
     }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -15,6 +15,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var usageManager: UsageManager!
     var statusManager: StatusManager!
     var updateManager: UpdateManager!
+
+    // PR 2c: multi-provider registry. Anthropic is the only provider today;
+    // subsequent PRs register additional stores (Codex, DeepSeek, Zed, ...)
+    // via `providers.append(...)`. The existing UsageManager continues to
+    // drive Anthropic tiles — providers[0] is a thin wrapper around it.
+    var providers: [ProviderBox] = []
     var eventMonitor: Any?
     var hotKeyRef: EventHotKeyRef?
 
@@ -39,6 +45,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize managers
         usageManager = UsageManager(statusItem: statusItem, delegate: self)
+        // Wrap the manager in a UsageProvider so future provider PRs can
+        // add themselves to `providers[]` without disturbing this one.
+        providers.append(ProviderBox(AnthropicUsageStore(manager: usageManager)))
         statusManager = StatusManager()
         updateManager = UpdateManager()
 

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -60,6 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // defaults false) and additionally requires a pasted API key, so it
         // is doubly inert until the user both enables and configures it.
         providers.append(ProviderBox(DeepSeekUsageStore()))
+        // PR 5-UI: register Zed. Opt-in (features.zed.enabled defaults false);
+        // it reads Zed's own Keychain login on first fetch (one-time macOS
+        // prompt), so it is inert until enabled and the prompt is allowed.
+        providers.append(ProviderBox(ZedUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -68,6 +68,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // an optional gated management key for balance/history. Inert until
         // enabled and configured.
         providers.append(ProviderBox(XAIUsageStore()))
+        // PR 7-UI: register OpenAI Platform. Opt-in; requires a pasted Admin
+        // key (sk-admin-). Inert until enabled and configured.
+        providers.append(ProviderBox(OpenAIUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -56,6 +56,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // features.codex.enabled defaults false), so registering it here is
         // inert for existing users — it contributes no tiles until enabled.
         providers.append(ProviderBox(CodexUsageStore()))
+        // PR 4-UI: register DeepSeek. Also opt-in (features.deepseek.enabled
+        // defaults false) and additionally requires a pasted API key, so it
+        // is doubly inert until the user both enables and configures it.
+        providers.append(ProviderBox(DeepSeekUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2326,6 +2330,16 @@ struct ProviderToggleRow: View {
     let onChange: (Bool) -> Void
 
     @State private var enabled: Bool = false
+    // Local buffer for a pasted secret (PasteKeyProvider). Never pre-filled
+    // with the stored secret — we only ever write, never read it back out.
+    @State private var keyInput: String = ""
+    @State private var hasStoredKey: Bool = false
+
+    /// The provider as a PasteKeyProvider, when it is configured by pasting a
+    /// secret; nil otherwise.
+    private var pasteKeyProvider: PasteKeyProvider? {
+        box.provider as? PasteKeyProvider
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -2354,9 +2368,44 @@ struct ProviderToggleRow: View {
                     .foregroundColor(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            // Key-entry affordance for paste-a-secret providers, shown only
+            // when the provider is enabled. Uses a SecureField so the pasted
+            // value is masked on screen; the stored secret is never read back
+            // into the field.
+            if enabled, let keyProvider = pasteKeyProvider {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        SecureField(keyProvider.keyPlaceholder, text: $keyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.caption2)
+                        Button("Save") {
+                            keyProvider.saveKey(keyInput)
+                            keyInput = ""
+                            hasStoredKey = keyProvider.hasKey
+                            onChange(true)  // trigger a fetch now that a key exists
+                        }
+                        .controlSize(.small)
+                        .disabled(keyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                        if hasStoredKey {
+                            Button("Clear") {
+                                keyProvider.saveKey("")  // empty clears
+                                hasStoredKey = keyProvider.hasKey
+                                onChange(false)
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
         }
         .onAppear {
             enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
+            hasStoredKey = pasteKeyProvider?.hasKey ?? false
         }
     }
 }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,72 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import CryptoKit
+import Foundation
+
+// MARK: - Logging (categorical redaction)
+//
+// PR 1 replaces every NSLog site that touched cookies, org IDs, or response
+// bodies with the categorical logger below. The call site cannot interpolate
+// a raw String; every value goes through a category, and each category has
+// its own emission rule. This makes accidental credential logging a compile-
+// time impossibility rather than a discipline problem.
+//
+// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
+// reintroduce raw-interpolation NSLog calls or the deleted response-body
+// log line at the network fetch site. The exact banned pattern lives in
+// the workflow file to avoid embedding it here (which would self-trigger).
+
+enum LogValue {
+    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
+    case `public`(String)
+    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
+    /// bodies, tokens, API keys, anything that could leak a credential.
+    case sensitive(String)
+    /// Emitted as a short SHA-256 prefix so the value can be correlated
+    /// across log lines without revealing it. Use for org IDs, user IDs.
+    case identifier(String)
+    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
+    /// retry counts, threshold values).
+    case count(Int)
+
+    var rendered: String {
+        switch self {
+        case .public(let s):
+            return s
+        case .sensitive(let s):
+            return "<redacted: \(s.count) chars>"
+        case .identifier(let s):
+            let digest = SHA256.hash(data: Data(s.utf8))
+            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+            return "<id: \(hex.prefix(8))>"
+        case .count(let n):
+            return String(n)
+        }
+    }
+}
+
+enum Log {
+    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
+    /// gate. Accepts a plain message — no interpolation of untrusted values.
+    static func debug(_ message: String) {
+        #if DEBUG
+        NSLog("[debug] %@", message)
+        #endif
+    }
+
+    /// Info-level diagnostics. Retained in release builds. Values must be
+    /// wrapped in a `LogValue` category, forcing an explicit redaction
+    /// decision at the call site.
+    static func info(_ message: String, _ values: LogValue...) {
+        let rendered = values.map(\.rendered).joined(separator: ", ")
+        if rendered.isEmpty {
+            NSLog("%@", message)
+        } else {
+            NSLog("%@ | %@", message, rendered)
+        }
+    }
+}
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -403,15 +469,15 @@ class UsageManager: ObservableObject {
     }
 
     func saveSessionCookie(_ cookie: String) {
-        NSLog("ClaudeUsage: Saving cookie, length: \(cookie.count)")
+        Log.info("ClaudeUsage: saving cookie", .count(cookie.count))
         sessionCookie = cookie
         UserDefaults.standard.set(cookie, forKey: "claude_session_cookie")
         UserDefaults.standard.synchronize()
-        NSLog("ClaudeUsage: Cookie saved successfully")
+        Log.info("ClaudeUsage: cookie saved successfully")
     }
 
     func clearSessionCookie() {
-        NSLog("ClaudeUsage: Clearing cookie")
+        Log.info("ClaudeUsage: clearing cookie")
         sessionCookie = ""
         UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
         UserDefaults.standard.synchronize()
@@ -435,7 +501,7 @@ class UsageManager: ObservableObject {
         // Update status bar to show 0%
         delegate?.updateStatusIcon(percentage: 0)
 
-        NSLog("ClaudeUsage: Cookie cleared, data reset")
+        Log.info("ClaudeUsage: cookie cleared, data reset")
     }
 
     func fetchOrganizationId(completion: @escaping (String?) -> Void) {
@@ -445,7 +511,7 @@ class UsageManager: ObservableObject {
             let trimmed = part.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("lastActiveOrg=") {
                 let orgId = trimmed.replacingOccurrences(of: "lastActiveOrg=", with: "")
-                NSLog("📋 Found org ID in cookie: \(orgId)")
+                Log.info("Found org ID in cookie", .identifier(orgId))
                 completion(orgId)
                 return
             }
@@ -545,11 +611,17 @@ class UsageManager: ObservableObject {
                     return
                 }
 
-                NSLog("📡 Status: \(httpResponse.statusCode)")
+                Log.info("Usage API response", .count(httpResponse.statusCode))
 
+                // Response body is intentionally NOT logged. It contains the
+                // full usage JSON tied to the user's cookie and would land in
+                // unified log. Diagnostics for debugging live parse issues
+                // must go through the DEBUG-only path.
+                #if DEBUG
                 if let data = data, let responseString = String(data: data, encoding: .utf8) {
-                    NSLog("📦 Response: \(responseString)")
+                    Log.debug("Usage API body (DEBUG only): \(responseString)")
                 }
+                #endif
 
                 if httpResponse.statusCode == 200, let data = data {
                     self?.parseUsageData(data)
@@ -1729,7 +1801,7 @@ struct UsageView: View {
 
                             HStack(spacing: 8) {
                                 Button("Save Cookie & Fetch") {
-                                    NSLog("ClaudeUsage: Save clicked, input length: \(sessionCookieInput.count)")
+                                    Log.info("ClaudeUsage: save clicked", .count(sessionCookieInput.count))
                                     if sessionCookieInput.isEmpty {
                                         usageManager.errorMessage = "Cookie field is empty!"
                                     } else {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -64,6 +64,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // it reads Zed's own Keychain login on first fetch (one-time macOS
         // prompt), so it is inert until enabled and the prompt is allowed.
         providers.append(ProviderBox(ZedUsageStore()))
+        // PR 6-UI: register xAI. Opt-in; requires a pasted inference key, with
+        // an optional gated management key for balance/history. Inert until
+        // enabled and configured.
+        providers.append(ProviderBox(XAIUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2338,11 +2342,20 @@ struct ProviderToggleRow: View {
     // with the stored secret — we only ever write, never read it back out.
     @State private var keyInput: String = ""
     @State private var hasStoredKey: Bool = false
+    // Secondary (gated, higher-privilege) key state — xAI's management key.
+    @State private var secondaryInput: String = ""
+    @State private var hasStoredSecondaryKey: Bool = false
 
     /// The provider as a PasteKeyProvider, when it is configured by pasting a
     /// secret; nil otherwise.
     private var pasteKeyProvider: PasteKeyProvider? {
         box.provider as? PasteKeyProvider
+    }
+
+    /// The provider as a SecondaryKeyProvider, when it accepts an optional
+    /// second (gated) key; nil otherwise.
+    private var secondaryKeyProvider: SecondaryKeyProvider? {
+        box.provider as? SecondaryKeyProvider
     }
 
     var body: some View {
@@ -2404,12 +2417,53 @@ struct ProviderToggleRow: View {
                     Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
                         .font(.caption2)
                         .foregroundColor(.secondary)
+
+                    // Secondary (gated, higher-privilege) key. Shown only once
+                    // the primary key is stored, and only for providers that
+                    // accept one (xAI's management key). Carries an explicit
+                    // warning before the field.
+                    if hasStoredKey, let secondary = secondaryKeyProvider {
+                        Divider()
+                        Text(secondary.secondaryKeyLabel)
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                        Text(secondary.secondaryKeyWarning)
+                            .font(.caption2)
+                            .foregroundColor(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                        HStack(spacing: 6) {
+                            SecureField(secondary.secondaryKeyPlaceholder, text: $secondaryInput)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.caption2)
+                            Button("Save") {
+                                secondary.saveSecondaryKey(secondaryInput)
+                                secondaryInput = ""
+                                hasStoredSecondaryKey = secondary.hasSecondaryKey
+                                onChange(true)
+                            }
+                            .controlSize(.small)
+                            .disabled(secondaryInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                            if hasStoredSecondaryKey {
+                                Button("Clear") {
+                                    secondary.saveSecondaryKey("")
+                                    hasStoredSecondaryKey = secondary.hasSecondaryKey
+                                    onChange(true)
+                                }
+                                .controlSize(.small)
+                            }
+                        }
+                        Text(hasStoredSecondaryKey ? "Management key saved in Keychain." : "No management key saved.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
         }
         .onAppear {
             enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
             hasStoredKey = pasteKeyProvider?.hasKey ?? false
+            hasStoredSecondaryKey = secondaryKeyProvider?.hasSecondaryKey ?? false
         }
     }
 }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,72 +2,11 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
-import CryptoKit
-import Foundation
 
-// MARK: - Logging (categorical redaction)
-//
-// PR 1 replaces every NSLog site that touched cookies, org IDs, or response
-// bodies with the categorical logger below. The call site cannot interpolate
-// a raw String; every value goes through a category, and each category has
-// its own emission rule. This makes accidental credential logging a compile-
-// time impossibility rather than a discipline problem.
-//
-// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
-// reintroduce raw-interpolation NSLog calls or the deleted response-body
-// log line at the network fetch site. The exact banned pattern lives in
-// the workflow file to avoid embedding it here (which would self-trigger).
-
-enum LogValue {
-    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
-    case `public`(String)
-    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
-    /// bodies, tokens, API keys, anything that could leak a credential.
-    case sensitive(String)
-    /// Emitted as a short SHA-256 prefix so the value can be correlated
-    /// across log lines without revealing it. Use for org IDs, user IDs.
-    case identifier(String)
-    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
-    /// retry counts, threshold values).
-    case count(Int)
-
-    var rendered: String {
-        switch self {
-        case .public(let s):
-            return s
-        case .sensitive(let s):
-            return "<redacted: \(s.count) chars>"
-        case .identifier(let s):
-            let digest = SHA256.hash(data: Data(s.utf8))
-            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
-            return "<id: \(hex.prefix(8))>"
-        case .count(let n):
-            return String(n)
-        }
-    }
-}
-
-enum Log {
-    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
-    /// gate. Accepts a plain message — no interpolation of untrusted values.
-    static func debug(_ message: String) {
-        #if DEBUG
-        NSLog("[debug] %@", message)
-        #endif
-    }
-
-    /// Info-level diagnostics. Retained in release builds. Values must be
-    /// wrapped in a `LogValue` category, forcing an explicit redaction
-    /// decision at the call site.
-    static func info(_ message: String, _ values: LogValue...) {
-        let rendered = values.map(\.rendered).joined(separator: ", ")
-        if rendered.isEmpty {
-            NSLog("%@", message)
-        } else {
-            NSLog("%@ | %@", message, rendered)
-        }
-    }
-}
+// The categorical logger (enum Log, enum LogValue) lives in Log.swift so
+// the SwiftPM library target can compile it without also compiling this
+// file's @main entry point. Both files are compiled together by
+// app/build.sh into the final .app bundle.
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -71,6 +71,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // PR 7-UI: register OpenAI Platform. Opt-in; requires a pasted Admin
         // key (sk-admin-). Inert until enabled and configured.
         providers.append(ProviderBox(OpenAIUsageStore()))
+        // PR 8-UI: register Perplexity Pro/Max. Opt-in
+        // (features.perplexity.enabled defaults false); requires a pasted
+        // session cookie from perplexity.ai. Doubly inert until the user
+        // both enables and configures it. Backend from PR #61.
+        providers.append(ProviderBox(PerplexityUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2421,7 +2426,9 @@ struct ProviderToggleRow: View {
                             .controlSize(.small)
                         }
                     }
-                    Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
+                    // Use the provider's declared noun ("Key" / "Cookie") so
+                    // the status line reflects what the user actually pasted.
+                    Text(hasStoredKey ? "\(keyProvider.secretKindNoun) saved in Keychain." : "No \(keyProvider.secretKindNoun.lowercased()) saved yet.")
                         .font(.caption2)
                         .foregroundColor(.secondary)
 

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -576,7 +576,11 @@ class UsageManager: ObservableObject {
         request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36", forHTTPHeaderField: "User-Agent")
         request.setValue("claude.ai", forHTTPHeaderField: "authority")
 
-        NSLog("🔍 Fetching from: \(urlString)")
+        // Do NOT log the full URL: it embeds the org id (a sensitive
+        // account identifier). Log a fixed endpoint label plus the org id
+        // through the categorical logger, which emits only a short SHA-256
+        // prefix rather than the plaintext id.
+        Log.info("Fetching Anthropic usage", .identifier(orgId))
 
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             DispatchQueue.main.async {

--- a/app/CodexUsageFetcher.swift
+++ b/app/CodexUsageFetcher.swift
@@ -1,0 +1,387 @@
+// PR 3-BE — Codex usage fetcher.
+//
+// Mirrors AnthropicUsageFetcher (PR 2b): a Sendable value type with no
+// observable state, no delegates, no side effects. It exposes a pure
+// static parser that turns the raw bytes of a
+// `GET https://chatgpt.com/backend-api/wham/usage` response into a
+// CodexUsageSnapshot, and a credential reader that ingests
+// `~/.codex/auth.json` (respecting `CODEX_HOME`).
+//
+// The two-layer split (Fetcher value type + Store observable class) is the
+// same as Anthropic: this fetcher is what the TestRunner fixtures hit, and
+// CodexUsageStore (PR 3-BE, separate file) is what SwiftUI observes.
+//
+// Feature posture: this file is dark code in PR 3-BE. Nothing constructs a
+// CodexUsageStore into the live provider registry yet; the popover wiring
+// and Settings toggle land in PR 3-UI. Shipping the backend first, behind a
+// default-off feature flag, keeps the release non-breaking.
+//
+// Response shape: established by a live read-only probe of the real
+// endpoint (structure only, no credential retained) plus the Codex CLI's
+// own deserialization structs. The authoritative fields are:
+//
+//   rate_limit.allowed                      Bool
+//   rate_limit.limit_reached                Bool
+//   rate_limit.primary_window.used_percent  Int      (0…100)
+//   rate_limit.primary_window.reset_after_seconds  Int  (relative)
+//   rate_limit.primary_window.reset_at      Int      (Unix epoch seconds)
+//   rate_limit.secondary_window.*           (same shape as primary)
+//   additional_rate_limits                  [Window]? (null or array)
+//   credits.has_credits / unlimited / balance (String) / overage_limit_reached
+//   plan_type                               String
+//
+// Note the reset timing is Unix-epoch integers, NOT ISO-8601 strings — this
+// differs from the Anthropic endpoint. `used_percent` is an integer here.
+
+import Foundation
+
+// MARK: - Snapshot
+
+/// One usage-limit window parsed from the Codex usage response. The primary
+/// (5-hour) and secondary (weekly) windows share this shape, as do the
+/// nested windows inside each `additional_rate_limits[]` element.
+///
+/// Field names and types are the `RateLimitWindowSnapshot` model from
+/// openai/codex (`rate_limit_window_snapshot.rs`): every field is an i32 on
+/// the wire.
+public struct CodexRateWindow: Equatable, Sendable {
+    /// 0…100 integer utilisation for the window.
+    public var usedPercent: Int
+    /// Length of the window in seconds (18000 = 5h, 604800 = 7d).
+    public var limitWindowSeconds: Int?
+    /// Seconds until the window resets, relative to the response time.
+    public var resetAfterSeconds: Int?
+    /// Absolute reset time as a Unix epoch (seconds). The endpoint returns
+    /// this as an integer, not an ISO-8601 string, and not milliseconds.
+    public var resetAt: Date?
+
+    public init(
+        usedPercent: Int = 0,
+        limitWindowSeconds: Int? = nil,
+        resetAfterSeconds: Int? = nil,
+        resetAt: Date? = nil
+    ) {
+        self.usedPercent = usedPercent
+        self.limitWindowSeconds = limitWindowSeconds
+        self.resetAfterSeconds = resetAfterSeconds
+        self.resetAt = resetAt
+    }
+}
+
+/// One element of `additional_rate_limits[]` — a model-specific limit lane
+/// (e.g. "GPT-5.3-Codex-Spark"). This is the `AdditionalRateLimitDetails`
+/// model from openai/codex (`additional_rate_limit_details.rs`).
+///
+/// The usage is NOT flat on the element: it is nested one level deeper under
+/// `rate_limit.primary_window` / `rate_limit.secondary_window`, both of which
+/// are individually nullable. Reading `used_percent` off the element root is
+/// the single most common integration mistake against this endpoint, so the
+/// nesting is preserved here deliberately.
+public struct CodexAdditionalLimit: Equatable, Sendable {
+    /// Human-readable limit name, e.g. "GPT-5.3-Codex-Spark".
+    public var limitName: String?
+    /// Metered-feature slug used to identify the lane server-side.
+    public var meteredFeature: String?
+    /// The 5-hour window for this lane, if present.
+    public var primaryWindow: CodexRateWindow?
+    /// The weekly window for this lane, if present.
+    public var secondaryWindow: CodexRateWindow?
+
+    public init(
+        limitName: String? = nil,
+        meteredFeature: String? = nil,
+        primaryWindow: CodexRateWindow? = nil,
+        secondaryWindow: CodexRateWindow? = nil
+    ) {
+        self.limitName = limitName
+        self.meteredFeature = meteredFeature
+        self.primaryWindow = primaryWindow
+        self.secondaryWindow = secondaryWindow
+    }
+}
+
+/// Credit balance block. Present on accounts that carry pay-as-you-go
+/// credits; `balance` is returned as a String by the endpoint.
+public struct CodexCredits: Equatable, Sendable {
+    public var hasCredits: Bool
+    public var unlimited: Bool
+    public var overageLimitReached: Bool
+    /// Raw balance string exactly as returned (e.g. "0", "12.50"). Kept as a
+    /// String because the endpoint returns it as a String and the tile
+    /// renders it verbatim; we do not reinterpret currency here.
+    public var balance: String?
+
+    public init(
+        hasCredits: Bool = false,
+        unlimited: Bool = false,
+        overageLimitReached: Bool = false,
+        balance: String? = nil
+    ) {
+        self.hasCredits = hasCredits
+        self.unlimited = unlimited
+        self.overageLimitReached = overageLimitReached
+        self.balance = balance
+    }
+}
+
+/// A parsed snapshot of the `wham/usage` response. Every field is optional
+/// or defaulted in the same spirit as AnthropicUsageSnapshot — a fresh
+/// account with no additional windows has an empty `additionalWindows`, and
+/// an account with no credit block has `credits == nil`.
+public struct CodexUsageSnapshot: Equatable, Sendable {
+    /// Whether the account is currently allowed to make requests.
+    public var allowed: Bool
+    /// Whether any window has hit its limit.
+    public var limitReached: Bool
+
+    /// The 5-hour (primary) window. Always present in a well-formed
+    /// response; nil only if `rate_limit` is entirely absent.
+    public var primaryWindow: CodexRateWindow?
+    /// The weekly (secondary) window.
+    public var secondaryWindow: CodexRateWindow?
+    /// Zero or more model-specific limit lanes (per-model or promotional
+    /// caps, e.g. Spark). `additional_rate_limits` is `null` on most
+    /// accounts, which parses to an empty array.
+    public var additionalLimits: [CodexAdditionalLimit]
+
+    /// Pay-as-you-go credit block, if the account carries one.
+    public var credits: CodexCredits?
+
+    /// Account plan identifier ("plus", "team", "free", …). Surfaced for the
+    /// help panel copy, not for a tile.
+    public var planType: String?
+
+    public init(
+        allowed: Bool = true,
+        limitReached: Bool = false,
+        primaryWindow: CodexRateWindow? = nil,
+        secondaryWindow: CodexRateWindow? = nil,
+        additionalLimits: [CodexAdditionalLimit] = [],
+        credits: CodexCredits? = nil,
+        planType: String? = nil
+    ) {
+        self.allowed = allowed
+        self.limitReached = limitReached
+        self.primaryWindow = primaryWindow
+        self.secondaryWindow = secondaryWindow
+        self.additionalLimits = additionalLimits
+        self.credits = credits
+        self.planType = planType
+    }
+}
+
+// MARK: - Credentials
+
+/// Credentials read from `~/.codex/auth.json`. Only the two fields the usage
+/// request needs are surfaced; the id_token and refresh_token are never read
+/// out of the file by this app (PR 3-BE does not refresh — see the plan's
+/// Phase 1 note deferring writeback to Phase 1b).
+public struct CodexCredentials: Equatable, Sendable {
+    public let accessToken: String
+    public let accountId: String
+
+    public init(accessToken: String, accountId: String) {
+        self.accessToken = accessToken
+        self.accountId = accountId
+    }
+}
+
+public enum CodexUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+public enum CodexAuthError: Error, Equatable {
+    /// `auth.json` does not exist. UI should prompt `codex auth login`.
+    case authFileMissing
+    /// `auth.json` exists but could not be parsed as JSON.
+    case authFileMalformed
+    /// `auth.json` parsed but is missing access_token or account_id (e.g. an
+    /// API-key-only login with `auth_mode == "apikey"` and null tokens).
+    case authFileIncomplete
+}
+
+// MARK: - Fetcher
+
+/// Pure parser and credential reader for the Codex usage endpoint. Value
+/// type with no observable state; all callers receive a snapshot (or a
+/// thrown error) and apply it themselves on the main actor.
+public struct CodexUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: Credential ingestion
+
+    /// Resolve the Codex home directory, honouring `CODEX_HOME` when set and
+    /// non-empty, else `~/.codex`.
+    public static func codexHome(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let override = environment["CODEX_HOME"],
+           !override.trimmingCharacters(in: .whitespaces).isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        // FileManager.homeDirectoryForCurrentUser is the real user home even
+        // inside a sandbox container's mapped path; matches the CLI, which
+        // uses the OS home rather than $HOME string interpolation.
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true)
+    }
+
+    /// Full path to `auth.json` under the resolved Codex home.
+    public static func authFileURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        codexHome(environment: environment).appendingPathComponent("auth.json", isDirectory: false)
+    }
+
+    /// Read and parse `auth.json`, extracting the access token and account
+    /// id needed for the usage request. Throws a typed CodexAuthError so the
+    /// Store can map each case to a distinct UI state.
+    ///
+    /// This is separated from file IO so tests can exercise the parse
+    /// directly against synthetic bytes without touching the filesystem.
+    public static func parseAuth(_ data: Data) throws -> CodexCredentials {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexAuthError.authFileMalformed
+        }
+        guard let tokens = json["tokens"] as? [String: Any] else {
+            throw CodexAuthError.authFileIncomplete
+        }
+        guard
+            let access = tokens["access_token"] as? String, !access.isEmpty,
+            let account = tokens["account_id"] as? String, !account.isEmpty
+        else {
+            throw CodexAuthError.authFileIncomplete
+        }
+        return CodexCredentials(accessToken: access, accountId: account)
+    }
+
+    /// Read credentials from disk. Returns `.authFileMissing` when the file
+    /// does not exist so the Store can render the "run codex auth login"
+    /// onboarding card rather than an error.
+    public static func readCredentials(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> CodexCredentials {
+        let url = authFileURL(environment: environment)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CodexAuthError.authFileMissing
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            // Existence check passed but the read failed (permissions, race
+            // with a concurrent `codex auth login` rewrite). Treat as
+            // malformed rather than missing — the file is there.
+            throw CodexAuthError.authFileMalformed
+        }
+        return try parseAuth(data)
+    }
+
+    // MARK: Pure parsing (this is what the fixtures hit)
+
+    /// Parse one window object into a CodexRateWindow. Tolerant of absent
+    /// fields: an object with only `used_percent` still parses.
+    private static func parseWindow(_ obj: [String: Any]) -> CodexRateWindow {
+        var w = CodexRateWindow()
+        // used_percent is an Int in the live response; accept a Double too so
+        // a future server-side change to fractional percentages does not
+        // silently drop the value.
+        if let p = obj["used_percent"] as? Int {
+            w.usedPercent = p
+        } else if let p = obj["used_percent"] as? Double {
+            w.usedPercent = Int(p)
+        }
+        if let s = obj["limit_window_seconds"] as? Int {
+            w.limitWindowSeconds = s
+        } else if let s = obj["limit_window_seconds"] as? Double {
+            w.limitWindowSeconds = Int(s)
+        }
+        if let s = obj["reset_after_seconds"] as? Int {
+            w.resetAfterSeconds = s
+        } else if let s = obj["reset_after_seconds"] as? Double {
+            w.resetAfterSeconds = Int(s)
+        }
+        // reset_at is a Unix epoch integer (seconds). JSONSerialization may
+        // surface a large integer as Int or, on 32-bit-ish paths, Double —
+        // handle both.
+        if let epoch = obj["reset_at"] as? Int {
+            w.resetAt = Date(timeIntervalSince1970: TimeInterval(epoch))
+        } else if let epoch = obj["reset_at"] as? Double {
+            w.resetAt = Date(timeIntervalSince1970: epoch)
+        }
+        return w
+    }
+
+    /// Parse the JSON body of a `wham/usage` response into a snapshot.
+    /// Preserves every field the tiles consume. Throws `invalidJSON` only
+    /// when the top level is not a JSON object — a well-formed but sparse
+    /// response (missing credits, null additional_rate_limits) parses to a
+    /// snapshot with defaulted/absent fields, matching how AnthropicUsage
+    /// Fetcher tolerates Free-plan minimal bodies.
+    public static func parse(_ data: Data) throws -> CodexUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexUsageParseError.invalidJSON
+        }
+
+        var snap = CodexUsageSnapshot()
+
+        snap.planType = json["plan_type"] as? String
+
+        if let rl = json["rate_limit"] as? [String: Any] {
+            if let allowed = rl["allowed"] as? Bool { snap.allowed = allowed }
+            if let reached = rl["limit_reached"] as? Bool { snap.limitReached = reached }
+
+            if let primary = rl["primary_window"] as? [String: Any] {
+                snap.primaryWindow = parseWindow(primary)
+            }
+            if let secondary = rl["secondary_window"] as? [String: Any] {
+                snap.secondaryWindow = parseWindow(secondary)
+            }
+        }
+
+        // additional_rate_limits is null on most accounts. When present it is
+        // an array of AdditionalRateLimitDetails: each element carries
+        // limit_name + metered_feature, and its usage is nested under
+        // `rate_limit.primary_window` / `rate_limit.secondary_window` — NOT
+        // flat on the element. Anything that is not an array (including
+        // explicit null) yields an empty list.
+        if let additional = json["additional_rate_limits"] as? [[String: Any]] {
+            snap.additionalLimits = additional.map { entry in
+                var limit = CodexAdditionalLimit(
+                    limitName: entry["limit_name"] as? String,
+                    meteredFeature: entry["metered_feature"] as? String
+                )
+                if let nested = entry["rate_limit"] as? [String: Any] {
+                    if let primary = nested["primary_window"] as? [String: Any] {
+                        limit.primaryWindow = parseWindow(primary)
+                    }
+                    if let secondary = nested["secondary_window"] as? [String: Any] {
+                        limit.secondaryWindow = parseWindow(secondary)
+                    }
+                }
+                return limit
+            }
+        }
+
+        if let c = json["credits"] as? [String: Any] {
+            var credits = CodexCredits()
+            if let has = c["has_credits"] as? Bool { credits.hasCredits = has }
+            if let unlimited = c["unlimited"] as? Bool { credits.unlimited = unlimited }
+            if let overage = c["overage_limit_reached"] as? Bool { credits.overageLimitReached = overage }
+            // balance is a String in the live response; accept a number too
+            // and stringify it defensively.
+            if let b = c["balance"] as? String {
+                credits.balance = b
+            } else if let b = c["balance"] as? Int {
+                credits.balance = String(b)
+            } else if let b = c["balance"] as? Double {
+                credits.balance = String(b)
+            }
+            snap.credits = credits
+        }
+
+        return snap
+    }
+}

--- a/app/CodexUsageStore.swift
+++ b/app/CodexUsageStore.swift
@@ -1,0 +1,376 @@
+// PR 3-BE — Codex UsageProvider conformer (dark code, feature-flag off).
+//
+// CodexUsageStore is the second UsageProvider (after AnthropicUsageStore).
+// It holds the observable state for the Codex tiles and drives the fetch
+// against `GET https://chatgpt.com/backend-api/wham/usage`, parsing the
+// response through the Sendable CodexUsageFetcher.
+//
+// Feature posture in PR 3-BE:
+//   - `features.codex.enabled` defaults FALSE. Every provider except
+//     Anthropic is opt-in; existing v1.3.1 users see zero change.
+//   - Nothing appends a CodexUsageStore into AppDelegate.providers yet.
+//     The popover wiring, Settings toggle, and shared-timer registration
+//     land in PR 3-UI. This file is compiled and unit-tested but inert at
+//     runtime until the flag is turned on and the store is registered.
+//
+// Auth posture (plan Phase 1): read `~/.codex/auth.json` only. Do NOT
+// initiate an in-app OAuth PKCE flow — using the Codex CLI's client id from
+// a third-party GUI is impersonation-adjacent. Do NOT write back to
+// auth.json on 401; instead surface a "session expired, run codex auth
+// login" state. Writeback is deferred to Phase 1b.
+//
+// Labels: every tile is prefixed "Codex", never "ChatGPT". The 5-hour and
+// weekly windows cover the Codex CLI, IDE extensions, Slack, and Cloud
+// tasks — one shared pool. General GPT chat is not counted here.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// @MainActor because the store owns @Published state observed by SwiftUI.
+// @preconcurrency on the UsageProvider conformance defers strict
+// actor-isolation checking until PR 16 migrates the protocol to @MainActor —
+// identical staging to AnthropicUsageStore.
+@MainActor
+public final class CodexUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "codex"
+    public let displayName: String = "Codex (OpenAI)"
+    public let featureFlagKey: String = "features.codex.enabled"
+
+    // MARK: Observable state
+
+    /// The most recent successfully parsed snapshot. Nil before the first
+    /// successful fetch, or after a fetch that failed.
+    @Published public private(set) var snapshot: CodexUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// True when auth.json is present and yields usable credentials. Set by
+    /// each fetch attempt so the tile can distinguish "not configured yet"
+    /// (needs onboarding card) from "configured but fetch failed" (error).
+    @Published public private(set) var hasCredentials: Bool = false
+    /// True when the last failure was a 401 — the user must re-run
+    /// `codex auth login`. Distinct from a generic network error.
+    @Published public private(set) var sessionExpired: Bool = false
+
+    // Injected dependencies keep the store unit-testable. The default
+    // production values read the real environment and hit the real
+    // endpoint; tests inject a fixed environment and a stubbed transport.
+    private let environment: [String: String]
+    private let transport: CodexUsageTransport
+    // Overrides UserDefaults for the feature flag in tests so a test does
+    // not have to mutate the shared standard defaults. Defaults to .standard.
+    private let defaults: UserDefaults
+
+    public init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        transport: CodexUsageTransport = URLSessionCodexTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.environment = environment
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    /// Codex is opt-in. Unlike Anthropic (on by default for compat), an
+    /// unset flag means OFF. The user turns it on in Settings (PR 3-UI).
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured means auth.json exists and parses. We probe the file
+    /// lazily so `isConfigured` is honest even before the first fetch.
+    public var isConfigured: Bool {
+        (try? CodexUsageFetcher.readCredentials(environment: environment)) != nil
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Not configured — render the onboarding card telling the user to
+        // run `codex auth login`. This is a needsAccess tile, matching the
+        // protocol's first-run onboarding kind.
+        if !isConfigured {
+            return [UsageTile(
+                id: "codex-needs-auth",
+                title: "Codex",
+                kind: .needsAccess(
+                    path: CodexUsageFetcher.authFileURL(environment: environment).path,
+                    guidance: "Run `codex auth login` in a terminal, then click Refresh."
+                )
+            )]
+        }
+
+        // Configured but the session expired (401) — a distinct actionable
+        // state, again pointing at re-login rather than a generic error.
+        if sessionExpired {
+            return [UsageTile(
+                id: "codex-session-expired",
+                title: "Codex",
+                kind: .text(
+                    status: "Codex session expired",
+                    subtitle: "Run `codex auth login` in a terminal, then click Refresh."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else {
+            // Configured, no error, but no data yet (pre-first-fetch). Empty
+            // tiles — the popover shows nothing for Codex until data lands,
+            // matching Anthropic's pre-fetch behaviour.
+            return []
+        }
+
+        var out: [UsageTile] = []
+
+        if let primary = snap.primaryWindow {
+            out.append(UsageTile(
+                id: "codex-5h",
+                title: "Codex (5 hour)",
+                kind: .bar(
+                    fraction: fraction(primary.usedPercent),
+                    resetsAt: primary.resetAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        if let secondary = snap.secondaryWindow {
+            out.append(UsageTile(
+                id: "codex-weekly",
+                title: "Codex (7 day)",
+                kind: .bar(
+                    fraction: fraction(secondary.usedPercent),
+                    resetsAt: secondary.resetAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        // Zero or more model-specific limit lanes (per-model or promotional
+        // caps, e.g. Spark). Empty on most accounts. Each lane's usage is
+        // nested under its own primary/secondary window; a lane can surface
+        // up to two bars. Index disambiguates the tile id when the server
+        // omits a limit_name.
+        for (index, limit) in snap.additionalLimits.enumerated() {
+            let label = limit.limitName ?? limit.meteredFeature ?? "Additional limit \(index + 1)"
+            if let primary = limit.primaryWindow {
+                out.append(UsageTile(
+                    id: "codex-additional-\(index)-5h",
+                    title: "Codex \(label) (5 hour)",
+                    kind: .bar(
+                        fraction: fraction(primary.usedPercent),
+                        resetsAt: primary.resetAt,
+                        badge: nil
+                    )
+                ))
+            }
+            if let secondary = limit.secondaryWindow {
+                out.append(UsageTile(
+                    id: "codex-additional-\(index)-weekly",
+                    title: "Codex \(label) (7 day)",
+                    kind: .bar(
+                        fraction: fraction(secondary.usedPercent),
+                        resetsAt: secondary.resetAt,
+                        badge: nil
+                    )
+                ))
+            }
+        }
+
+        // Optional credits tile — only when the account actually carries a
+        // credit balance. Suppressed otherwise so free/subscription accounts
+        // do not see a confusing "0" credit line.
+        if let credits = snap.credits, credits.hasCredits, let balance = credits.balance {
+            out.append(UsageTile(
+                id: "codex-credits",
+                title: "Codex credits",
+                kind: .text(
+                    status: credits.unlimited ? "Unlimited" : balance,
+                    subtitle: credits.overageLimitReached ? "Overage limit reached" : nil
+                )
+            ))
+        }
+
+        return out
+    }
+
+    /// Convert a 0…100 integer percentage into a 0.0…1.0 fraction, clamped
+    /// so a malformed >100 value cannot overflow a progress bar.
+    private func fraction(_ percent: Int) -> Double {
+        min(max(Double(percent) / 100.0, 0.0), 1.0)
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result to observable state. Extracted from the
+    /// async completion so the TestRunner can drive every branch (success,
+    /// 401 → sessionExpired, httpError, networkError) synchronously without
+    /// touching the network. `now` is injected so the lastUpdatedAt
+    /// assertion is deterministic.
+    public func apply(_ result: CodexUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try CodexUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+                self.sessionExpired = false
+            } catch {
+                self.lastError = "Could not parse Codex usage"
+            }
+        case .unauthorized:
+            // 401 — surface the re-login state. Do NOT write back to
+            // auth.json in PR 3-BE (Phase 1). Keep the last snapshot so the
+            // popover does not flash empty, but flag expiry.
+            self.sessionExpired = true
+            self.lastError = nil
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    /// Test-only helper to set credential presence without a real auth.json.
+    /// Used by tile-rendering tests that inject a store with a fixed
+    /// environment. Never called in production.
+    public func setHasCredentialsForTesting(_ value: Bool) {
+        self.hasCredentials = value
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        let creds: CodexCredentials
+        do {
+            creds = try CodexUsageFetcher.readCredentials(environment: environment)
+        } catch CodexAuthError.authFileMissing {
+            // Not configured. Clear any stale data; tiles render the
+            // onboarding card via isConfigured == false.
+            hasCredentials = false
+            snapshot = nil
+            lastError = nil
+            sessionExpired = false
+            return
+        } catch {
+            hasCredentials = false
+            snapshot = nil
+            lastError = "Codex credentials unreadable"
+            sessionExpired = false
+            return
+        }
+
+        hasCredentials = true
+
+        transport.fetchUsage(credentials: creds) { [weak self] result in
+            // Transport guarantees the completion is delivered on the main
+            // queue; applying @Published state here is main-actor safe. The
+            // application logic lives in `apply(_:)` so the TestRunner can
+            // drive every branch synchronously.
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // PR 3-BE does not own the credential file — auth.json belongs to the
+        // Codex CLI. "Clear" only drops our in-memory state; it never deletes
+        // the user's CLI login. Turning the provider off is done via the
+        // Settings toggle (PR 3-UI), not here.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        sessionExpired = false
+        hasCredentials = false
+    }
+}
+
+// MARK: - Transport abstraction
+
+/// Result of a usage fetch. `unauthorized` is split out from `httpError` so
+/// the store can render the distinct "session expired" state on 401.
+public enum CodexUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the network so the store is unit-testable without hitting the
+/// live endpoint. The completion MUST be delivered on the main queue.
+public protocol CodexUsageTransport: Sendable {
+    func fetchUsage(
+        credentials: CodexCredentials,
+        completion: @escaping @Sendable (CodexUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues the real request with the Bearer token and
+/// account-id header, mirroring the Codex CLI's own request. The response
+/// body is never logged (it is tied to the user's account) — only the
+/// status code goes through the categorical logger, matching the Anthropic
+/// fetch site and satisfying the CI credential-leak guard.
+public struct URLSessionCodexTransport: CodexUsageTransport {
+    private let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+
+    public init() {}
+
+    public func fetchUsage(
+        credentials: CodexCredentials,
+        completion: @escaping @Sendable (CodexUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(credentials.accountId, forHTTPHeaderField: "chatgpt-account-id")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (CodexUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                // Error object may reference the request; do not log it (it
+                // can carry the URL with headers in some transports). A
+                // generic marker is enough.
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("Codex usage API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/CodexUsageStore.swift
+++ b/app/CodexUsageStore.swift
@@ -275,14 +275,11 @@ public final class CodexUsageStore: @preconcurrency UsageProvider {
         hasCredentials = true
 
         transport.fetchUsage(credentials: creds) { [weak self] result in
-            // Transport guarantees the completion is delivered on the main
-            // queue; applying @Published state here is main-actor safe. The
-            // application logic lives in `apply(_:)` so the TestRunner can
-            // drive every branch synchronously.
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Hop to the main actor to apply @Published state. Task {
+            // @MainActor } is safe whichever queue the transport delivers on
+            // (cannot trap like assumeIsolated). The application logic lives
+            // in `apply(_:)` so the TestRunner can drive every branch directly.
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 

--- a/app/CopilotUsageFetcher.swift
+++ b/app/CopilotUsageFetcher.swift
@@ -1,0 +1,268 @@
+// PR 9-BE — GitHub Copilot usage fetcher (fine-grained PAT).
+//
+// Seventh non-Anthropic provider. Reads GitHub's public REST billing
+// endpoint for the authenticated user's AI Credit spend:
+//   GET /users/{username}/settings/billing/ai_credit/usage
+// on api.github.com, with a fine-grained PAT carrying the `Plan (Read)`
+// permission (Account permissions section). Verified against the mid-2026
+// canonical OpenAPI spec (github/rest-api-description, API version
+// 2026-03-10) and against docs.github.com/en/rest/billing/usage.
+//
+// Feature posture: features.copilot.enabled defaults false. Nothing
+// registers a store into the live registry yet (the tile + Settings PAT
+// paste sheet land in PR 9-UI). This file is compiled and unit-tested but
+// inert at runtime until enabled.
+//
+// Deliberately out of scope for PR 9-BE (deferred to a follow-up PR if
+// there's user demand):
+//   - OAuth Device Flow to a bespoke ClaudeUsageBar GitHub App. Requires
+//     a pre-registered client_id and a device-code prompt UX — meaningful
+//     additional surface area. PAT paste (the same UX as DeepSeek/xAI/
+//     OpenAI) is the shipped path for this milestone.
+//   - The internal copilot_internal/* endpoints. GitHub explicitly does
+//     not permit third-party clients to hit them, abuse-detection has
+//     suspended accounts using them (github/copilot-language-server-release
+//     #10), and their client_id gating (Iv1.b507a08c87ecfe98, VS Code
+//     Copilot's own OAuth App id) means a bespoke GitHub App token would
+//     be rejected anyway.
+//
+// Credential posture: the PAT is a spending credential (can view billing,
+// scope-appropriate account info). Stored in KeychainStore, never logged.
+// Only HTTP status codes go through Log.info(.count).
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// One entry from `usageItems[]`. Every field is present on the wire for a
+/// populated report (verified against the OpenAPI spec's required list); we
+/// parse defensively so a schema tweak that adds/removes an optional field
+/// does not throw.
+public struct CopilotUsageItem: Equatable, Sendable {
+    /// e.g. "Copilot AI Credits", "Copilot" for premium requests.
+    public var product: String
+    /// e.g. "AI Credit", "Copilot Premium Request".
+    public var sku: String
+    /// Model name, e.g. "GPT-5". Optional in some SKUs.
+    public var model: String?
+    /// e.g. "ai-credits", "requests". Do NOT gate the credit line on this
+    /// field — SKU strings are the reliable discriminator per the research
+    /// report (docs render `unitType: "credits"` in one place and
+    /// `"ai-credits"` in another).
+    public var unitType: String
+    /// Per-unit price in USD. Fixed at 0.01 for AI Credit today.
+    public var pricePerUnit: Double
+    /// Total volume before any included allowance is applied. May be
+    /// fractional (some captures show float grossQuantity like 3956.1799545)
+    /// — do NOT decode as Int.
+    public var grossQuantity: Double
+    /// Gross USD amount (pricePerUnit * grossQuantity).
+    public var grossAmount: Double
+    /// Allowance already consumed within the included per-plan bucket.
+    public var discountQuantity: Double
+    public var discountAmount: Double
+    /// Chargeable overage quantity (gross minus discount).
+    public var netQuantity: Double
+    /// Chargeable overage in USD. This is what the MTD tile sums.
+    public var netAmount: Double
+
+    public init(
+        product: String,
+        sku: String,
+        model: String? = nil,
+        unitType: String,
+        pricePerUnit: Double,
+        grossQuantity: Double,
+        grossAmount: Double,
+        discountQuantity: Double,
+        discountAmount: Double,
+        netQuantity: Double,
+        netAmount: Double
+    ) {
+        self.product = product
+        self.sku = sku
+        self.model = model
+        self.unitType = unitType
+        self.pricePerUnit = pricePerUnit
+        self.grossQuantity = grossQuantity
+        self.grossAmount = grossAmount
+        self.discountQuantity = discountQuantity
+        self.discountAmount = discountAmount
+        self.netQuantity = netQuantity
+        self.netAmount = netAmount
+    }
+}
+
+/// Parsed `/settings/billing/ai_credit/usage` body. `timePeriod` and `user`
+/// are always present on a 200; `usageItems` can legitimately be `[]` when
+/// the user's Copilot licence is billed through an organisation/enterprise
+/// (the personal endpoint returns 200 with an empty array, NOT a 404).
+public struct CopilotUsageSnapshot: Equatable, Sendable {
+    public var year: Int
+    public var month: Int?
+    public var day: Int?
+    public var user: String
+    /// Optional top-level filter echo — the endpoint returns whatever
+    /// `product` filter was requested, or nil when no filter.
+    public var product: String?
+    /// Same, for `model` filter.
+    public var model: String?
+    /// One entry per (SKU × model) combination for the requested period.
+    public var items: [CopilotUsageItem]
+
+    public init(
+        year: Int = 0,
+        month: Int? = nil,
+        day: Int? = nil,
+        user: String = "",
+        product: String? = nil,
+        model: String? = nil,
+        items: [CopilotUsageItem] = []
+    ) {
+        self.year = year
+        self.month = month
+        self.day = day
+        self.user = user
+        self.product = product
+        self.model = model
+        self.items = items
+    }
+
+    /// Sum of `netAmount` across items — this is what the tile displays as
+    /// "MTD spend". `max(0, …)` guards against a hostile server that emits
+    /// negative amounts.
+    public var netAmountMTDUSD: Double {
+        max(0, items.reduce(0.0) { $0 + $1.netAmount })
+    }
+
+    /// Grouping helper for a "by SKU" breakdown tile. Ordered by
+    /// descending net amount so the biggest line item is first.
+    public var itemsBySkuDescending: [CopilotUsageItem] {
+        items.sorted { $0.netAmount > $1.netAmount }
+    }
+
+    /// True when the endpoint returned a 200 with an empty items array —
+    /// the documented signal that the user's Copilot licence is managed
+    /// through an org/enterprise seat and the personal endpoint carries
+    /// no data for them.
+    public var isEmptyOrgBilled: Bool {
+        items.isEmpty
+    }
+}
+
+public enum CopilotUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct CopilotUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain key under which the fine-grained PAT is stored.
+    public static let patKeychainKey = "copilot.pat_token"
+
+    /// Keychain key under which the user's GitHub login (needed for the
+    /// path parameter) is stored. We derive this from the PAT via the
+    /// `/user` endpoint at fetch time and persist it so subsequent fetches
+    /// skip the extra round-trip.
+    public static let loginKeychainKey = "copilot.github_login"
+
+    /// GitHub REST API version this parser was verified against. Pinned so
+    /// a client-driven change to a new schema is deliberate. Sunset for
+    /// the previous version (2022-11-28) is 10 March 2028; migrating past
+    /// then is a separate future PR.
+    public static let apiVersion = "2026-03-10"
+
+    // MARK: - Parsers
+
+    /// Parse the `ai_credit/usage` response.
+    public static func parseUsage(_ data: Data) throws -> CopilotUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CopilotUsageParseError.invalidJSON
+        }
+        // Codex round-1 finding #6: `usageItems` is REQUIRED per the
+        // OpenAPI 2026-03-10 spec. A missing key is a schema violation
+        // (proxy stripped it, GitHub broke the response) — NOT the same
+        // as the documented `usageItems: []` "org-billed" signal, which
+        // is an empty array. Refuse the missing case so we surface a
+        // parse error rather than mis-labelling as org-billed.
+        guard let items = json["usageItems"] as? [[String: Any]] else {
+            throw CopilotUsageParseError.unexpectedShape("usageItems missing")
+        }
+
+        var snap = CopilotUsageSnapshot()
+        if let period = json["timePeriod"] as? [String: Any] {
+            snap.year = intOrZero(period["year"])
+            snap.month = intOrNil(period["month"])
+            snap.day = intOrNil(period["day"])
+        }
+        snap.user = (json["user"] as? String) ?? ""
+        snap.product = json["product"] as? String
+        snap.model = json["model"] as? String
+        snap.items = items.compactMap { parseItem($0) }
+        return snap
+    }
+
+    private static func parseItem(_ entry: [String: Any]) -> CopilotUsageItem? {
+        // sku and product are the load-bearing discriminators; refuse an
+        // item that lacks either rather than smuggling in an empty-string
+        // line.
+        guard let product = entry["product"] as? String, !product.isEmpty,
+              let sku = entry["sku"] as? String, !sku.isEmpty else {
+            return nil
+        }
+        return CopilotUsageItem(
+            product: product,
+            sku: sku,
+            model: entry["model"] as? String,
+            unitType: (entry["unitType"] as? String) ?? "",
+            pricePerUnit: doubleOrZero(entry["pricePerUnit"]),
+            grossQuantity: doubleOrZero(entry["grossQuantity"]),
+            grossAmount: doubleOrZero(entry["grossAmount"]),
+            discountQuantity: doubleOrZero(entry["discountQuantity"]),
+            discountAmount: doubleOrZero(entry["discountAmount"]),
+            netQuantity: doubleOrZero(entry["netQuantity"]),
+            netAmount: doubleOrZero(entry["netAmount"])
+        )
+    }
+
+    /// Parse `GET /user` (used to discover the authenticated user's login
+    /// for the billing endpoint's `{username}` path parameter). Only the
+    /// `login` field is consumed.
+    public static func parseAuthenticatedUserLogin(_ data: Data) throws -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let login = json["login"] as? String, !login.isEmpty else {
+            throw CopilotUsageParseError.unexpectedShape("missing user.login")
+        }
+        return login
+    }
+
+    // MARK: - Numeric coercion
+
+    /// Int coercion. Rejects non-finite / oversize Doubles rather than
+    /// trapping. Accepts numeric strings defensively (some third-party
+    /// GitHub proxies stringify small integers).
+    static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+    static func intOrZero(_ value: Any?) -> Int { intOrNil(value) ?? 0 }
+
+    /// Double coercion. Non-finite → nil. Preserves fractional precision
+    /// (GitHub's grossQuantity has been observed as 3956.1799545).
+    static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d.isFinite ? d : nil }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s).flatMap { $0.isFinite ? $0 : nil } }
+        return nil
+    }
+    static func doubleOrZero(_ value: Any?) -> Double { doubleOrNil(value) ?? 0 }
+}

--- a/app/CopilotUsageStore.swift
+++ b/app/CopilotUsageStore.swift
@@ -1,0 +1,556 @@
+// PR 9-BE — GitHub Copilot UsageProvider conformer (dark code, flag off).
+//
+// Seventh non-Anthropic provider. Reads GitHub's public REST billing
+// endpoint for the authenticated user's Copilot AI Credit spend via a
+// fine-grained PAT with the `Plan (Read)` permission. See CopilotUsageFetcher
+// for the full deferred-scope notes.
+//
+// Feature posture: features.copilot.enabled defaults false. Nothing registers
+// a store into the live registry yet (the tile + Settings paste sheet land
+// in PR 9-UI).
+//
+// Credential posture: the PAT is a spending credential (can view billing).
+// Stored in KeychainStore, never logged. Only HTTP status codes go through
+// Log.info(.count).
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class CopilotUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
+
+    public let id: String = "copilot"
+    public let displayName: String = "GitHub Copilot"
+    public let featureFlagKey: String = "features.copilot.enabled"
+
+    // PasteKeyProvider — the user pastes a fine-grained PAT prefixed
+    // `github_pat_`. The `Plan (Read)` permission is a per-user account
+    // permission (not an org permission), so the PAT resource owner MUST
+    // be the user's own account.
+    public let keyPlaceholder: String = "github_pat_… (fine-grained token, Plan: Read)"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: CopilotUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: CopilotUsageTransport
+    private let defaults: UserDefaults
+
+    /// Monotonically-increasing generation counter. Every credential-changing
+    /// event (`saveKey`, `clear`) bumps it; every `fetch()` snapshots the
+    /// current value into its completion closure and only applies the
+    /// result if the counter is still that value. This defeats two Codex
+    /// review #1/#2 races:
+    ///   - fetch launched with PAT A completes AFTER the user saved PAT B →
+    ///     the stale result would otherwise land in `snapshot`.
+    ///   - fetch launched, then `clear()` was called → the stale result
+    ///     would otherwise repopulate state that clear had just wiped.
+    private var fetchGeneration: UInt64 = 0
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: CopilotUsageTransport = URLSessionCopilotTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when a PAT is stored. `.unavailable` (locked keychain) counts
+    /// as configured so a locked screen does not drop the provider to
+    /// onboarding (parity with the PR #60 hardening pattern; and the
+    /// chk1-audit Bug #2 fix in Perplexity).
+    public var hasKey: Bool {
+        switch credentials.readResult(CopilotUsageFetcher.patKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
+    }
+
+    /// Save a pasted PAT. Empty input clears it and the cached login. We
+    /// clear the login too because a new PAT may belong to a different
+    /// GitHub user. Also bumps the fetch generation so any in-flight
+    /// fetch launched with the previous PAT will be discarded when its
+    /// completion fires.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(CopilotUsageFetcher.patKeychainKey)
+            credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+        } else {
+            credentials.write(CopilotUsageFetcher.patKeychainKey, Data(trimmed.utf8))
+            // Do NOT preserve a stale login here — the new PAT may belong
+            // to a different account. The next fetch discovers it via /user.
+            credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+        }
+        fetchGeneration &+= 1
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool { defaults.bool(forKey: featureFlagKey) }
+    public var isConfigured: Bool { hasKey }
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "copilot-needs-key",
+                title: "GitHub Copilot",
+                kind: .needsAccess(
+                    path: "api.github.com",
+                    guidance: "Paste a fine-grained GitHub PAT with 'Plan: Read' (Account permissions) in Settings. Resource owner must be your own account."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        // Org-billed / no-activity signal: 200 with usageItems == [] means
+        // the user has no personal spend to report (either their Copilot
+        // seat is managed through an org/enterprise, or they simply had
+        // zero AI Credit usage in the period). Surface a specific tile so
+        // an empty section is not mistaken for a fetch failure.
+        if snap.isEmptyOrgBilled {
+            return [UsageTile(
+                id: "copilot-empty",
+                title: "GitHub Copilot",
+                kind: .text(
+                    status: "No personal usage",
+                    subtitle: "If your Copilot seat is managed by an organisation or enterprise, personal usage is not reported on this endpoint."
+                )
+            )]
+        }
+
+        var out: [UsageTile] = []
+
+        // Headline MTD spend tile. netAmount is a USD Double; the balance
+        // tile takes minor units (cents). Crash-safe against a hostile
+        // 1e300 amount via the same Int(exactly:) clamp used in Perplexity.
+        let usdMTD = snap.netAmountMTDUSD
+        let cents: Int = {
+            let clamped = max(0.0, usdMTD * 100.0)
+            guard clamped.isFinite else { return 0 }
+            return Int(exactly: clamped.rounded()) ?? Int.max
+        }()
+        out.append(UsageTile(
+            id: "copilot-mtd",
+            title: "Copilot spend (MTD)",
+            kind: .balance(
+                remainingMinorUnits: cents,
+                currency: "USD",
+                plan: periodLabel(snap),
+                resetsAt: nil        // no month-end date on the wire
+            )
+        ))
+
+        // Per-SKU breakdown as `.text` tiles. Cap at the top three so the
+        // popover does not stretch on accounts with many SKUs.
+        for item in snap.itemsBySkuDescending.prefix(3) where item.netAmount > 0 {
+            let dollarString = String(format: "USD %.2f", item.netAmount)
+            let subtitle: String = {
+                var parts: [String] = []
+                if let model = item.model, !model.isEmpty { parts.append(model) }
+                let qty = item.netQuantity
+                // Codex round-1 finding #3: `Int(qty)` traps on non-finite
+                // or oversize Doubles (`Int(1e300)` is a trap, not a
+                // truncation). Guard with `Int(exactly:)` on the rounded
+                // integer path and fall back to a %.2f render for anything
+                // that would not round-trip cleanly.
+                let qtyString: String = {
+                    if qty.isFinite && qty == qty.rounded(),
+                       let asInt = Int(exactly: qty.rounded()) {
+                        return String(asInt)
+                    }
+                    return String(format: "%.2f", qty)
+                }()
+                let unit = item.unitType.isEmpty ? "units" : item.unitType
+                parts.append("\(qtyString) \(unit)")
+                return parts.joined(separator: " · ")
+            }()
+            out.append(UsageTile(
+                id: "copilot-sku-\(item.sku.lowercased().replacingOccurrences(of: " ", with: "-"))",
+                title: item.sku,
+                kind: .text(status: dollarString, subtitle: subtitle)
+            ))
+        }
+
+        return out
+    }
+
+    /// Human label for the reporting period, e.g. "July 2026" or "2026".
+    private func periodLabel(_ snap: CopilotUsageSnapshot) -> String {
+        // Codex round-1 finding #7: hostile `month: 13` would let
+        // `Calendar.date(from:)` roll over to January of the next year,
+        // labelling the wrong billing period. Validate 1…12 before use.
+        if let month = snap.month, (1 ... 12).contains(month) {
+            let fmt = DateFormatter()
+            fmt.dateFormat = "LLLL yyyy"
+            var comps = DateComponents()
+            comps.year = snap.year
+            comps.month = month
+            comps.day = 1
+            if let date = Calendar(identifier: .gregorian).date(from: comps) {
+                return fmt.string(from: date)
+            }
+        }
+        return String(snap.year)
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: CopilotUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            // 401 site-wide (or 403 with x-ratelimit-remaining > 0): the PAT
+            // is invalid, expired, or lacks the Plan permission. Drop the
+            // stale snapshot to match the Perplexity chk1 fix pattern.
+            self.snapshot = nil
+            self.lastError = "GitHub token invalid or missing Plan permission. Re-generate a fine-grained PAT with Plan: Read."
+        case .rateLimited(let retryAfterSeconds):
+            if let sec = retryAfterSeconds, sec > 0 {
+                self.lastError = "GitHub rate-limited (retry in \(sec)s)."
+            } else {
+                self.lastError = "GitHub rate-limited. Try again shortly."
+            }
+        case .httpError(let code):
+            if (500 ..< 600).contains(code) {
+                self.lastError = "GitHub server error (HTTP \(code)). Retry later."
+            } else {
+                self.lastError = "HTTP \(code)"
+            }
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        // Use readResult() so a locked keychain (.unavailable) is
+        // distinguished from a truly-missing PAT — same audit-hardened
+        // pattern the chk1-fix branch established for Perplexity.
+        let patData: Data
+        switch credentials.readResult(CopilotUsageFetcher.patKeychainKey) {
+        case .found(let value) where !value.isEmpty:
+            patData = value
+        case .found, .missing:
+            snapshot = nil
+            lastError = nil
+            return
+        case .unavailable:
+            snapshot = nil
+            lastError = "Keychain locked or unavailable. Unlock your Mac to refresh Copilot usage."
+            return
+        }
+        guard let pat = String(data: patData, encoding: .utf8) else {
+            snapshot = nil
+            lastError = "Could not decode the stored GitHub token. Re-paste it in Settings."
+            return
+        }
+        // Cached login (if any) from a prior fetch, so we can skip the
+        // /user round-trip. read() rather than readResult() is fine here —
+        // absence just triggers a fresh discovery.
+        let cachedLogin = credentials.read(CopilotUsageFetcher.loginKeychainKey)
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        // Codex round-2 finding #1: EVERY fetch bumps the generation, not
+        // just credential changes. That way two overlapping fetches (e.g.
+        // auto-refresh timer + user's Refresh button) never share the same
+        // launchedAt, so the earlier one is always superseded by the later.
+        fetchGeneration &+= 1
+        let launchedAt = fetchGeneration
+
+        transport.fetchAll(token: pat, cachedLogin: cachedLogin) { [weak self] result, discoveredLogin in
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                // Codex round-1 findings #1 + #2: discard if the credential
+                // that launched this fetch has since been rotated or cleared.
+                guard self.fetchGeneration == launchedAt else { return }
+                // Codex round-1 finding #5 (broadened per round-2 #2): if
+                // the fetch was launched with a CACHED login and it failed
+                // in any way that suggests the login is wrong (404, 401
+                // — the user's login may have been renamed such that the
+                // cached username is now someone else's, or 403 that isn't
+                // a rate limit), drop the cache. Next fetch re-discovers
+                // via /user. rateLimited is left alone — no reason to
+                // suspect the cached login there.
+                if cachedLogin != nil {
+                    switch result {
+                    case .httpError(404), .unauthorized:
+                        self.credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+                    default:
+                        break
+                    }
+                }
+                // Persist a freshly-discovered login so future fetches skip
+                // the /user hop. Only write when the login actually changed
+                // (i.e. the transport resolved one and it differs from cache).
+                if let login = discoveredLogin, cachedLogin != login {
+                    self.credentials.write(CopilotUsageFetcher.loginKeychainKey, Data(login.utf8))
+                }
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        credentials.delete(CopilotUsageFetcher.patKeychainKey)
+        credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+        // Bump BEFORE clearing state — an in-flight fetch's completion
+        // will see the new generation and skip its apply() step.
+        fetchGeneration &+= 1
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum CopilotUsageResult: Sendable {
+    case success(CopilotUsageSnapshot)
+    case unauthorized
+    /// 429, or 403 with `x-ratelimit-remaining: 0`. Optional retry hint
+    /// from `Retry-After` (seconds) or `x-ratelimit-reset` (delta).
+    case rateLimited(retryAfterSeconds: Int?)
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the login-discovery-plus-billing chain. Completion MAY be
+/// delivered on any queue; the store hops to the main actor via
+/// `Task { @MainActor }`. `discoveredLogin` is nil when the transport
+/// reused a cached login (no /user hop), and populated when a fresh
+/// discovery occurred (so the store can persist it).
+public protocol CopilotUsageTransport: Sendable {
+    func fetchAll(
+        token: String,
+        cachedLogin: String?,
+        completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void
+    )
+}
+
+/// Production transport. Chains: `GET /user` (skipped when `cachedLogin`
+/// is present) → `GET /users/{login}/settings/billing/ai_credit/usage`.
+/// Uses a private URLSession with ephemeral configuration and bounded
+/// timeouts — same chk1-audit pattern the Perplexity transport landed.
+public struct URLSessionCopilotTransport: CopilotUsageTransport {
+
+    private let userURL = URL(string: "https://api.github.com/user")!
+    private let apiBase = "https://api.github.com"
+
+    /// Chrome-shaped User-Agent is unnecessary for api.github.com (no
+    /// Cloudflare browser fingerprinting here) but a non-empty User-Agent
+    /// IS required — GitHub rejects headerless requests with 403.
+    /// Version-tagged so a Sentry-style investigation can reproduce.
+    private let userAgent = "ClaudeUsageBar/1.7 (github.com/Artzainnn/ClaudeUsageBar)"
+
+    /// Private URLSession isolated from URLSession.shared (chk1-fix pattern
+    /// carried over from Perplexity). `.ephemeral` = in-memory cookie jar
+    /// (irrelevant here — GitHub sets no auth cookies — but keeps the
+    /// isolation guarantee), no disk cache, bounded timeouts.
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
+
+    public init() {}
+
+    public func fetchAll(
+        token: String,
+        cachedLogin: String?,
+        completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void
+    ) {
+        let deliver: @Sendable (CopilotUsageResult, String?) -> Void = { result, login in
+            DispatchQueue.main.async { completion(result, login) }
+        }
+
+        // Reject a token that carries control chars before it reaches an
+        // Authorization header. Same defence-in-depth as Perplexity.
+        guard let safeToken = RequestSafety.headerValue(token) else {
+            deliver(.unauthorized, nil)
+            return
+        }
+        let authHeader = "Bearer \(safeToken)"
+
+        // If we have a cached login, skip /user and hit billing directly.
+        if let login = cachedLogin, !login.isEmpty {
+            fetchUsage(login: login, authHeader: authHeader) { result in
+                deliver(result, nil)   // no new login discovered
+            }
+            return
+        }
+
+        // Otherwise discover the login via /user first.
+        get(userURL, authHeader: authHeader) { data, status, headers in
+            guard let status = status else {
+                deliver(.networkError, nil); return
+            }
+            if status == 401 {
+                deliver(.unauthorized, nil); return
+            }
+            if status == 403 {
+                if Self.isRateLimitResponse(headers) {
+                    deliver(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)), nil)
+                } else {
+                    deliver(.unauthorized, nil)
+                }
+                return
+            }
+            if status == 429 {
+                deliver(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)), nil)
+                return
+            }
+            guard status == 200, let data = data,
+                  let login = try? CopilotUsageFetcher.parseAuthenticatedUserLogin(data) else {
+                deliver(status == 200 ? .networkError : .httpError(status), nil); return
+            }
+            self.fetchUsage(login: login, authHeader: authHeader) { result in
+                deliver(result, login)
+            }
+        }
+    }
+
+    /// True when the response is a rate-limit response. Two flavours:
+    ///   - Primary: `x-ratelimit-remaining: 0`.
+    ///   - Secondary (abuse) rate limit: 403 with `Retry-After` present
+    ///     regardless of remaining. Codex round-2 finding #3: a naive
+    ///     "remaining == 0" check misclassified secondary rate limits as
+    ///     auth failures. `public` for unit-testability (same rationale as
+    ///     the Perplexity accumulator — app-only module, no external
+    ///     consumers).
+    public static func isRateLimitResponse(_ headers: [String: String]?) -> Bool {
+        guard let headers = headers else { return false }
+        if let raw = headers["x-ratelimit-remaining"], let remaining = Int(raw), remaining == 0 {
+            return true
+        }
+        if headers["retry-after"] != nil {
+            return true
+        }
+        return false
+    }
+
+    /// Extract a seconds-hint from a rate-limit response. GitHub's contract:
+    /// `Retry-After` (seconds OR HTTP-date) is preferred; if absent,
+    /// `x-ratelimit-reset` (UTC epoch seconds) gives an absolute reset time
+    /// from which we compute a delta. Returns nil when nothing is usable.
+    /// `public` for unit-testability.
+    public static func retryAfterSeconds(from headers: [String: String]?) -> Int? {
+        guard let headers = headers else { return nil }
+        if let raw = headers["retry-after"] {
+            if let s = Int(raw), s > 0 { return s }
+            // Codex round-2 finding #4: Retry-After may be an HTTP-date
+            // per RFC 9110. Parse it against RFC 1123 format.
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(identifier: "GMT")
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+            if let date = fmt.date(from: raw) {
+                let delta = Int(date.timeIntervalSince(Date()))
+                return delta > 0 ? delta : nil
+            }
+        }
+        if let raw = headers["x-ratelimit-reset"], let epoch = Int(raw) {
+            let delta = epoch - Int(Date().timeIntervalSince1970)
+            return delta > 0 ? delta : nil
+        }
+        return nil
+    }
+
+    /// Hit the AI-Credit billing endpoint for the given login.
+    private func fetchUsage(
+        login: String,
+        authHeader: String,
+        done: @escaping @Sendable (CopilotUsageResult) -> Void
+    ) {
+        // Path segment safety: the login is a semi-trusted string (comes
+        // from either a Keychain-cached value or GitHub's /user response).
+        // Encode as a single path segment so a hostile value cannot alter
+        // the path.
+        guard let encodedLogin = RequestSafety.pathSegment(login) else {
+            done(.unauthorized); return
+        }
+        let urlString = "\(apiBase)/users/\(encodedLogin)/settings/billing/ai_credit/usage"
+        guard let url = URL(string: urlString) else {
+            done(.networkError); return
+        }
+        get(url, authHeader: authHeader) { data, status, headers in
+            guard let status = status else { done(.networkError); return }
+            if status == 401 {
+                done(.unauthorized); return
+            }
+            if status == 403 {
+                if Self.isRateLimitResponse(headers) {
+                    done(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)))
+                } else {
+                    done(.unauthorized)
+                }
+                return
+            }
+            if status == 429 {
+                done(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)))
+                return
+            }
+            guard status == 200, let data = data,
+                  let snap = try? CopilotUsageFetcher.parseUsage(data) else {
+                done(.httpError(status)); return
+            }
+            done(.success(snap))
+        }
+    }
+
+    private func get(
+        _ url: URL,
+        authHeader: String,
+        done: @escaping @Sendable (Data?, Int?, [String: String]?) -> Void
+    ) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue(CopilotUsageFetcher.apiVersion, forHTTPHeaderField: "X-GitHub-Api-Version")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        session.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil, nil); return }
+            let http = response as? HTTPURLResponse
+            let status = http?.statusCode
+            Log.info("GitHub Copilot billing API response", .count(status ?? -1))
+            // Lower-case header keys for reliable lookup — HTTPURLResponse
+            // headers are case-insensitive per the docs but Foundation
+            // preserves the wire casing.
+            var headers: [String: String] = [:]
+            if let allHeaders = http?.allHeaderFields {
+                for (k, v) in allHeaders {
+                    if let ks = k as? String, let vs = v as? String {
+                        headers[ks.lowercased()] = vs
+                    }
+                }
+            }
+            done(data, status, headers)
+        }.resume()
+    }
+}

--- a/app/DeepSeekUsageFetcher.swift
+++ b/app/DeepSeekUsageFetcher.swift
@@ -147,34 +147,73 @@ public struct KeychainStore: CredentialStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
+            // Use the modern data-protection keychain for every item, as the
+            // security standard requires for spending credentials. Set on the
+            // base query so read/update/delete all target the same keychain
+            // the item was written to.
+            kSecUseDataProtectionKeychain as String: true,
         ]
     }
 
     public func read(_ key: String) -> Data? {
+        if case .found(let data) = readResult(key) { return data }
+        return nil
+    }
+
+    /// Richer read that distinguishes a missing item from a keychain that is
+    /// present but unavailable (locked, access denied). Callers that gate a
+    /// "not configured" onboarding state should use this so a transient
+    /// unavailability is not mistaken for "no credential", which would wrongly
+    /// prompt the user to re-paste. `read` remains for the common case.
+    public func readResult(_ key: String) -> CredentialReadResult {
         var query = baseQuery(key)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
 
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess else { return nil }
-        return item as? Data
+        switch status {
+        case errSecSuccess:
+            if let data = item as? Data { return .found(data) }
+            return .missing
+        case errSecItemNotFound:
+            return .missing
+        default:
+            // errSecInteractionNotAllowed (locked), errSecAuthFailed, etc.
+            return .unavailable(status)
+        }
     }
 
     public func write(_ key: String, _ value: Data) {
-        // Upsert: try to update an existing item first; if none exists, add.
+        // Upsert. Update first; if the item does not exist, add it. Crucially,
+        // the update path ALSO refreshes kSecAttrAccessible so an item created
+        // by an older build with a weaker accessibility class is upgraded to
+        // the current one (rather than silently keeping the weak attribute).
         let query = baseQuery(key)
-        let attributes: [String: Any] = [kSecValueData as String: value]
+        let attributes: [String: Any] = [
+            kSecValueData as String: value,
+            // WhenUnlockedThisDeviceOnly: the credential is inaccessible
+            // whenever the device is locked, never syncs to iCloud Keychain,
+            // and does not migrate to a new device. This is the least-
+            // privilege class mandated for spending credentials (stricter than
+            // AfterFirstUnlock, which stays readable while locked).
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
 
         if updateStatus == errSecItemNotFound {
             var addQuery = baseQuery(key)
             addQuery[kSecValueData as String] = value
-            // Only unlocked-while-this-device flags; the credential never
-            // syncs to iCloud Keychain and is unavailable before first
-            // unlock. Matches least-privilege for a spending credential.
-            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-            SecItemAdd(addQuery as CFDictionary, nil)
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                // The item was neither updated nor added (e.g. locked keychain
+                // or a duplicate race). Log the failure category (never the
+                // value) so a silently-dropped write is diagnosable.
+                Log.info("Keychain write failed", .count(Int(addStatus)))
+            }
+        } else if updateStatus != errSecSuccess {
+            Log.info("Keychain update failed", .count(Int(updateStatus)))
         }
     }
 

--- a/app/DeepSeekUsageFetcher.swift
+++ b/app/DeepSeekUsageFetcher.swift
@@ -1,0 +1,184 @@
+// PR 4-BE — DeepSeek usage fetcher + the first Keychain credential store.
+//
+// DeepSeek is the template "paste-a-key" provider: the user pastes an
+// `sk-...` API key, which is stored in the macOS Keychain (a spending
+// credential — it must never sit in UserDefaults). The provider then polls
+// `GET https://api.deepseek.com/user/balance` for the account balance.
+//
+// This file ships two things:
+//   1. DeepSeekUsageFetcher — Sendable value type, pure parser, mirroring
+//      the Anthropic/Codex fetchers. Fixtures hit `parse(_:)`.
+//   2. KeychainStore — the first concrete CredentialStore (the protocol was
+//      introduced in PR 47). Backs every future spending credential
+//      (DeepSeek key, Perplexity cookie, OpenAI admin key, ...).
+//
+// Response shape (verified against api-docs.deepseek.com/api/get-user-balance):
+//   {
+//     "is_available": Bool,          // is the balance sufficient for calls
+//     "balance_infos": [
+//       { "currency": "USD" | "CNY",
+//         "total_balance":     String,   // amounts are STRINGS, not numbers
+//         "granted_balance":   String,   // from promotions
+//         "topped_up_balance": String }  // paid top-ups
+//     ]
+//   }
+// All amounts are strings and are preserved verbatim — we do not reinterpret
+// currency or arithmetic on them beyond what the balance tile needs.
+
+import Foundation
+import Security
+
+// MARK: - Snapshot
+
+/// One currency's balance breakdown from `balance_infos[]`.
+public struct DeepSeekBalance: Equatable, Sendable {
+    /// "USD" or "CNY" as returned by the endpoint.
+    public var currency: String
+    /// Total balance, verbatim string (e.g. "110.00").
+    public var totalBalance: String
+    /// Promotional / granted portion, verbatim string.
+    public var grantedBalance: String
+    /// Paid top-up portion, verbatim string.
+    public var toppedUpBalance: String
+
+    public init(
+        currency: String,
+        totalBalance: String,
+        grantedBalance: String,
+        toppedUpBalance: String
+    ) {
+        self.currency = currency
+        self.totalBalance = totalBalance
+        self.grantedBalance = grantedBalance
+        self.toppedUpBalance = toppedUpBalance
+    }
+}
+
+/// A parsed snapshot of the `/user/balance` response.
+public struct DeepSeekUsageSnapshot: Equatable, Sendable {
+    /// Whether the balance is sufficient for API calls. When false the tile
+    /// turns amber and the balance is de-emphasised.
+    public var isAvailable: Bool
+    /// One entry per currency present on the account. Usually a single
+    /// currency, but the endpoint returns an array.
+    public var balances: [DeepSeekBalance]
+
+    public init(isAvailable: Bool = false, balances: [DeepSeekBalance] = []) {
+        self.isAvailable = isAvailable
+        self.balances = balances
+    }
+}
+
+public enum DeepSeekUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+/// Pure parser for the DeepSeek balance endpoint. Value type, no observable
+/// state. The Store owns the HTTP call and applies the snapshot.
+public struct DeepSeekUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Parse the JSON body of a `/user/balance` response. Throws
+    /// `invalidJSON` only when the top level is not a JSON object. A sparse
+    /// but well-formed body (empty balance_infos) parses to a snapshot with
+    /// an empty `balances` array, matching how the sibling fetchers tolerate
+    /// minimal shapes.
+    public static func parse(_ data: Data) throws -> DeepSeekUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DeepSeekUsageParseError.invalidJSON
+        }
+
+        var snap = DeepSeekUsageSnapshot()
+        if let available = json["is_available"] as? Bool {
+            snap.isAvailable = available
+        }
+
+        if let infos = json["balance_infos"] as? [[String: Any]] {
+            snap.balances = infos.compactMap { info in
+                guard let currency = info["currency"] as? String else { return nil }
+                return DeepSeekBalance(
+                    currency: currency,
+                    totalBalance: stringAmount(info["total_balance"]),
+                    grantedBalance: stringAmount(info["granted_balance"]),
+                    toppedUpBalance: stringAmount(info["topped_up_balance"])
+                )
+            }
+        }
+
+        return snap
+    }
+
+    /// Balances are strings on the wire; preserve them verbatim. Accept a
+    /// number defensively (in case the API ever returns one) and stringify
+    /// it, and fall back to "0" when the field is absent.
+    private static func stringAmount(_ value: Any?) -> String {
+        if let s = value as? String { return s }
+        if let i = value as? Int { return String(i) }
+        if let d = value as? Double { return String(d) }
+        return "0"
+    }
+}
+
+// MARK: - KeychainStore
+
+/// First concrete CredentialStore (protocol from PR 47). Stores spending
+/// credentials in the macOS login Keychain as generic passwords, keyed by a
+/// per-app service plus the caller's key. Every provider that holds a
+/// spending credential (DeepSeek API key, Perplexity cookie, OpenAI admin
+/// key) uses this rather than UserDefaults.
+///
+/// The service string namespaces our items so they never collide with other
+/// apps' Keychain entries. `read` returns nil for a missing item (not an
+/// error); `write` upserts; `delete` is idempotent.
+public struct KeychainStore: CredentialStore {
+    /// Keychain service used to namespace this app's items.
+    private let service: String
+
+    public init(service: String = "com.claude.usagebar.credentials") {
+        self.service = service
+    }
+
+    private func baseQuery(_ key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    public func read(_ key: String) -> Data? {
+        var query = baseQuery(key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else { return nil }
+        return item as? Data
+    }
+
+    public func write(_ key: String, _ value: Data) {
+        // Upsert: try to update an existing item first; if none exists, add.
+        let query = baseQuery(key)
+        let attributes: [String: Any] = [kSecValueData as String: value]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            var addQuery = baseQuery(key)
+            addQuery[kSecValueData as String] = value
+            // Only unlocked-while-this-device flags; the credential never
+            // syncs to iCloud Keychain and is unavailable before first
+            // unlock. Matches least-privilege for a spending credential.
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            SecItemAdd(addQuery as CFDictionary, nil)
+        }
+    }
+
+    public func delete(_ key: String) {
+        SecItemDelete(baseQuery(key) as CFDictionary)
+    }
+}

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -1,0 +1,261 @@
+// PR 4-BE — DeepSeek UsageProvider conformer (dark code, feature-flag off).
+//
+// Third provider (after Anthropic and Codex). DeepSeek is the "paste-a-key"
+// template: the user pastes an `sk-...` API key, stored in the Keychain via
+// KeychainStore, and the provider polls the account balance.
+//
+// Feature posture in PR 4-BE:
+//   - `features.deepseek.enabled` defaults FALSE (opt-in, like every
+//     non-Anthropic provider).
+//   - Nothing registers a DeepSeekUsageStore into AppDelegate.providers yet;
+//     the tile + Settings key-paste sheet land in PR 4-UI. This file is
+//     compiled and unit-tested but inert at runtime until then.
+//
+// Credential posture: the API key is a spending credential. It is stored in
+// the Keychain (never UserDefaults) and never logged. Only the HTTP status
+// code is logged, satisfying the CI credential-leak guard.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class DeepSeekUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "deepseek"
+    public let displayName: String = "DeepSeek"
+    public let featureFlagKey: String = "features.deepseek.enabled"
+
+    /// Keychain key under which the DeepSeek API key is stored.
+    public static let apiKeyKeychainKey = "deepseek.api_key"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: DeepSeekUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: DeepSeekUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: DeepSeekUsageTransport = URLSessionDeepSeekTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when an API key is stored. The key itself is never exposed.
+    public var hasKey: Bool {
+        guard let data = credentials.read(Self.apiKeyKeychainKey) else { return false }
+        return !data.isEmpty
+    }
+
+    /// Store a pasted API key (trimmed). Empty input clears the key instead.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(Self.apiKeyKeychainKey)
+        } else {
+            credentials.write(Self.apiKeyKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    public var isConfigured: Bool {
+        hasKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Not configured — onboarding card prompting the user to paste a key.
+        if !isConfigured {
+            return [UsageTile(
+                id: "deepseek-needs-key",
+                title: "DeepSeek",
+                kind: .needsAccess(
+                    path: "api.deepseek.com",
+                    guidance: "Paste your DeepSeek API key (sk-…) in Settings to track your balance."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Availability warning tile — shown only when the balance is not
+        // sufficient for API calls, so a healthy account stays uncluttered.
+        if !snap.isAvailable {
+            out.append(UsageTile(
+                id: "deepseek-status",
+                title: "DeepSeek",
+                kind: .text(
+                    status: "Balance too low",
+                    subtitle: "Top up your DeepSeek account to keep making API calls."
+                )
+            ))
+        }
+
+        // One balance tile per currency. Total headline with the granted +
+        // topped-up split as the subtitle. Amounts are shown verbatim (the
+        // endpoint returns decimal strings), prefixed with the currency.
+        for balance in snap.balances {
+            out.append(UsageTile(
+                id: "deepseek-balance-\(balance.currency.lowercased())",
+                title: "DeepSeek balance (\(balance.currency))",
+                kind: .text(
+                    status: "\(balance.currency) \(balance.totalBalance)",
+                    subtitle: "Granted \(balance.grantedBalance) + topped-up \(balance.toppedUpBalance)"
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result to observable state. Extracted so the
+    /// TestRunner can drive every branch synchronously.
+    public func apply(_ result: DeepSeekUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try DeepSeekUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+            } catch {
+                self.lastError = "Could not parse DeepSeek balance"
+            }
+        case .unauthorized:
+            // 401 — the pasted key is invalid or revoked. Surface an
+            // actionable message; keep the key so the user can correct it in
+            // Settings rather than silently losing it.
+            self.lastError = "Invalid DeepSeek API key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let keyData = credentials.read(Self.apiKeyKeychainKey),
+              !keyData.isEmpty,
+              let key = String(data: keyData, encoding: .utf8) else {
+            // No key stored; tiles render the onboarding card.
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchBalance(apiKey: key) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Clearing DeepSeek DOES delete its credential — unlike Codex, the
+        // key belongs to this app (the user pasted it here), not to an
+        // external CLI. This is the "Clear API key" action in Settings.
+        credentials.delete(Self.apiKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum DeepSeekUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the network for unit testing. The completion MUST be delivered
+/// on the main queue.
+public protocol DeepSeekUsageTransport: Sendable {
+    func fetchBalance(
+        apiKey: String,
+        completion: @escaping @Sendable (DeepSeekUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues the real request with the Bearer key. The
+/// response body is never logged; only the status code goes through the
+/// categorical logger.
+public struct URLSessionDeepSeekTransport: DeepSeekUsageTransport {
+    private let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
+
+    public init() {}
+
+    public func fetchBalance(
+        apiKey: String,
+        completion: @escaping @Sendable (DeepSeekUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: balanceURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (DeepSeekUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("DeepSeek balance API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -20,11 +20,14 @@ import SwiftUI
 import Combine
 
 @MainActor
-public final class DeepSeekUsageStore: @preconcurrency UsageProvider {
+public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
 
     public let id: String = "deepseek"
     public let displayName: String = "DeepSeek"
     public let featureFlagKey: String = "features.deepseek.enabled"
+
+    // PasteKeyProvider: the DeepSeek key is pasted by the user into Settings.
+    public let keyPlaceholder: String = "sk-…"
 
     /// Keychain key under which the DeepSeek API key is stored.
     public static let apiKeyKeychainKey = "deepseek.api_key"

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -54,10 +54,16 @@ public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyPr
 
     // MARK: - Credential management
 
-    /// True when an API key is stored. The key itself is never exposed.
+    /// True when an API key is stored. The key itself is never exposed. A
+    /// keychain that is present but temporarily unreadable (locked) counts as
+    /// configured, so a locked screen does not drop the provider back to the
+    /// paste-key onboarding card.
     public var hasKey: Bool {
-        guard let data = credentials.read(Self.apiKeyKeychainKey) else { return false }
-        return !data.isEmpty
+        switch credentials.readResult(Self.apiKeyKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
     }
 
     /// Store a pasted API key (trimmed). Empty input clears the key instead.
@@ -177,10 +183,9 @@ public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyPr
         }
 
         transport.fetchBalance(apiKey: key) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 

--- a/app/Log.swift
+++ b/app/Log.swift
@@ -1,0 +1,72 @@
+// MARK: - Logging (categorical redaction)
+//
+// PR 1 introduced the categorical logger below to replace every NSLog site
+// in the app that touched cookies, org IDs, or response bodies. The call
+// site cannot interpolate a raw String; every value goes through a
+// category, and each category has its own emission rule. This makes
+// accidental credential logging a compile-time impossibility rather than a
+// discipline problem.
+//
+// PR 2a extracted the types out of ClaudeUsageBar.swift into this file so
+// the SwiftPM library target can compile them without also trying to
+// compile the @main entry point (which would conflict with TestRunner's
+// own main).
+//
+// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
+// reintroduce raw-interpolation NSLog calls or the deleted response-body
+// log line at the network fetch site. The exact banned pattern lives in
+// the workflow file to avoid embedding it here (which would self-trigger).
+
+import Foundation
+import CryptoKit
+
+public enum LogValue {
+    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
+    case `public`(String)
+    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
+    /// bodies, tokens, API keys, anything that could leak a credential.
+    case sensitive(String)
+    /// Emitted as a short SHA-256 prefix so the value can be correlated
+    /// across log lines without revealing it. Use for org IDs, user IDs.
+    case identifier(String)
+    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
+    /// retry counts, threshold values).
+    case count(Int)
+
+    public var rendered: String {
+        switch self {
+        case .public(let s):
+            return s
+        case .sensitive(let s):
+            return "<redacted: \(s.count) chars>"
+        case .identifier(let s):
+            let digest = SHA256.hash(data: Data(s.utf8))
+            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+            return "<id: \(hex.prefix(8))>"
+        case .count(let n):
+            return String(n)
+        }
+    }
+}
+
+public enum Log {
+    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
+    /// gate. Accepts a plain message — no interpolation of untrusted values.
+    public static func debug(_ message: String) {
+        #if DEBUG
+        NSLog("[debug] %@", message)
+        #endif
+    }
+
+    /// Info-level diagnostics. Retained in release builds. Values must be
+    /// wrapped in a `LogValue` category, forcing an explicit redaction
+    /// decision at the call site.
+    public static func info(_ message: String, _ values: LogValue...) {
+        let rendered = values.map(\.rendered).joined(separator: ", ")
+        if rendered.isEmpty {
+            NSLog("%@", message)
+        } else {
+            NSLog("%@ | %@", message, rendered)
+        }
+    }
+}

--- a/app/OpenAIUsageFetcher.swift
+++ b/app/OpenAIUsageFetcher.swift
@@ -1,0 +1,173 @@
+// PR 7-BE — OpenAI Platform usage fetcher (developer API, Admin key).
+//
+// Reads an OpenAI ORGANIZATION's usage, cost, and configured rate limits via
+// an Admin key (sk-admin-...). Admin keys can view billing and manage users
+// but cannot make inference calls; the UI gates the paste behind a warning.
+//
+// Feature posture: features.openai.enabled defaults false; nothing registers
+// a store into the live registry yet (tile + admin-key sheet land in PR 7-UI).
+//
+// Endpoints (all officially documented, Authorization: Bearer sk-admin-...):
+//   GET /v1/organization/usage/completions?bucket_width=1d&group_by=model
+//       -> tokens + request counts by model, bucketed by time.
+//   GET /v1/organization/costs?bucket_width=1d&start_time=<month start>
+//       -> spend by line item, bucketed; amount.value is USD dollars.
+//   GET /v1/organization/projects/{project_id}/rate_limits
+//       -> configured per-model RPM/TPM ceilings.
+//
+// The usage + costs endpoints share a bucketed page shape:
+//   { "object": "page", "data": [ { "object": "bucket", "start_time": Int,
+//     "end_time": Int, "results": [ <result> ] } ], "has_more": Bool,
+//     "next_page": String|null }
+// Results differ per endpoint. This fetcher parses each into flat aggregates
+// the tiles consume.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// Per-model token totals aggregated across the returned usage buckets.
+public struct OpenAIModelTokens: Equatable, Sendable {
+    public var model: String
+    public var inputTokens: Int
+    public var outputTokens: Int
+    public var requests: Int
+
+    public init(model: String, inputTokens: Int = 0, outputTokens: Int = 0, requests: Int = 0) {
+        self.model = model
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.requests = requests
+    }
+
+    public var totalTokens: Int { inputTokens + outputTokens }
+}
+
+/// Per-model configured rate-limit ceilings (context, not remaining).
+public struct OpenAIRateLimit: Equatable, Sendable {
+    public var model: String
+    public var maxRequestsPerMinute: Int?
+    public var maxTokensPerMinute: Int?
+
+    public init(model: String, maxRequestsPerMinute: Int? = nil, maxTokensPerMinute: Int? = nil) {
+        self.model = model
+        self.maxRequestsPerMinute = maxRequestsPerMinute
+        self.maxTokensPerMinute = maxTokensPerMinute
+    }
+}
+
+public struct OpenAIUsageSnapshot: Equatable, Sendable {
+    /// Per-model token usage over the queried window (last 24h by default).
+    public var tokensByModel: [OpenAIModelTokens]
+    /// Month-to-date spend in USD, summed across cost buckets/line items.
+    public var costMTDUSD: Double
+    public var costCurrency: String?
+    /// Configured per-model rate-limit ceilings.
+    public var rateLimits: [OpenAIRateLimit]
+
+    public init(
+        tokensByModel: [OpenAIModelTokens] = [],
+        costMTDUSD: Double = 0,
+        costCurrency: String? = nil,
+        rateLimits: [OpenAIRateLimit] = []
+    ) {
+        self.tokensByModel = tokensByModel
+        self.costMTDUSD = costMTDUSD
+        self.costCurrency = costCurrency
+        self.rateLimits = rateLimits
+    }
+}
+
+public enum OpenAIUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct OpenAIUsageFetcher: Sendable {
+
+    public init() {}
+
+    public static let adminKeyKeychainKey = "openai.admin_key"
+
+    /// Iterate the `data[].results[]` buckets of a page response, calling
+    /// `handle` for each result dictionary. Shared by usage and costs.
+    private static func forEachResult(_ json: [String: Any], _ handle: ([String: Any]) -> Void) {
+        guard let buckets = json["data"] as? [[String: Any]] else { return }
+        for bucket in buckets {
+            guard let results = bucket["results"] as? [[String: Any]] else { continue }
+            for result in results { handle(result) }
+        }
+    }
+
+    /// Parse GET /v1/organization/usage/completions. Aggregates token and
+    /// request counts by model across all buckets. When group_by=model is
+    /// not set, results carry no model field and fold into an "all" bucket.
+    public static func parseCompletions(_ data: Data) throws -> [OpenAIModelTokens] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIUsageParseError.invalidJSON
+        }
+        var byModel: [String: OpenAIModelTokens] = [:]
+        forEachResult(json) { result in
+            let model = (result["model"] as? String) ?? "all"
+            var entry = byModel[model] ?? OpenAIModelTokens(model: model)
+            entry.inputTokens += intOr0(result["input_tokens"])
+            entry.outputTokens += intOr0(result["output_tokens"])
+            entry.requests += intOr0(result["num_model_requests"])
+            byModel[model] = entry
+        }
+        // Stable order: highest total tokens first.
+        return byModel.values.sorted { $0.totalTokens > $1.totalTokens }
+    }
+
+    /// Parse GET /v1/organization/costs. Sums `amount.value` (USD dollars)
+    /// across all buckets/line items. Returns the total and the currency.
+    public static func parseCosts(_ data: Data) throws -> (usd: Double, currency: String?) {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIUsageParseError.invalidJSON
+        }
+        var total = 0.0
+        var currency: String?
+        forEachResult(json) { result in
+            guard let amount = result["amount"] as? [String: Any] else { return }
+            total += doubleOr0(amount["value"])
+            if currency == nil { currency = amount["currency"] as? String }
+        }
+        return (total, currency)
+    }
+
+    /// Parse GET /v1/organization/projects/{id}/rate_limits.
+    public static func parseRateLimits(_ data: Data) throws -> [OpenAIRateLimit] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIUsageParseError.invalidJSON
+        }
+        guard let arr = json["data"] as? [[String: Any]] else { return [] }
+        return arr.compactMap { entry in
+            guard let model = entry["model"] as? String else { return nil }
+            return OpenAIRateLimit(
+                model: model,
+                maxRequestsPerMinute: intOrNil(entry["max_requests_per_1_minute"]),
+                maxTokensPerMinute: intOrNil(entry["max_tokens_per_1_minute"])
+            )
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func intOr0(_ v: Any?) -> Int { intOrNil(v) ?? 0 }
+    private static func doubleOr0(_ v: Any?) -> Double { doubleOrNil(v) ?? 0 }
+
+    private static func intOrNil(_ v: Any?) -> Int? {
+        if let i = v as? Int { return i }
+        if let d = v as? Double { return Int(d) }
+        if let s = v as? String { return Int(s) }
+        return nil
+    }
+    private static func doubleOrNil(_ v: Any?) -> Double? {
+        if let d = v as? Double { return d }
+        if let i = v as? Int { return Double(i) }
+        if let s = v as? String { return Double(s) }
+        return nil
+    }
+}

--- a/app/OpenAIUsageFetcher.swift
+++ b/app/OpenAIUsageFetcher.swift
@@ -92,13 +92,22 @@ public struct OpenAIUsageFetcher: Sendable {
 
     public static let adminKeyKeychainKey = "openai.admin_key"
 
+    /// Defensive caps on how much of a response we traverse. A hostile or
+    /// buggy API could return an enormous data[]/results[] after
+    /// JSONSerialization has already materialised it; capping the traversal
+    /// bounds the CPU spent aggregating. The real endpoint returns at most
+    /// ~31 buckets (limit=31) each with a handful of per-model results, so
+    /// these caps are far above any legitimate response.
+    private static let maxBuckets = 400
+    private static let maxResultsPerBucket = 2000
+
     /// Iterate the `data[].results[]` buckets of a page response, calling
     /// `handle` for each result dictionary. Shared by usage and costs.
     private static func forEachResult(_ json: [String: Any], _ handle: ([String: Any]) -> Void) {
         guard let buckets = json["data"] as? [[String: Any]] else { return }
-        for bucket in buckets {
+        for bucket in buckets.prefix(maxBuckets) {
             guard let results = bucket["results"] as? [[String: Any]] else { continue }
-            for result in results { handle(result) }
+            for result in results.prefix(maxResultsPerBucket) { handle(result) }
         }
     }
 
@@ -113,9 +122,11 @@ public struct OpenAIUsageFetcher: Sendable {
         forEachResult(json) { result in
             let model = (result["model"] as? String) ?? "all"
             var entry = byModel[model] ?? OpenAIModelTokens(model: model)
-            entry.inputTokens += intOr0(result["input_tokens"])
-            entry.outputTokens += intOr0(result["output_tokens"])
-            entry.requests += intOr0(result["num_model_requests"])
+            // Clamp negatives to 0: a negative token/request count is
+            // meaningless and would corrupt the sort and the tile total.
+            entry.inputTokens += max(0, intOr0(result["input_tokens"]))
+            entry.outputTokens += max(0, intOr0(result["output_tokens"]))
+            entry.requests += max(0, intOr0(result["num_model_requests"]))
             byModel[model] = entry
         }
         // Stable order: highest total tokens first.
@@ -161,12 +172,17 @@ public struct OpenAIUsageFetcher: Sendable {
 
     private static func intOrNil(_ v: Any?) -> Int? {
         if let i = v as? Int { return i }
-        if let d = v as? Double { return Int(d) }
+        // Int(Double) TRAPS on a non-finite or out-of-range value; a hostile
+        // API can send 1e300 as valid JSON. Int(exactly:) is crash-safe.
+        if let d = v as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
         if let s = v as? String { return Int(s) }
         return nil
     }
     private static func doubleOrNil(_ v: Any?) -> Double? {
-        if let d = v as? Double { return d }
+        if let d = v as? Double { return d.isFinite ? d : nil }
         if let i = v as? Int { return Double(i) }
         if let s = v as? String { return Double(s) }
         return nil

--- a/app/OpenAIUsageFetcher.swift
+++ b/app/OpenAIUsageFetcher.swift
@@ -8,8 +8,9 @@
 // a store into the live registry yet (tile + admin-key sheet land in PR 7-UI).
 //
 // Endpoints (all officially documented, Authorization: Bearer sk-admin-...):
-//   GET /v1/organization/usage/completions?bucket_width=1d&group_by=model
-//       -> tokens + request counts by model, bucketed by time.
+//   GET /v1/organization/usage/completions?bucket_width=1h&group_by=model
+//       -> tokens + request counts by model, hourly buckets over a rolling
+//          24h window (see URLSessionOpenAITransport.completionsQuery).
 //   GET /v1/organization/costs?bucket_width=1d&start_time=<month start>
 //       -> spend by line item, bucketed; amount.value is USD dollars.
 //   GET /v1/organization/projects/{project_id}/rate_limits

--- a/app/OpenAIUsageStore.swift
+++ b/app/OpenAIUsageStore.swift
@@ -91,8 +91,10 @@ public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProv
         var out: [UsageTile] = []
 
         // Month-to-date cost as a balance-style tile (a spend total, so no
-        // reset; shown as an amount).
-        let currency = snap.costCurrency ?? "USD"
+        // reset; shown as an amount). The costs API returns the currency
+        // lowercase ("usd"); uppercase it for display consistency with the
+        // "USD" fallback.
+        let currency = snap.costCurrency?.uppercased() ?? "USD"
         out.append(UsageTile(
             id: "openai-cost-mtd",
             title: "OpenAI spend (month to date)",
@@ -197,20 +199,9 @@ public struct URLSessionOpenAITransport: OpenAIUsageTransport {
             DispatchQueue.main.async { completion(result) }
         }
 
-        // Query windows: last ~24h of completions grouped by model; costs
-        // from the start of the current UTC month. start_time is computed by
-        // the caller-agnostic helper so tests can stub the transport entirely.
         let now = Date()
-        let dayAgo = Int(now.timeIntervalSince1970) - 24 * 3600
-        let monthStart = Self.startOfUTCMonth(now)
-
-        // `limit=31` is the max for bucket_width=1d and covers a full month in
-        // a SINGLE page, so neither the 24h nor the month-to-date window ever
-        // spans multiple pages — we do not need to follow has_more/next_page
-        // here. (Multi-page pagination would only matter for windows longer
-        // than 31 daily buckets, which these tiles never request.)
-        let completionsURL = "\(base)/usage/completions?bucket_width=1d&group_by=model&limit=31&start_time=\(dayAgo)"
-        let costsURL = "\(base)/costs?bucket_width=1d&group_by=line_item&limit=31&start_time=\(monthStart)"
+        let completionsURL = base + Self.completionsQuery(now: now)
+        let costsURL = base + Self.costsQuery(now: now)
 
         get(completionsURL, bearer: adminKey) { compData, compStatus in
             guard compStatus == 200, let compData = compData,
@@ -251,6 +242,28 @@ public struct URLSessionOpenAITransport: OpenAIUsageTransport {
                 }
             }
         }
+    }
+
+    /// Query path (relative to `base`) for the completions/token-usage tile.
+    ///
+    /// Uses `bucket_width=1h` with `limit=24` for a TRUE rolling 24-hour
+    /// window. A previous version used `bucket_width=1d`, which returns whole
+    /// UTC-day buckets: with `start_time=now-24h` that folds in usage from
+    /// 00:00 UTC of the prior day, so a tile labelled "(24h)" could sum up to
+    /// ~48h of tokens. Hourly buckets bounded to 24 give exactly the last 24h.
+    /// 24 hourly buckets fit a single page (the 1h max is 168), so no
+    /// pagination is needed.
+    public static func completionsQuery(now: Date) -> String {
+        let dayAgo = Int(now.timeIntervalSince1970) - 24 * 3600
+        return "/usage/completions?bucket_width=1h&group_by=model&limit=24&start_time=\(dayAgo)"
+    }
+
+    /// Query path (relative to `base`) for the month-to-date cost tile.
+    /// `bucket_width=1d` from the start of the UTC month; `limit=31` is the
+    /// 1d max and covers every day of the longest month in a single page.
+    public static func costsQuery(now: Date) -> String {
+        let monthStart = startOfUTCMonth(now)
+        return "/costs?bucket_width=1d&group_by=line_item&limit=31&start_time=\(monthStart)"
     }
 
     /// Start of the current month in UTC, as a Unix timestamp.

--- a/app/OpenAIUsageStore.swift
+++ b/app/OpenAIUsageStore.swift
@@ -49,8 +49,15 @@ public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProv
 
     // MARK: - Credential (PasteKeyProvider)
 
+    /// True when the admin key is stored. An unreadable (locked) keychain
+    /// counts as configured so a locked screen does not drop the provider
+    /// back to the paste-key onboarding card.
     public var hasKey: Bool {
-        !(credentials.read(OpenAIUsageFetcher.adminKeyKeychainKey)?.isEmpty ?? true)
+        switch credentials.readResult(OpenAIUsageFetcher.adminKeyKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
     }
 
     public func saveKey(_ raw: String) {
@@ -154,8 +161,11 @@ public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProv
         }
 
         transport.fetchAll(adminKey: key) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated { self.apply(result) }
+            // Hop to the main actor to apply state. Task { @MainActor } is
+            // safe whichever queue the transport delivers on — unlike
+            // assumeIsolated, it cannot trap if a future/custom transport
+            // calls back off-main.
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 
@@ -225,7 +235,11 @@ public struct URLSessionOpenAITransport: OpenAIUsageTransport {
                           let projJSON = try? JSONSerialization.jsonObject(with: projData) as? [String: Any],
                           let projects = projJSON["data"] as? [[String: Any]],
                           let firstProject = projects.first,
-                          let projectId = firstProject["id"] as? String else {
+                          let rawProjectId = firstProject["id"] as? String,
+                          // The project id comes from the API response; encode
+                          // it as a single path segment so it cannot alter the
+                          // request path.
+                          let projectId = RequestSafety.pathSegment(rawProjectId) else {
                         deliver(.success(base))
                         return
                     }

--- a/app/OpenAIUsageStore.swift
+++ b/app/OpenAIUsageStore.swift
@@ -1,0 +1,280 @@
+// PR 7-BE — OpenAI Platform UsageProvider conformer (dark code, flag off).
+//
+// Sixth provider. Reads an OpenAI organisation's token usage, month-to-date
+// cost, and configured rate-limit ceilings via an Admin key (sk-admin-...),
+// stored in the Keychain. Admin keys can view billing and manage users but
+// cannot make inference calls — the UI gates the paste behind a warning.
+//
+// Feature posture: features.openai.enabled defaults false; nothing registers
+// a store into the live registry yet (admin-key sheet + tiles land in PR 7-UI).
+//
+// The admin key never reaches a log line; only HTTP status codes are logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
+
+    public let id: String = "openai"
+    public let displayName: String = "OpenAI Platform"
+    public let featureFlagKey: String = "features.openai.enabled"
+
+    // PasteKeyProvider — an Organization Admin key. These org endpoints are
+    // admin-gated; there is no api.usage.read scoped-key fallback (confirmed
+    // against the OpenAI Admin API reference), so the placeholder names the
+    // admin key specifically.
+    public let keyPlaceholder: String = "sk-admin-…"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: OpenAIUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: OpenAIUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: OpenAIUsageTransport = URLSessionOpenAITransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential (PasteKeyProvider)
+
+    public var hasKey: Bool {
+        !(credentials.read(OpenAIUsageFetcher.adminKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(OpenAIUsageFetcher.adminKeyKeychainKey)
+        } else {
+            credentials.write(OpenAIUsageFetcher.adminKeyKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool { defaults.bool(forKey: featureFlagKey) }
+    public var isConfigured: Bool { hasKey }
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "openai-needs-key",
+                title: "OpenAI Platform",
+                kind: .needsAccess(
+                    path: "platform.openai.com",
+                    guidance: "Paste an OpenAI Admin key (sk-admin-…) in Settings to track org spend and usage."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Month-to-date cost as a balance-style tile (a spend total, so no
+        // reset; shown as an amount).
+        let currency = snap.costCurrency ?? "USD"
+        out.append(UsageTile(
+            id: "openai-cost-mtd",
+            title: "OpenAI spend (month to date)",
+            kind: .text(status: String(format: "%@ %.2f", currency, snap.costMTDUSD), subtitle: nil)
+        ))
+
+        // Token usage over the last 24h, top models. Rendered as counter
+        // tiles (total tokens per model) so the generic renderer handles it.
+        for model in snap.tokensByModel.prefix(4) {
+            out.append(UsageTile(
+                id: "openai-tokens-\(model.model)",
+                title: "OpenAI \(model.model) (24h)",
+                kind: .counter(used: model.totalTokens, limit: nil, resetsAt: nil)
+            ))
+        }
+
+        // Configured ceilings — reference context, top models by TPM.
+        for limit in snap.rateLimits.prefix(3) {
+            let tpm = limit.maxTokensPerMinute.map { "\($0) TPM" } ?? "—"
+            let rpm = limit.maxRequestsPerMinute.map { "\($0) RPM" } ?? "—"
+            out.append(UsageTile(
+                id: "openai-ceiling-\(limit.model)",
+                title: "OpenAI \(limit.model) limits",
+                kind: .text(status: tpm, subtitle: rpm)
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: OpenAIUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            self.lastError = "Invalid OpenAI Admin key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let data = credentials.read(OpenAIUsageFetcher.adminKeyKeychainKey),
+              !data.isEmpty, let key = String(data: data, encoding: .utf8) else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchAll(adminKey: key) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated { self.apply(result) }
+        }
+    }
+
+    public func clear() {
+        credentials.delete(OpenAIUsageFetcher.adminKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum OpenAIUsageResult: Sendable {
+    case success(OpenAIUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+public protocol OpenAIUsageTransport: Sendable {
+    func fetchAll(
+        adminKey: String,
+        completion: @escaping @Sendable (OpenAIUsageResult) -> Void
+    )
+}
+
+/// Production transport. Chains usage/completions + costs (both required for
+/// the headline tiles); rate_limits is best-effort (needs a project id, which
+/// it discovers from /v1/organization/projects). Bodies are never logged.
+public struct URLSessionOpenAITransport: OpenAIUsageTransport {
+    private let base = "https://api.openai.com/v1/organization"
+
+    public init() {}
+
+    public func fetchAll(
+        adminKey: String,
+        completion: @escaping @Sendable (OpenAIUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (OpenAIUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Query windows: last ~24h of completions grouped by model; costs
+        // from the start of the current UTC month. start_time is computed by
+        // the caller-agnostic helper so tests can stub the transport entirely.
+        let now = Date()
+        let dayAgo = Int(now.timeIntervalSince1970) - 24 * 3600
+        let monthStart = Self.startOfUTCMonth(now)
+
+        // `limit=31` is the max for bucket_width=1d and covers a full month in
+        // a SINGLE page, so neither the 24h nor the month-to-date window ever
+        // spans multiple pages — we do not need to follow has_more/next_page
+        // here. (Multi-page pagination would only matter for windows longer
+        // than 31 daily buckets, which these tiles never request.)
+        let completionsURL = "\(base)/usage/completions?bucket_width=1d&group_by=model&limit=31&start_time=\(dayAgo)"
+        let costsURL = "\(base)/costs?bucket_width=1d&group_by=line_item&limit=31&start_time=\(monthStart)"
+
+        get(completionsURL, bearer: adminKey) { compData, compStatus in
+            guard compStatus == 200, let compData = compData,
+                  let tokens = try? OpenAIUsageFetcher.parseCompletions(compData) else {
+                deliver(compStatus == 401 || compStatus == 403 ? .unauthorized
+                        : (compStatus == nil ? .networkError : .httpError(compStatus!)))
+                return
+            }
+
+            self.get(costsURL, bearer: adminKey) { costData, _ in
+                let cost = costData.flatMap { try? OpenAIUsageFetcher.parseCosts($0) }
+                let base = OpenAIUsageSnapshot(
+                    tokensByModel: tokens,
+                    costMTDUSD: cost?.usd ?? 0,
+                    costCurrency: cost?.currency
+                )
+                // Rate limits are best-effort: discover a project id, then
+                // fetch its ceilings. Any failure just omits that section.
+                self.get("\(self.base)/projects?limit=1", bearer: adminKey) { projData, _ in
+                    guard let projData = projData,
+                          let projJSON = try? JSONSerialization.jsonObject(with: projData) as? [String: Any],
+                          let projects = projJSON["data"] as? [[String: Any]],
+                          let firstProject = projects.first,
+                          let projectId = firstProject["id"] as? String else {
+                        deliver(.success(base))
+                        return
+                    }
+                    self.get("\(self.base)/projects/\(projectId)/rate_limits", bearer: adminKey) { rlData, _ in
+                        let limits = rlData.flatMap { try? OpenAIUsageFetcher.parseRateLimits($0) } ?? []
+                        let full = OpenAIUsageSnapshot(
+                            tokensByModel: tokens,
+                            costMTDUSD: cost?.usd ?? 0,
+                            costCurrency: cost?.currency,
+                            rateLimits: limits
+                        )
+                        deliver(.success(full))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Start of the current month in UTC, as a Unix timestamp.
+    public static func startOfUTCMonth(_ date: Date) -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.year, .month], from: date)
+        let start = cal.date(from: comps) ?? date
+        return Int(start.timeIntervalSince1970)
+    }
+
+    private func get(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        guard let url = URL(string: urlString) else { done(nil, nil); return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("OpenAI org API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}

--- a/app/PerplexityUsageFetcher.swift
+++ b/app/PerplexityUsageFetcher.swift
@@ -1,0 +1,484 @@
+// PR 8-BE — Perplexity Pro/Max usage fetcher (session-cookie authenticated).
+//
+// Sixth non-Anthropic provider, first cookie-authenticated one. The user
+// pastes their perplexity.ai session cookie (a spending credential — it lets
+// the bearer make paid Sonar queries and can top up on-demand credits), so
+// the cookie lives in the Keychain, never in UserDefaults.
+//
+// Auth ingestion accepts all four NextAuth v4/Auth.js v5 session cookie
+// names ("__Secure-next-auth.session-token" (live default), "next-auth.
+// session-token", "__Secure-authjs.session-token", "authjs.session-token"),
+// plus the chunked variants (.0, .1, …) NextAuth splits large JWEs into.
+// Bare tokens are accepted verbatim and sent under the default name.
+//
+// The three endpoints (all undocumented — perplexity.ai's own web UI calls
+// them):
+//   GET /rest/billing/credits?version=2.18&source=default
+//        → balance_cents (float USD cents), renewal_date_ts (Unix seconds),
+//          current_period_purchased_cents (float), credit_grants[] (each
+//          { type: "recurring"|"promotional"|"purchased", amount_cents,
+//          expires_at_ts?: Unix seconds }), total_usage_cents (float).
+//   GET /rest/rate-limit/all
+//        → remaining_pro, remaining_research, remaining_labs,
+//          remaining_agentic_research (ints — REMAINING ONLY, no totals, no
+//          resets), model_specific_limits {}, sources.source_to_limit
+//          { source_id: { monthly_limit: int|nil, remaining: int|nil } }.
+//          Total caps must be inferred client-side (plan lookup); the
+//          endpoint reports no plan/tier field of its own.
+//   GET /rest/user/settings
+//        → subscription_status ("active"|"trialing"|"none"),
+//          subscription_source, subscription_tier ("free"|"pro"|"max"), plus
+//          pages/upload/create limits and query_count. Supplies the plan
+//          label the rate-limit endpoint lacks.
+//
+// Cloudflare bot protection fronts perplexity.ai/rest/*. A residential-IP
+// URLSession GET with a valid cookie + a browser-shaped User-Agent + Accept
+// + Origin/Referer headers passes challenge on Macs today (verified across
+// three independent OSS consumers). Data centre / VPS traffic gets 403-
+// challenged regardless of cookie validity. We ship the browser headers
+// and surface 401/403 as invalidToken, which is what the user actually
+// needs to act on.
+//
+// Credentials never enter a log line; only status codes go through
+// Log.info(.count). The CI credential-leak guard is extended in this PR to
+// cover the `sessionCookie` name already, and `perplexity` variable prefixes
+// where they exist.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// One entry from `credit_grants[]`. Type strings observed: "recurring"
+/// (the monthly plan allotment), "promotional" (bonus, may expire), and
+/// "purchased" (on-demand top-ups). Unknown types are preserved verbatim so
+/// a new tier introduced server-side is not silently dropped.
+public struct PerplexityCreditGrant: Equatable, Sendable {
+    public var type: String
+    public var amountCents: Double
+    /// Unix epoch seconds; nil for grants that never expire (e.g. purchased).
+    public var expiresAtEpoch: Double?
+
+    public init(type: String, amountCents: Double, expiresAtEpoch: Double? = nil) {
+        self.type = type
+        self.amountCents = amountCents
+        self.expiresAtEpoch = expiresAtEpoch
+    }
+}
+
+/// Parsed `/rest/billing/credits` body.
+public struct PerplexityCredits: Equatable, Sendable {
+    /// Live balance in USD cents (float on the wire; we preserve precision).
+    public var balanceCents: Double
+    /// Renewal (start of next billing cycle) as Unix epoch seconds.
+    public var renewalEpoch: Double
+    /// On-demand purchases in the current billing period. May be reported
+    /// both here and inside `credit_grants` as `purchased`; the store
+    /// deduplicates by taking the max, per CodexBar convention.
+    public var currentPeriodPurchasedCents: Double
+    /// One entry per grant.
+    public var grants: [PerplexityCreditGrant]
+    /// Spend so far in the current billing period.
+    public var totalUsageCents: Double
+
+    public init(
+        balanceCents: Double = 0,
+        renewalEpoch: Double = 0,
+        currentPeriodPurchasedCents: Double = 0,
+        grants: [PerplexityCreditGrant] = [],
+        totalUsageCents: Double = 0
+    ) {
+        self.balanceCents = balanceCents
+        self.renewalEpoch = renewalEpoch
+        self.currentPeriodPurchasedCents = currentPeriodPurchasedCents
+        self.grants = grants
+        self.totalUsageCents = totalUsageCents
+    }
+}
+
+/// One entry from `sources.source_to_limit`. Both fields are nullable in the
+/// wire shape; a null `monthlyLimit` means the source is unmetered.
+public struct PerplexitySourceLimit: Equatable, Sendable {
+    public var sourceId: String
+    public var monthlyLimit: Int?
+    public var remaining: Int?
+
+    public init(sourceId: String, monthlyLimit: Int? = nil, remaining: Int? = nil) {
+        self.sourceId = sourceId
+        self.monthlyLimit = monthlyLimit
+        self.remaining = remaining
+    }
+}
+
+/// Parsed `/rest/rate-limit/all` body. Only remaining counts are on the
+/// wire — no totals, no reset timestamps, no plan/tier field.
+public struct PerplexityRateLimits: Equatable, Sendable {
+    public var remainingPro: Int
+    public var remainingResearch: Int
+    public var remainingLabs: Int
+    public var remainingAgenticResearch: Int
+    public var sources: [PerplexitySourceLimit]
+
+    public init(
+        remainingPro: Int = 0,
+        remainingResearch: Int = 0,
+        remainingLabs: Int = 0,
+        remainingAgenticResearch: Int = 0,
+        sources: [PerplexitySourceLimit] = []
+    ) {
+        self.remainingPro = remainingPro
+        self.remainingResearch = remainingResearch
+        self.remainingLabs = remainingLabs
+        self.remainingAgenticResearch = remainingAgenticResearch
+        self.sources = sources
+    }
+}
+
+/// Parsed subset of `/rest/user/settings`. The response is large; we ingest
+/// only the fields that inform tiles. Everything else is deliberately
+/// ignored to avoid tying us to churn on unrelated flags.
+public struct PerplexityUserSettings: Equatable, Sendable {
+    /// "active" | "trialing" | "none" | (other, preserved verbatim).
+    public var subscriptionStatus: String?
+    /// "stripe" | "revenuecat" | "none" | (other).
+    public var subscriptionSource: String?
+    /// "free" | "pro" | "max" | (other). The plan label the rate-limit
+    /// endpoint lacks.
+    public var subscriptionTier: String?
+    /// Best-effort per-feature limits carried by the endpoint. Zero for
+    /// absent fields.
+    public var pagesLimit: Int
+    public var uploadLimit: Int
+    public var createLimit: Int
+    public var queryCount: Int
+
+    public init(
+        subscriptionStatus: String? = nil,
+        subscriptionSource: String? = nil,
+        subscriptionTier: String? = nil,
+        pagesLimit: Int = 0,
+        uploadLimit: Int = 0,
+        createLimit: Int = 0,
+        queryCount: Int = 0
+    ) {
+        self.subscriptionStatus = subscriptionStatus
+        self.subscriptionSource = subscriptionSource
+        self.subscriptionTier = subscriptionTier
+        self.pagesLimit = pagesLimit
+        self.uploadLimit = uploadLimit
+        self.createLimit = createLimit
+        self.queryCount = queryCount
+    }
+}
+
+/// Aggregate snapshot the store applies. Any subset may be nil when the
+/// corresponding endpoint failed; the transport reports partial success by
+/// filling only the pieces that came back OK. A hard 401/403 short-circuits
+/// to `unauthorized` instead of a `success` with everything nil.
+public struct PerplexityUsageSnapshot: Equatable, Sendable {
+    public var credits: PerplexityCredits?
+    public var rateLimits: PerplexityRateLimits?
+    public var settings: PerplexityUserSettings?
+
+    public init(
+        credits: PerplexityCredits? = nil,
+        rateLimits: PerplexityRateLimits? = nil,
+        settings: PerplexityUserSettings? = nil
+    ) {
+        self.credits = credits
+        self.rateLimits = rateLimits
+        self.settings = settings
+    }
+}
+
+public enum PerplexityUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Cookie normalisation
+
+/// Session cookie forms Perplexity/NextAuth may present. Ordered
+/// most-preferred first: the __Secure- prefixed pair takes priority since
+/// perplexity.ai serves HTTPS-only and the __Secure- variant is the one live
+/// consumers see today (July 2026).
+public enum PerplexityCookie {
+    /// The four accepted NextAuth session cookie names, in priority order.
+    /// Insensitive to case for the match; casing is preserved for the header.
+    public static let supportedSessionCookieNames: [String] = [
+        "__Secure-next-auth.session-token",
+        "__Secure-authjs.session-token",
+        "next-auth.session-token",
+        "authjs.session-token",
+    ]
+
+    /// Default cookie name to send when the user pasted only a bare token.
+    public static let defaultSessionCookieName: String = "__Secure-next-auth.session-token"
+
+    /// Extract a `(cookieName, token)` pair from whatever the user pasted:
+    ///   - a bare token (no `;` and no `=`) → wrapped under the default cookie
+    ///     name.
+    ///   - a `name=value` pair or full cookie header (`a=1; b=2; …`) → the
+    ///     highest-priority supported session cookie is picked.
+    ///   - a paste that contains `=` but yields no supported cookie AND has
+    ///     no `;` separators → treated as a bare token verbatim. This catches
+    ///     opaque tokens with base64 padding (`abc.def==`) that would
+    ///     otherwise be mis-parsed as `abc.def=` = empty (an unsupported cookie
+    ///     name).
+    ///   - NextAuth chunked variants (`__Secure-next-auth.session-token.0`,
+    ///     `.1`, …) → reassembled in index order under the base name; the
+    ///     chunk index is bounded to defeat overflow / mass-allocation
+    ///     attacks.
+    /// Returns nil when the input yields no usable cookie.
+    public static func extract(from rawInput: String) -> (name: String, token: String)? {
+        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Bare token — no `=`, no `;`. Send under the default name.
+        if !trimmed.contains("="), !trimmed.contains(";") {
+            return (defaultSessionCookieName, trimmed)
+        }
+
+        // Otherwise parse `k=v; k=v; …` pairs.
+        var pairs: [(String, String)] = []
+        for chunk in trimmed.split(separator: ";") {
+            let piece = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let eq = piece.firstIndex(of: "=") else { continue }
+            let key = String(piece[..<eq]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let val = String(piece[piece.index(after: eq)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !key.isEmpty, !val.isEmpty {
+                pairs.append((key, val))
+            }
+        }
+        if let picked = pickSessionCookie(from: pairs) {
+            return picked
+        }
+        // Fallback: the input contains an `=` but did NOT parse into a
+        // supported session cookie AND has no `;` separators, so it is most
+        // likely a bare opaque token whose payload happens to contain `=`
+        // (e.g. base64 padding). Send it verbatim under the default name.
+        //
+        // Exception: if the name-part LOOKS like a session-cookie form
+        // (starts with one of the supported base names, e.g. a chunked
+        // variant that failed the index-bound check), do NOT fall back —
+        // that would let a hostile chunked-index paste smuggle a bogus
+        // token through the overflow guard.
+        if !trimmed.contains(";"),
+           let firstEq = trimmed.firstIndex(of: "="),
+           !looksLikeSessionCookieName(String(trimmed[..<firstEq])) {
+            return (defaultSessionCookieName, trimmed)
+        }
+        return nil
+    }
+
+    /// True when `raw` starts with (or equals, case-insensitively) any of
+    /// the four supported session-cookie base names. Used to prevent the
+    /// bare-token fallback from swallowing a malformed session-cookie paste.
+    private static func looksLikeSessionCookieName(_ raw: String) -> Bool {
+        let lower = raw.lowercased().trimmingCharacters(in: .whitespaces)
+        for expected in supportedSessionCookieNames {
+            let base = expected.lowercased()
+            if lower == base { return true }
+            if lower.hasPrefix(base + ".") { return true }
+        }
+        return false
+    }
+
+    /// Pick the highest-priority supported session cookie from a name/value
+    /// list. Handles NextAuth chunked cookies by reassembling in index order.
+    static func pickSessionCookie(from pairs: [(String, String)]) -> (name: String, token: String)? {
+        // Build case-insensitive lookup by lowercased key.
+        var byLoweredName: [String: (String, String)] = [:]
+        var chunkedByBase: [String: [Int: String]] = [:]
+        for (k, v) in pairs {
+            let lower = k.lowercased()
+            byLoweredName[lower] = (k, v)
+            for expected in supportedSessionCookieNames {
+                let base = expected.lowercased() + "."
+                guard lower.hasPrefix(base) else { continue }
+                let suffix = String(lower.dropFirst(base.count))
+                // Bound the chunk index defensively: NextAuth's real chunk
+                // indexes are 0..~10 (each ~4 KB). Reject indexes outside
+                // [0, maxAllowedChunkIndex] so a hostile paste of
+                // `…session-token.9223372036854775807=x` cannot overflow the
+                // `maxIdx + 1` arithmetic in `reassemble`, nor force a
+                // ~2 GB reserveCapacity.
+                guard let idx = Int(suffix), idx >= 0, idx <= maxAllowedChunkIndex else { continue }
+                chunkedByBase[expected.lowercased(), default: [:]][idx] = v
+            }
+        }
+
+        // Prefer a whole cookie over its chunked variant when both are present.
+        for expected in supportedSessionCookieNames {
+            let lower = expected.lowercased()
+            if let (originalName, value) = byLoweredName[lower] {
+                return (originalName, value)
+            }
+            if let chunks = chunkedByBase[lower], let reassembled = reassemble(chunks: chunks) {
+                return (expected, reassembled)
+            }
+        }
+        return nil
+    }
+
+    /// Absolute cap on the NextAuth chunk index. Real deployments have never
+    /// been observed above single digits; 64 is a generous ceiling that
+    /// still prevents pathological allocation.
+    static let maxAllowedChunkIndex: Int = 64
+
+    private static func reassemble(chunks: [Int: String]) -> String? {
+        guard let maxIdx = chunks.keys.max() else { return nil }
+        // Redundant safety net — pickSessionCookie already caps at
+        // maxAllowedChunkIndex, but reassemble may be reached via a future
+        // caller. `maxIdx + 1` cannot overflow here because maxIdx is bounded.
+        guard maxIdx >= 0, maxIdx <= maxAllowedChunkIndex else { return nil }
+        var parts: [String] = []
+        parts.reserveCapacity(maxIdx + 1)
+        for i in 0 ... maxIdx {
+            guard let piece = chunks[i] else { return nil }  // gap → refuse
+            parts.append(piece)
+        }
+        return parts.joined()
+    }
+}
+
+// MARK: - Fetcher
+
+public struct PerplexityUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain key under which the pasted cookie is stored (raw input as
+    /// pasted; parsing runs at fetch time so a user can update the paste
+    /// format without needing to re-enter).
+    public static let cookieKeychainKey = "perplexity.session_cookie"
+
+    // MARK: Endpoint parsing
+
+    /// Parse the `/rest/billing/credits` body.
+    public static func parseCredits(_ data: Data) throws -> PerplexityCredits {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PerplexityUsageParseError.invalidJSON
+        }
+        var out = PerplexityCredits()
+        out.balanceCents = doubleOrZero(json["balance_cents"])
+        // Clamp Unix-second timestamps to a sane range. A wild value
+        // ("1e300") would create a pathological Date which then flows into
+        // DateFormatter downstream. saneEpochOrZero rejects anything outside
+        // [Jan 2000, Jan 2100] and returns 0 (treated by the store as "no
+        // renewal date"). Verified with round-2 Codex review #4.
+        out.renewalEpoch = saneEpochOrZero(json["renewal_date_ts"])
+        out.currentPeriodPurchasedCents = doubleOrZero(json["current_period_purchased_cents"])
+        out.totalUsageCents = doubleOrZero(json["total_usage_cents"])
+        if let grants = json["credit_grants"] as? [[String: Any]] {
+            out.grants = grants.compactMap { entry in
+                guard let type = entry["type"] as? String else { return nil }
+                return PerplexityCreditGrant(
+                    type: type,
+                    amountCents: doubleOrZero(entry["amount_cents"]),
+                    expiresAtEpoch: saneEpochOrNil(entry["expires_at_ts"])
+                )
+            }
+        }
+        return out
+    }
+
+    /// Sane bounds for a Unix-seconds timestamp coming off an untrusted API.
+    /// Jan 1 2000 UTC .. Jan 1 2100 UTC — anything outside is treated as
+    /// missing / garbage so a `Date` derived from it stays inside Foundation's
+    /// safe range.
+    static let minSaneEpoch: Double = 946684800   // 2000-01-01 UTC
+    static let maxSaneEpoch: Double = 4102444800  // 2100-01-01 UTC
+
+    /// Coerce to a Double epoch inside the sane range, else return 0.
+    static func saneEpochOrZero(_ value: Any?) -> Double {
+        saneEpochOrNil(value) ?? 0
+    }
+
+    /// Coerce to a Double epoch inside the sane range, else return nil.
+    static func saneEpochOrNil(_ value: Any?) -> Double? {
+        guard let d = doubleOrNil(value), d.isFinite,
+              d >= minSaneEpoch, d <= maxSaneEpoch else { return nil }
+        return d
+    }
+
+    /// Parse the `/rest/rate-limit/all` body.
+    public static func parseRateLimits(_ data: Data) throws -> PerplexityRateLimits {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PerplexityUsageParseError.invalidJSON
+        }
+        var out = PerplexityRateLimits()
+        out.remainingPro = max(0, intOrZero(json["remaining_pro"]))
+        out.remainingResearch = max(0, intOrZero(json["remaining_research"]))
+        out.remainingLabs = max(0, intOrZero(json["remaining_labs"]))
+        out.remainingAgenticResearch = max(0, intOrZero(json["remaining_agentic_research"]))
+
+        if let sources = json["sources"] as? [String: Any],
+           let map = sources["source_to_limit"] as? [String: Any] {
+            var parsed: [PerplexitySourceLimit] = []
+            parsed.reserveCapacity(map.count)
+            for (sourceId, raw) in map {
+                guard let entry = raw as? [String: Any] else { continue }
+                parsed.append(PerplexitySourceLimit(
+                    sourceId: sourceId,
+                    monthlyLimit: intOrNil(entry["monthly_limit"]),
+                    remaining: intOrNil(entry["remaining"])
+                ))
+            }
+            // Sort for deterministic tile ordering / test equality.
+            out.sources = parsed.sorted { $0.sourceId < $1.sourceId }
+        }
+        return out
+    }
+
+    /// Parse the `/rest/user/settings` body. Only fields that inform tiles
+    /// are extracted; everything else in the response is intentionally
+    /// ignored to keep the parser resilient to churn on unrelated flags.
+    public static func parseUserSettings(_ data: Data) throws -> PerplexityUserSettings {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PerplexityUsageParseError.invalidJSON
+        }
+        var out = PerplexityUserSettings()
+        out.subscriptionStatus = json["subscription_status"] as? String
+        out.subscriptionSource = json["subscription_source"] as? String
+        out.subscriptionTier = json["subscription_tier"] as? String
+        out.pagesLimit = max(0, intOrZero(json["pages_limit"]))
+        out.uploadLimit = max(0, intOrZero(json["upload_limit"]))
+        out.createLimit = max(0, intOrZero(json["create_limit"]))
+        out.queryCount = max(0, intOrZero(json["query_count"]))
+        return out
+    }
+
+    // MARK: Number coercion
+
+    /// Int coercion. Accepts Int, finite Double (rounded), or a numeric
+    /// string. Returns nil rather than trapping on a non-finite / oversize
+    /// Double (`Int(1e300)` traps; `Int(exactly:)` does not).
+    static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
+        if let s = value as? String {
+            return Int(s) ?? Double(s).flatMap { $0.isFinite ? Int(exactly: $0.rounded()) : nil }
+        }
+        return nil
+    }
+
+    static func intOrZero(_ value: Any?) -> Int {
+        intOrNil(value) ?? 0
+    }
+
+    /// Double coercion. Nil is returned only for a non-finite Double or a
+    /// truly missing field; strings are parsed defensively.
+    static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d.isFinite ? d : nil }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s).flatMap { $0.isFinite ? $0 : nil } }
+        return nil
+    }
+
+    static func doubleOrZero(_ value: Any?) -> Double {
+        doubleOrNil(value) ?? 0
+    }
+}

--- a/app/PerplexityUsageFetcher.swift
+++ b/app/PerplexityUsageFetcher.swift
@@ -230,7 +230,21 @@ public enum PerplexityCookie {
     ///     attacks.
     /// Returns nil when the input yields no usable cookie.
     public static func extract(from rawInput: String) -> (name: String, token: String)? {
-        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        var trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // Strip an optional leading "Cookie:" header prefix in any casing
+        // (Cookie:, cookie:, CoOkIe:, …). Some browsers' "Copy as HAR" /
+        // "Copy request headers" tools return the whole header line; the
+        // user should not have to hand-strip it. Truly ASCII case-insensitive
+        // so no spelling permutation falls through into the bare-token
+        // fallback and stores the header line as a token.
+        let prefixToken = "cookie:"
+        if trimmed.count >= prefixToken.count {
+            let head = trimmed.prefix(prefixToken.count)
+            if head.lowercased() == prefixToken {
+                trimmed = String(trimmed.dropFirst(prefixToken.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
         guard !trimmed.isEmpty else { return nil }
 
         // Bare token — no `=`, no `;`. Send under the default name.

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -515,8 +515,11 @@ private enum PerplexityEndpointKind {
 /// Thread-safe accumulator for the three concurrent GETs. A final call to
 /// `finalize()` collapses the state into a single snapshot + unauthorized
 /// flag. Lock-protected because `dataTask` completions can land on any
-/// queue.
-private final class PerplexityFetchAccumulator: @unchecked Sendable {
+/// queue. `public` (rather than `private`) so TestRunner can lock in the
+/// httpError priority ordering without going through a live URL session
+/// (chk1 Omission #1). The type is otherwise an internal implementation
+/// detail — not re-exported, not part of the store's public API surface.
+public final class PerplexityFetchAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var credits: PerplexityCredits?
     private var rateLimits: PerplexityRateLimits?
@@ -528,23 +531,25 @@ private final class PerplexityFetchAccumulator: @unchecked Sendable {
     /// failed.
     private var httpError: Int?
 
-    func setCredits(_ value: PerplexityCredits) {
+    public init() {}
+
+    public func setCredits(_ value: PerplexityCredits) {
         lock.lock(); defer { lock.unlock() }
         credits = value
     }
-    func setRateLimits(_ value: PerplexityRateLimits) {
+    public func setRateLimits(_ value: PerplexityRateLimits) {
         lock.lock(); defer { lock.unlock() }
         rateLimits = value
     }
-    func setSettings(_ value: PerplexityUserSettings) {
+    public func setSettings(_ value: PerplexityUserSettings) {
         lock.lock(); defer { lock.unlock() }
         settings = value
     }
-    func setUnauthorized() {
+    public func setUnauthorized() {
         lock.lock(); defer { lock.unlock() }
         unauthorized = true
     }
-    func recordHttpError(_ status: Int) {
+    public func recordHttpError(_ status: Int) {
         lock.lock(); defer { lock.unlock() }
         // Priority: 429 > 5xx > anything else. Only replace when the new
         // code carries strictly more signal.
@@ -561,7 +566,7 @@ private final class PerplexityFetchAccumulator: @unchecked Sendable {
             httpError = status
         }
     }
-    func finalize() -> (Bool, Int?, PerplexityUsageSnapshot) {
+    public func finalize() -> (Bool, Int?, PerplexityUsageSnapshot) {
         lock.lock(); defer { lock.unlock() }
         return (unauthorized, httpError, PerplexityUsageSnapshot(
             credits: credits,
@@ -569,4 +574,14 @@ private final class PerplexityFetchAccumulator: @unchecked Sendable {
             settings: settings
         ))
     }
+
+    #if DEBUG
+    /// Test-only accessor for the current httpError. Guarded behind DEBUG
+    /// so it cannot be reached from production paths and stays out of
+    /// release-binary symbol tables.
+    public var currentHttpError: Int? {
+        lock.lock(); defer { lock.unlock() }
+        return httpError
+    }
+    #endif
 }

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -116,9 +116,10 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
 
         var out: [UsageTile] = []
 
-        // Plan tile from user/settings. Fall back to a plain "Perplexity" label
-        // when settings is absent (Cloudflare-challenged that endpoint).
-        if let settings = snap.settings, let tier = normalisedTier(settings.subscriptionTier, source: settings.subscriptionSource) {
+        // Plan tile from user/settings. Only rendered when we can name a
+        // plan tier — the tile is omitted when the settings endpoint was
+        // Cloudflare-challenged or only reported a billing source.
+        if let settings = snap.settings, let tier = normalisedTier(settings.subscriptionTier) {
             let statusLine = settings.subscriptionStatus.map { "\(tier) (\($0))" } ?? tier
             out.append(UsageTile(
                 id: "perplexity-plan",
@@ -202,23 +203,24 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
         return out
     }
 
-    /// Normalise raw subscription strings into a human label. Preserves
+    /// Normalise a raw subscription-tier string into a human label. Preserves
     /// unknown values verbatim so a new tier introduced server-side is not
-    /// silently swallowed.
-    private func normalisedTier(_ rawTier: String?, source: String?) -> String? {
-        // Prefer subscription_tier when present; fall back to source name.
-        if let tier = rawTier?.trimmingCharacters(in: .whitespaces), !tier.isEmpty, tier.lowercased() != "none" {
-            switch tier.lowercased() {
-            case "free": return "Free"
-            case "pro": return "Pro"
-            case "max": return "Max"
-            default: return tier
-            }
+    /// silently swallowed. Returns nil when no tier is reported — the caller
+    /// omits the plan tile in that case rather than mislabelling it with a
+    /// billing-provider name (chk1 Bug #3: `subscription_source` values like
+    /// "stripe" / "revenuecat" are billing providers, NOT plans).
+    private func normalisedTier(_ rawTier: String?) -> String? {
+        guard let tier = rawTier?.trimmingCharacters(in: .whitespaces),
+              !tier.isEmpty,
+              tier.lowercased() != "none" else {
+            return nil
         }
-        if let src = source?.trimmingCharacters(in: .whitespaces), !src.isEmpty, src.lowercased() != "none" {
-            return src.capitalized
+        switch tier.lowercased() {
+        case "free": return "Free"
+        case "pro":  return "Pro"
+        case "max":  return "Max"
+        default:     return tier   // preserve an unknown tier verbatim
         }
-        return nil
     }
 
     // MARK: - Result application (testable seam)
@@ -261,13 +263,34 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
 
     public func fetch() {
         guard isEnabled else { return }
-        guard let data = credentials.read(PerplexityUsageFetcher.cookieKeychainKey),
-              !data.isEmpty,
-              let raw = String(data: data, encoding: .utf8) else {
-            // No credential in the store (or locked keychain returning nil
-            // read here). Onboarding card renders via isConfigured=false.
+        // Use readResult() rather than read() so a locked keychain
+        // (.unavailable) is distinguished from a truly-missing item. Round-2
+        // review addressed the malformed-cookie case; this closes the same
+        // silent-no-op gap for the locked-keychain scenario — isConfigured
+        // still returns true when the item exists but is unreadable, so
+        // without an explicit branch here the UI would report the provider
+        // as configured while fetch quietly did nothing (chk1 Bug #2).
+        let data: Data
+        switch credentials.readResult(PerplexityUsageFetcher.cookieKeychainKey) {
+        case .found(let value) where !value.isEmpty:
+            data = value
+        case .found, .missing:
+            // No credential stored (or empty item — treat as missing).
+            // Onboarding card renders via isConfigured=false.
             snapshot = nil
             lastError = nil
+            return
+        case .unavailable:
+            // Keychain present but temporarily unreadable (locked screen,
+            // access denied). Surface an actionable message so the tile
+            // does not silently blank while the user's Mac is locked.
+            snapshot = nil
+            lastError = "Keychain locked or unavailable. Unlock your Mac to refresh Perplexity usage."
+            return
+        }
+        guard let raw = String(data: data, encoding: .utf8) else {
+            snapshot = nil
+            lastError = "Could not decode the stored Perplexity cookie. Re-paste it in Settings."
             return
         }
         guard let cookie = PerplexityCookie.extract(from: raw) else {
@@ -335,6 +358,32 @@ public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
     /// it is the shape Perplexity's own web bundle sends.
     private let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+
+    /// Private URLSession, isolated from `URLSession.shared` (chk1 Risk #1
+    /// + #2). Two problems the shared session has for a cookie-authenticated
+    /// provider:
+    ///   1. The default `HTTPCookieStorage` is disk-backed under
+    ///      ~/Library/Cookies/. Perplexity sets several cookies on every
+    ///      response (`__cf_bm`, `cf_clearance`, session tokens); with the
+    ///      shared session those would silently persist across app launches
+    ///      in a store the user cannot see, and would leak onto every other
+    ///      request the app makes to perplexity.ai (including Anthropic's
+    ///      tracker if that ever traversed the domain).
+    ///   2. `URLSessionConfiguration.default.timeoutIntervalForResource` is
+    ///      604 800 seconds (7 days). A stalled Perplexity response would
+    ///      park its callback for a week.
+    /// Our explicit `Cookie:` header is the ONLY source of session state for
+    /// this transport; the response cookie jar is nulled so nothing sticks.
+    /// Timeouts are matched to the 60s poll cadence.
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
 
     public init() {}
 
@@ -443,7 +492,10 @@ public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
         request.setValue("https://www.perplexity.ai/account/usage", forHTTPHeaderField: "Referer")
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
 
-        URLSession.shared.dataTask(with: request) { data, response, error in
+        // Private session (see the `session` property comment) — critical
+        // that this is NOT URLSession.shared, so Perplexity's Set-Cookie
+        // responses cannot contaminate the process-wide cookie jar.
+        session.dataTask(with: request) { data, response, error in
             if error != nil { done(nil, nil); return }
             let status = (response as? HTTPURLResponse)?.statusCode
             Log.info("Perplexity API response", .count(status ?? -1))

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -2,9 +2,10 @@
 //
 // Sixth non-Anthropic provider; first cookie-authenticated one. The user's
 // perplexity.ai session cookie is stored in the Keychain (PasteKeyProvider
-// UX; the field ships in PR 8-UI). Three endpoints are polled every 5
-// minutes when enabled: credits, rate-limit/all, user/settings. Bodies are
-// never logged; only HTTP status codes go through Log.info(.count).
+// UX shipped in PR 8-UI). Three endpoints are polled every 60 seconds by
+// the shared AppDelegate timer when enabled: credits, rate-limit/all,
+// user/settings. Bodies are never logged; only HTTP status codes go
+// through Log.info(.count).
 //
 // Feature posture: features.perplexity.enabled defaults false. Nothing
 // registers a store into the live registry yet — the tile + Settings sheet
@@ -150,8 +151,13 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
             // published Pro/Max plan comparisons (CodexBar comment) —
             // NB: the initial draft used 5 000 which flipped Pro users to
             // "Max" one order of magnitude too early.
+            // Defensive lowercase compare: Perplexity has been observed
+            // returning "recurring" verbatim, but a future casing change
+            // ("Recurring") would silently drop the recurring total and
+            // blank out the plan hint. Match case-insensitively so a
+            // schema tweak does not cause a silent regression.
             let recurring = credits.grants
-                .filter { $0.type == "recurring" }
+                .filter { $0.type.lowercased() == "recurring" }
                 .reduce(0.0) { $0 + max(0, $1.amountCents) }
             let planHint: String? = recurring <= 0
                 ? nil

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -520,10 +520,17 @@ private enum PerplexityEndpointKind {
 /// Thread-safe accumulator for the three concurrent GETs. A final call to
 /// `finalize()` collapses the state into a single snapshot + unauthorized
 /// flag. Lock-protected because `dataTask` completions can land on any
-/// queue. `public` (rather than `private`) so TestRunner can lock in the
-/// httpError priority ordering without going through a live URL session
-/// (chk1 Omission #1). The type is otherwise an internal implementation
-/// detail — not re-exported, not part of the store's public API surface.
+/// queue.
+///
+/// `public` (rather than `private`) so TestRunner — a separate SwiftPM
+/// target — can lock in the httpError priority ordering and multi-endpoint
+/// partial-success shapes without going through a live URL session
+/// (chk1 Omission #1 + #2). Codex round-4 flagged this as a small API
+/// surface leak; we accept the leak because ClaudeUsageBar is an app-only
+/// module with no external library consumers, so no downstream code can
+/// depend on this shape. If the module ever gains an external API contract,
+/// switch TestRunner to `@testable import ClaudeUsageBar` and revert this
+/// to `internal`.
 public final class PerplexityFetchAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var credits: PerplexityCredits?

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -30,6 +30,10 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
     // or a full cookie header string (browser DevTools "Copy value" or
     // "Copy string"). Extraction runs at fetch time.
     public let keyPlaceholder: String = "__Secure-next-auth.session-token=… (or paste the cookie value)"
+    /// Override the default noun so the generic ProviderToggleRow renders
+    /// "Cookie saved in Keychain" rather than "Key saved in Keychain",
+    /// matching what the user actually pasted.
+    public var secretKindNoun: String { "Cookie" }
 
     // MARK: Observable state
 

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -1,0 +1,510 @@
+// PR 8-BE — Perplexity Pro/Max UsageProvider conformer (dark code, flag off).
+//
+// Sixth non-Anthropic provider; first cookie-authenticated one. The user's
+// perplexity.ai session cookie is stored in the Keychain (PasteKeyProvider
+// UX; the field ships in PR 8-UI). Three endpoints are polled every 5
+// minutes when enabled: credits, rate-limit/all, user/settings. Bodies are
+// never logged; only HTTP status codes go through Log.info(.count).
+//
+// Feature posture: features.perplexity.enabled defaults false. Nothing
+// registers a store into the live registry yet — the tile + Settings sheet
+// land in PR 8-UI.
+//
+// Polling etiquette: perplexity.ai's own internal endpoints ask consumers
+// to cache 60s+ to avoid a shadow-ban on the session cookie. The shared
+// AppDelegate timer fires providers at 60s; that meets the etiquette
+// without a per-provider override.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
+
+    public let id: String = "perplexity"
+    public let displayName: String = "Perplexity"
+    public let featureFlagKey: String = "features.perplexity.enabled"
+
+    // PasteKeyProvider — the input can be a bare token, a name=value pair,
+    // or a full cookie header string (browser DevTools "Copy value" or
+    // "Copy string"). Extraction runs at fetch time.
+    public let keyPlaceholder: String = "__Secure-next-auth.session-token=… (or paste the cookie value)"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: PerplexityUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: PerplexityUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: PerplexityUsageTransport = URLSessionPerplexityTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when a session cookie is stored, treating a locked keychain as
+    /// "still configured" so a locked screen does not drop the provider back
+    /// to onboarding (parity with DeepSeek / xAI / OpenAI).
+    public var hasKey: Bool {
+        switch credentials.readResult(PerplexityUsageFetcher.cookieKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
+    }
+
+    /// Store the pasted cookie verbatim (whitespace-trimmed only). We do NOT
+    /// pre-parse: keeping the raw input lets the user amend a stray prefix
+    /// without re-pasting the whole thing, and extraction runs at fetch
+    /// time.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(PerplexityUsageFetcher.cookieKeychainKey)
+        } else {
+            credentials.write(PerplexityUsageFetcher.cookieKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    public var isConfigured: Bool {
+        hasKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "perplexity-needs-key",
+                title: "Perplexity",
+                kind: .needsAccess(
+                    path: "perplexity.ai",
+                    guidance: "Paste your Perplexity session cookie in Settings. Sign in on perplexity.ai, then copy the value of the __Secure-next-auth.session-token cookie."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan tile from user/settings. Fall back to a plain "Perplexity" label
+        // when settings is absent (Cloudflare-challenged that endpoint).
+        if let settings = snap.settings, let tier = normalisedTier(settings.subscriptionTier, source: settings.subscriptionSource) {
+            let statusLine = settings.subscriptionStatus.map { "\(tier) (\($0))" } ?? tier
+            out.append(UsageTile(
+                id: "perplexity-plan",
+                title: "Perplexity plan",
+                kind: .text(status: statusLine, subtitle: nil)
+            ))
+        }
+
+        // Credits balance tile. balance_cents is a live USD-cents number;
+        // the balance tile takes minor units directly. Renewal date drives
+        // the resetsAt hint.
+        if let credits = snap.credits {
+            // Crash-safety: balance_cents is a Double parsed from an
+            // untrusted server. `Int(Double)` traps on non-finite / oversize
+            // values (1e300 is a valid JSON number). Clamp with
+            // Int(exactly:) on the rounded Double, then max(0, …).
+            let cents: Int = {
+                let clamped = max(0.0, credits.balanceCents)
+                guard clamped.isFinite else { return 0 }
+                return Int(exactly: clamped.rounded()) ?? Int.max
+            }()
+            let renewsAt: Date? = credits.renewalEpoch > 0
+                ? Date(timeIntervalSince1970: credits.renewalEpoch)
+                : nil
+            // Plan hint on the balance tile comes from the recurring grant
+            // total. Perplexity's own plans put Pro's monthly credit
+            // allotment in the ~$5 range and Max's in the ~$100+ range; use
+            // 10 000 cents ($100) as the Pro/Max boundary so a $50 (5 000c)
+            // recurring grant is still labelled Pro. Verified against
+            // published Pro/Max plan comparisons (CodexBar comment) —
+            // NB: the initial draft used 5 000 which flipped Pro users to
+            // "Max" one order of magnitude too early.
+            let recurring = credits.grants
+                .filter { $0.type == "recurring" }
+                .reduce(0.0) { $0 + max(0, $1.amountCents) }
+            let planHint: String? = recurring <= 0
+                ? nil
+                : (recurring < 10000 ? "Pro" : "Max")
+            out.append(UsageTile(
+                id: "perplexity-credits",
+                title: "Perplexity credits",
+                kind: .balance(
+                    remainingMinorUnits: cents,
+                    currency: "USD",
+                    plan: planHint,
+                    resetsAt: renewsAt
+                )
+            ))
+        }
+
+        // Per-mode counters from /rest/rate-limit/all. Only remaining values
+        // are on the wire — no totals — so we cannot render a proper
+        // used/limit counter without inferring a plan cap client-side. That
+        // inference is brittle (Perplexity ships plan changes without
+        // notice), so surface the raw number as a `.text` tile ("42 left")
+        // rather than a `.counter` whose "limit" would be the same as
+        // "remaining" and read as unused. Only emit tiles for modes that
+        // report a positive number so a free-tier account isn't papered
+        // with four grey zeros.
+        if let limits = snap.rateLimits {
+            let modes: [(String, String, Int)] = [
+                ("perplexity-pro", "Pro Search", limits.remainingPro),
+                ("perplexity-research", "Deep Research", limits.remainingResearch),
+                ("perplexity-labs", "Labs", limits.remainingLabs),
+                ("perplexity-agentic", "Agentic Research", limits.remainingAgenticResearch),
+            ]
+            for (id, title, remaining) in modes where remaining > 0 {
+                out.append(UsageTile(
+                    id: id,
+                    title: title,
+                    kind: .text(status: "\(remaining) left", subtitle: nil)
+                ))
+            }
+        }
+
+        return out
+    }
+
+    /// Normalise raw subscription strings into a human label. Preserves
+    /// unknown values verbatim so a new tier introduced server-side is not
+    /// silently swallowed.
+    private func normalisedTier(_ rawTier: String?, source: String?) -> String? {
+        // Prefer subscription_tier when present; fall back to source name.
+        if let tier = rawTier?.trimmingCharacters(in: .whitespaces), !tier.isEmpty, tier.lowercased() != "none" {
+            switch tier.lowercased() {
+            case "free": return "Free"
+            case "pro": return "Pro"
+            case "max": return "Max"
+            default: return tier
+            }
+        }
+        if let src = source?.trimmingCharacters(in: .whitespaces), !src.isEmpty, src.lowercased() != "none" {
+            return src.capitalized
+        }
+        return nil
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result. Extracted so the TestRunner can drive every
+    /// branch synchronously.
+    public func apply(_ result: PerplexityUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            // 401/403 — cookie expired, or Cloudflare bounced us. Both need
+            // the same user action (re-copy the cookie from a signed-in
+            // browser); the differentiation is hidden behind one message.
+            // Also drop the stale snapshot so the tile does not keep
+            // showing an obsolete balance / counters while the credential
+            // is known-bad (Codex adversarial review #6).
+            self.snapshot = nil
+            self.lastError = "Perplexity session cookie expired or blocked. Sign in on perplexity.ai and paste a fresh cookie."
+        case .httpError(let code):
+            // 429 is Perplexity's rate-limit / soft-shadow-ban signal;
+            // 5xx is a real server problem the user cannot fix. Give each
+            // a distinct message so the user knows whether to slow down or
+            // wait for Perplexity to recover.
+            if code == 429 {
+                self.lastError = "Perplexity is rate-limiting this session. Slow polling or wait a few minutes."
+            } else if (500 ..< 600).contains(code) {
+                self.lastError = "Perplexity server error (HTTP \(code)). Retry later."
+            } else {
+                self.lastError = "HTTP \(code)"
+            }
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let data = credentials.read(PerplexityUsageFetcher.cookieKeychainKey),
+              !data.isEmpty,
+              let raw = String(data: data, encoding: .utf8) else {
+            // No credential in the store (or locked keychain returning nil
+            // read here). Onboarding card renders via isConfigured=false.
+            snapshot = nil
+            lastError = nil
+            return
+        }
+        guard let cookie = PerplexityCookie.extract(from: raw) else {
+            // The stored blob exists but is not a usable cookie. Surface an
+            // actionable error rather than silently no-op'ing forever —
+            // isConfigured is still true (hasKey checks presence, not
+            // parseability), so without this message the user sees an
+            // empty section indefinitely.
+            snapshot = nil
+            lastError = "Could not parse the stored Perplexity cookie. Re-paste it in Settings."
+            return
+        }
+
+        transport.fetchAll(cookieName: cookie.name, cookieValue: cookie.token) { [weak self] result in
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
+        }
+    }
+
+    public func clear() {
+        // Clearing Perplexity DOES delete the cookie — the user pasted it
+        // here. Same pattern as DeepSeek's Clear Key.
+        credentials.delete(PerplexityUsageFetcher.cookieKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum PerplexityUsageResult: Sendable {
+    case success(PerplexityUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the multi-endpoint fetch. The completion MAY be delivered on
+/// any queue; the store hops to the main actor via a `Task { @MainActor }`
+/// before touching @Published state (see the Hardening pass in PR #60 for
+/// why `assumeIsolated` is banned).
+public protocol PerplexityUsageTransport: Sendable {
+    func fetchAll(
+        cookieName: String,
+        cookieValue: String,
+        completion: @escaping @Sendable (PerplexityUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues three GETs in parallel with the pasted
+/// cookie, browser-shaped headers, and no body. Bodies are never logged;
+/// only status codes go through Log.info(.count).
+public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
+
+    private let creditsURL = URL(string: "https://www.perplexity.ai/rest/billing/credits?version=2.18&source=default")!
+    private let rateLimitsURL = URL(string: "https://www.perplexity.ai/rest/rate-limit/all")!
+    private let settingsURL = URL(string: "https://www.perplexity.ai/rest/user/settings?version=2.18&source=default")!
+
+    /// Browser-shaped User-Agent. Cloudflare bot detection fingerprints on
+    /// TLS + IP; a plain URLSession UA is enough for residential Mac users
+    /// but the header still needs to smell like a browser to avoid the
+    /// challenge-page filter. This UA is not spoofing a specific browser —
+    /// it is the shape Perplexity's own web bundle sends.
+    private let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+
+    public init() {}
+
+    public func fetchAll(
+        cookieName: String,
+        cookieValue: String,
+        completion: @escaping @Sendable (PerplexityUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (PerplexityUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Cookie assembly. Both name and value pass through
+        // RequestSafety.headerValue to reject control chars (CR/LF/NUL) that
+        // could split the header. Additionally, `;`, `,`, `=` are rejected
+        // in the *value*, and the same set plus space is rejected in the
+        // *name*, to defeat a Cookie-splicing attack: a hostile string
+        // pasted (or Keychain-injected) as a value like "real; other=evil"
+        // would otherwise silently add a second cookie to the request, and
+        // a similarly hostile name like "session-token=real; other" would
+        // splice via the name half. NextAuth cookie names are letters,
+        // digits, `-`, `.`, `_`; JWEs are base64url with dot separators;
+        // neither ever legitimately contains these splitters.
+        guard let safeName = RequestSafety.headerValue(cookieName),
+              let safeValue = RequestSafety.headerValue(cookieValue),
+              !safeName.contains(";"),
+              !safeName.contains(","),
+              !safeName.contains("="),
+              !safeName.contains(" "),
+              !safeValue.contains(";"),
+              !safeValue.contains(",") else {
+            deliver(.unauthorized)
+            return
+        }
+        let cookieHeader = "\(safeName)=\(safeValue)"
+
+        let group = DispatchGroup()
+        // Atomic accumulator around a lock — three concurrent GETs feed it.
+        let acc = PerplexityFetchAccumulator()
+
+        for (url, kind) in [
+            (creditsURL, PerplexityEndpointKind.credits),
+            (rateLimitsURL, .rateLimits),
+            (settingsURL, .settings),
+        ] {
+            group.enter()
+            get(url, cookieHeader: cookieHeader) { data, status in
+                defer { group.leave() }
+                if let status = status, (status == 401 || status == 403) {
+                    acc.setUnauthorized()
+                    return
+                }
+                if status == 200, let data = data {
+                    switch kind {
+                    case .credits:
+                        if let parsed = try? PerplexityUsageFetcher.parseCredits(data) {
+                            acc.setCredits(parsed)
+                        }
+                    case .rateLimits:
+                        if let parsed = try? PerplexityUsageFetcher.parseRateLimits(data) {
+                            acc.setRateLimits(parsed)
+                        }
+                    case .settings:
+                        if let parsed = try? PerplexityUsageFetcher.parseUserSettings(data) {
+                            acc.setSettings(parsed)
+                        }
+                    }
+                } else if let status = status {
+                    // A non-success, non-auth status (429, 5xx, ...). Remember
+                    // the highest-signal code so a total failure can surface it
+                    // to the user rather than degrading to "Network error".
+                    // 429 is Perplexity's shadow-ban / rate-limit response
+                    // and is the most actionable — the user needs to slow
+                    // down or wait, not re-paste a cookie.
+                    acc.recordHttpError(status)
+                }
+            }
+        }
+
+        group.notify(queue: .global()) {
+            let (unauthorized, httpError, snap) = acc.finalize()
+            if unauthorized {
+                deliver(.unauthorized)
+            } else if snap.credits == nil && snap.rateLimits == nil && snap.settings == nil {
+                // Every endpoint failed. Prefer the HTTP status when one is
+                // remembered (429/5xx) — Codex round-3 review — else fall
+                // back to networkError for a genuine transport failure.
+                if let code = httpError {
+                    deliver(.httpError(code))
+                } else {
+                    deliver(.networkError)
+                }
+            } else {
+                deliver(.success(snap))
+            }
+        }
+    }
+
+    private func get(_ url: URL, cookieHeader: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("https://www.perplexity.ai", forHTTPHeaderField: "Origin")
+        request.setValue("https://www.perplexity.ai/account/usage", forHTTPHeaderField: "Referer")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("Perplexity API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}
+
+// MARK: - Endpoint kind + accumulator
+
+/// Which endpoint a completion is reporting for. Nested in the transport
+/// only (not part of the public surface).
+private enum PerplexityEndpointKind {
+    case credits, rateLimits, settings
+}
+
+/// Thread-safe accumulator for the three concurrent GETs. A final call to
+/// `finalize()` collapses the state into a single snapshot + unauthorized
+/// flag. Lock-protected because `dataTask` completions can land on any
+/// queue.
+private final class PerplexityFetchAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var credits: PerplexityCredits?
+    private var rateLimits: PerplexityRateLimits?
+    private var settings: PerplexityUserSettings?
+    private var unauthorized = false
+    /// Highest-priority non-2xx status seen. Prioritises 429 (shadow-ban
+    /// signal, most actionable), then 5xx, then anything else, so the
+    /// finalize step surfaces the most useful code when every endpoint
+    /// failed.
+    private var httpError: Int?
+
+    func setCredits(_ value: PerplexityCredits) {
+        lock.lock(); defer { lock.unlock() }
+        credits = value
+    }
+    func setRateLimits(_ value: PerplexityRateLimits) {
+        lock.lock(); defer { lock.unlock() }
+        rateLimits = value
+    }
+    func setSettings(_ value: PerplexityUserSettings) {
+        lock.lock(); defer { lock.unlock() }
+        settings = value
+    }
+    func setUnauthorized() {
+        lock.lock(); defer { lock.unlock() }
+        unauthorized = true
+    }
+    func recordHttpError(_ status: Int) {
+        lock.lock(); defer { lock.unlock() }
+        // Priority: 429 > 5xx > anything else. Only replace when the new
+        // code carries strictly more signal.
+        let priority: (Int) -> Int = { code in
+            if code == 429 { return 3 }
+            if code >= 500 && code < 600 { return 2 }
+            return 1
+        }
+        if let existing = httpError {
+            if priority(status) > priority(existing) {
+                httpError = status
+            }
+        } else {
+            httpError = status
+        }
+    }
+    func finalize() -> (Bool, Int?, PerplexityUsageSnapshot) {
+        lock.lock(); defer { lock.unlock() }
+        return (unauthorized, httpError, PerplexityUsageSnapshot(
+            credits: credits,
+            rateLimits: rateLimits,
+            settings: settings
+        ))
+    }
+}

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -372,14 +372,19 @@ public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
     ///   2. `URLSessionConfiguration.default.timeoutIntervalForResource` is
     ///      604 800 seconds (7 days). A stalled Perplexity response would
     ///      park its callback for a week.
-    /// Our explicit `Cookie:` header is the ONLY source of session state for
-    /// this transport; the response cookie jar is nulled so nothing sticks.
+    /// This session uses `.ephemeral` configuration — Apple's documented
+    /// pattern for a URLSession with in-memory-only cookie storage isolated
+    /// from `URLSession.shared`. `.ephemeral` gives us a per-session cookie
+    /// jar that:
+    ///   - Cloudflare's per-poll `__cf_bm` challenge cookies still work
+    ///     inside a single fetchAll() cycle (chk1-fix Codex round 4: nulling
+    ///     the store entirely could break Cloudflare challenge flows).
+    ///   - Nothing persists to disk (unlike the shared session's default
+    ///     store under ~/Library/Cookies/).
+    ///   - Nothing leaks into the shared jar or any other provider.
     /// Timeouts are matched to the 60s poll cadence.
     private let session: URLSession = {
-        let config = URLSessionConfiguration.default
-        config.httpShouldSetCookies = false
-        config.httpCookieAcceptPolicy = .never
-        config.httpCookieStorage = nil
+        let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 30
         return URLSession(configuration: config)

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -164,6 +164,25 @@ public protocol CredentialStore {
     func delete(_ key: String)
 }
 
+// MARK: - PasteKeyProvider
+
+/// Optional capability for providers configured by pasting a secret (an API
+/// key, a session cookie). The Settings toggle row shows a secure entry
+/// field for any provider that conforms. Providers configured another way
+/// (Codex reads a CLI file; Anthropic uses the cookie sheet) do not conform.
+///
+/// @MainActor because conformers are main-actor stores; the entry field is
+/// itself on the main actor.
+@MainActor
+public protocol PasteKeyProvider {
+    /// Placeholder shown in the entry field (e.g. "sk-…").
+    var keyPlaceholder: String { get }
+    /// True when a secret is currently stored.
+    var hasKey: Bool { get }
+    /// Store a pasted secret. Empty input clears it.
+    func saveKey(_ raw: String)
+}
+
 // MARK: - ProviderCopy
 
 /// Per-provider help and disclosure copy for the Settings toggles. Kept in
@@ -176,6 +195,8 @@ public enum ProviderCopy {
         switch id {
         case "codex":
             return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
+        case "deepseek":
+            return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -121,7 +121,13 @@ public protocol UsageProvider: AnyObject, ObservableObject {
 /// observation site did not. `ProviderBox` is the fix.
 @MainActor
 public final class ProviderBox: ObservableObject, Identifiable {
-    public let provider: any UsageProvider
+    // `nonisolated` so consumers that are not themselves main-actor-isolated
+    // (e.g. ProvidersModel.fetchEnabled, called from AppDelegate timer and
+    // lifecycle closures) can read it without an actor hop. It is an
+    // immutable `let` set once at init; the underlying provider's own methods
+    // remain main-actor-isolated, so this only exposes the reference, not
+    // unsynchronised mutable state.
+    public nonisolated let provider: any UsageProvider
     // Cached at construction rather than reaching through `provider.id` on
     // every access — keeps `id` a nonisolated stored property so the
     // Identifiable conformance is Swift-6-strict-concurrency clean.
@@ -156,6 +162,35 @@ public protocol CredentialStore {
     func read(_ key: String) -> Data?
     func write(_ key: String, _ value: Data)
     func delete(_ key: String)
+}
+
+// MARK: - ProviderCopy
+
+/// Per-provider help and disclosure copy for the Settings toggles. Kept in
+/// the library (not the app view file) so the strings are unit-testable —
+/// they are user-facing and must not silently change. Returns nil for a
+/// provider with no bespoke copy.
+public enum ProviderCopy {
+    /// Explanatory help shown under a provider's Settings toggle.
+    public static func help(for id: String) -> String? {
+        switch id {
+        case "codex":
+            return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
+        default:
+            return nil
+        }
+    }
+
+    /// A warning line shown for providers backed by a private/undocumented
+    /// API that may break without notice. Rendered in an accent colour.
+    public static func disclosure(for id: String) -> String? {
+        switch id {
+        case "codex":
+            return "Uses OpenAI's private Codex API. It may stop working without notice."
+        default:
+            return nil
+        }
+    }
 }
 
 /// UserDefaults-backed credential store. Used only for the legacy

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -247,6 +247,18 @@ public protocol PasteKeyProvider {
     var hasKey: Bool { get }
     /// Store a pasted secret. Empty input clears it.
     func saveKey(_ raw: String)
+    /// Human word for what the user pasted, used in status text like
+    /// "Key saved in Keychain" or "Cookie saved in Keychain". Defaults to
+    /// "Key" for API-key providers via the extension below; override on a
+    /// concrete conformer for cookie/session providers (e.g. Perplexity).
+    /// Declared as a protocol requirement — not just an extension — so
+    /// existential dispatch (`box.provider as PasteKeyProvider`) picks up
+    /// the concrete override rather than the default.
+    var secretKindNoun: String { get }
+}
+
+public extension PasteKeyProvider {
+    var secretKindNoun: String { "Key" }
 }
 
 // MARK: - SecondaryKeyProvider
@@ -292,6 +304,8 @@ public enum ProviderCopy {
             return "Shows your xAI (Grok) API key permissions. Paste an inference key (xai-…) below. Add a management key too to also see prepaid balance and daily usage. Both are stored in your Keychain."
         case "openai":
             return "Shows your OpenAI organisation's month-to-date spend, token usage by model, and configured rate limits. Paste an Organization Admin key (sk-admin-…); it is stored in your Keychain."
+        case "perplexity":
+            return "Can show your Perplexity plan, credit balance, and per-mode remaining queries (Pro Search, Deep Research, Labs, Agentic) when available. Sign in on perplexity.ai, open your browser's cookie inspector, and paste your __Secure-next-auth.session-token cookie below — the bare value, a name=value pair, or the full copied Cookie header all work. It is stored in your Keychain."
         default:
             return nil
         }
@@ -305,6 +319,8 @@ public enum ProviderCopy {
             return "Uses OpenAI's private Codex API. It may stop working without notice."
         case "openai":
             return "An Admin key can view billing and manage users in your OpenAI organisation. It cannot make inference calls. Store yours only if you are comfortable with this app holding it."
+        case "perplexity":
+            return "Uses Perplexity's private web-app endpoints. They may stop working without notice. The pasted value is a full Perplexity web session cookie — it can let this app act as your signed-in account, including spending or purchasing credits your plan allows, until it expires or is revoked (for example by signing out or clearing sessions on perplexity.ai)."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -23,6 +23,47 @@ import Foundation
 import SwiftUI
 import Combine
 
+// MARK: - RequestSafety
+
+/// Small hardening helpers for building credentialed requests from values
+/// that originate in an API response (a team id, project id) or a keychain
+/// account attribute (a user id). Server-issued strings are only semi-trusted:
+/// a compromised or buggy endpoint could return an id containing "/", "?",
+/// "#", or control characters that would alter the request path or split an
+/// HTTP header. These helpers reject or encode such input.
+public enum RequestSafety {
+    /// Percent-encode a single URL PATH segment, rejecting characters that
+    /// would change the path structure. Returns nil if the input is empty or
+    /// contains characters not valid in a path segment even after encoding
+    /// (control characters). "/" and "?" and "#" are encoded, not passed
+    /// through, so an id like "../admin" cannot traverse the path.
+    public static func pathSegment(_ raw: String) -> String? {
+        guard !raw.isEmpty else { return nil }
+        // Reject control characters outright — they have no business in an id.
+        if raw.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F }) {
+            return nil
+        }
+        // Encode everything that is not an unreserved path character. This
+        // encodes "/", "?", "#", "%", etc., so the segment cannot escape its
+        // position in the path.
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")   // RFC 3986 unreserved
+        return raw.addingPercentEncoding(withAllowedCharacters: allowed)
+    }
+
+    /// Validate a value destined for an HTTP header (e.g. a user id in an
+    /// Authorization header). Rejects CR, LF, and other control characters
+    /// that could split or inject headers. Returns the value unchanged when
+    /// safe, or nil when it must not be sent.
+    public static func headerValue(_ raw: String) -> String? {
+        guard !raw.isEmpty else { return nil }
+        if raw.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F }) {
+            return nil
+        }
+        return raw
+    }
+}
+
 // MARK: - UsageTile
 
 /// One renderable tile in the popover. A provider may contribute zero or
@@ -162,6 +203,31 @@ public protocol CredentialStore {
     func read(_ key: String) -> Data?
     func write(_ key: String, _ value: Data)
     func delete(_ key: String)
+
+    /// Read that distinguishes a genuinely absent credential (`.missing`)
+    /// from a keychain that is present but unreadable (`.unavailable`, e.g.
+    /// locked or access-denied). Only `.missing` should drive a provider's
+    /// "not configured" onboarding state. The default implementation maps the
+    /// plain `read` (found → `.found`, nil → `.missing`); `KeychainStore`
+    /// overrides it to report the real status.
+    func readResult(_ key: String) -> CredentialReadResult
+}
+
+public extension CredentialStore {
+    func readResult(_ key: String) -> CredentialReadResult {
+        if let data = read(key) { return .found(data) }
+        return .missing
+    }
+}
+
+/// Outcome of a credential read that separates a genuinely absent credential
+/// (`.missing`) from a store that is present but unreadable (`.unavailable`,
+/// e.g. a locked keychain). Only `.missing` should drive a "not configured"
+/// onboarding state. `OSStatus` is Foundation's `Int32` security-result code.
+public enum CredentialReadResult: Equatable {
+    case found(Data)
+    case missing
+    case unavailable(OSStatus)
 }
 
 // MARK: - PasteKeyProvider

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -224,6 +224,8 @@ public enum ProviderCopy {
             return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
         case "xai":
             return "Shows your xAI (Grok) API key permissions. Paste an inference key (xai-…) below. Add a management key too to also see prepaid balance and daily usage. Both are stored in your Keychain."
+        case "openai":
+            return "Shows your OpenAI organisation's month-to-date spend, token usage by model, and configured rate limits. Paste an Organization Admin key (sk-admin-…); it is stored in your Keychain."
         default:
             return nil
         }
@@ -235,6 +237,8 @@ public enum ProviderCopy {
         switch id {
         case "codex":
             return "Uses OpenAI's private Codex API. It may stop working without notice."
+        case "openai":
+            return "An Admin key can view billing and manage users in your OpenAI organisation. It cannot make inference calls. Store yours only if you are comfortable with this app holding it."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -183,6 +183,29 @@ public protocol PasteKeyProvider {
     func saveKey(_ raw: String)
 }
 
+// MARK: - SecondaryKeyProvider
+
+/// Optional capability for providers that accept a SECOND, higher-privilege
+/// secret gated behind a warning (e.g. xAI's management key, which can
+/// create/rotate/delete API keys). The Settings row renders a second, opt-in
+/// entry field with the warning text for any provider that conforms.
+///
+/// A provider adopting this must also adopt PasteKeyProvider for its primary
+/// (required) key.
+@MainActor
+public protocol SecondaryKeyProvider {
+    /// Placeholder for the secondary field.
+    var secondaryKeyPlaceholder: String { get }
+    /// Short label for the opt-in row (e.g. "Enable balance + history").
+    var secondaryKeyLabel: String { get }
+    /// Warning shown before the field (e.g. what the key can do).
+    var secondaryKeyWarning: String { get }
+    /// True when a secondary secret is stored.
+    var hasSecondaryKey: Bool { get }
+    /// Store a pasted secondary secret. Empty input clears it.
+    func saveSecondaryKey(_ raw: String)
+}
+
 // MARK: - ProviderCopy
 
 /// Per-provider help and disclosure copy for the Settings toggles. Kept in
@@ -199,6 +222,8 @@ public enum ProviderCopy {
             return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
         case "zed":
             return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
+        case "xai":
+            return "Shows your xAI (Grok) API key permissions. Paste an inference key (xai-…) below. Add a management key too to also see prepaid balance and daily usage. Both are stored in your Keychain."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -197,6 +197,8 @@ public enum ProviderCopy {
             return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
         case "deepseek":
             return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
+        case "zed":
+            return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -1,0 +1,181 @@
+// PR 2c — UsageProvider protocol and supporting types.
+//
+// This PR introduces the multi-provider surface without adding any new
+// provider. It ships:
+//
+//   1. A `UsageProvider` protocol every provider will conform to.
+//   2. A `UsageTile` value type for popover rendering.
+//   3. A `ProviderBox` type-erasing wrapper so SwiftUI can observe a
+//      collection of heterogeneous providers via a single ObservableObject.
+//   4. `AnthropicUsageStore` — the first conformer, wrapping the existing
+//      UsageManager. Behaviour identical to v1.3.1.
+//
+// Everything is additive. UsageManager is not removed. The popover is not
+// yet driven by `[UsageProvider]` — that switch lands in a follow-up PR
+// once at least one non-Anthropic provider exists.
+//
+// The two-layer split (Fetcher value type + Store observable class) is
+// documented in EXPANSION_PLAN.md § 2. Fetchers are Sendable value types
+// with no observable state (see AnthropicUsageFetcher in PR 2b). Stores
+// hold @Published state on the main actor and are what SwiftUI observes.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// MARK: - UsageTile
+
+/// One renderable tile in the popover. A provider may contribute zero or
+/// more tiles. The `Kind` enum encodes the presentation semantics without
+/// coupling to a specific SwiftUI view; downstream PRs render each kind
+/// with the appropriate component.
+public struct UsageTile: Identifiable, Equatable, Sendable {
+    public let id: String                   // "anthropic-5h", "codex-weekly"
+    public let title: String                // "Session (5 hour)"
+    public let kind: Kind
+
+    public enum Kind: Equatable, Sendable {
+        /// Progress-bar tile with a 0.0…1.0 fraction and optional reset time.
+        case bar(fraction: Double, resetsAt: Date?, badge: String?)
+
+        /// Balance tile — displayed as a monetary amount plus an optional
+        /// plan label and reset time.
+        case balance(remainingMinorUnits: Int, currency: String, plan: String?, resetsAt: Date?)
+
+        /// Counter tile — used / limit with optional reset time.
+        case counter(used: Int, limit: Int?, resetsAt: Date?)
+
+        /// Freeform text tile — plan info, status warnings, "needs access".
+        case text(status: String, subtitle: String?)
+
+        /// The provider needs a permission the user has not granted.
+        case needsAccess(path: String, guidance: String)
+    }
+
+    public init(id: String, title: String, kind: Kind) {
+        self.id = id
+        self.title = title
+        self.kind = kind
+    }
+}
+
+// MARK: - UsageProvider
+
+/// Every provider (Anthropic, Codex, DeepSeek, Zed, xAI, OpenAI Platform,
+/// Perplexity, Copilot, local-file readers) conforms to this protocol.
+/// Providers are held in `AppDelegate.providers` as a heterogeneous
+/// collection wrapped in `ProviderBox` for SwiftUI observation.
+public protocol UsageProvider: AnyObject, ObservableObject {
+    /// Stable identifier used for feature flags, notification-threshold
+    /// tracking, and log correlation. Examples: "anthropic", "codex",
+    /// "deepseek".
+    var id: String { get }
+
+    /// Display name in the popover section header and Settings toggle.
+    var displayName: String { get }
+
+    /// UserDefaults key that gates activation. Defaulted false. Reading and
+    /// writing this flag is the provider's responsibility.
+    var featureFlagKey: String { get }
+
+    /// True when the user has activated the provider via Settings.
+    var isEnabled: Bool { get }
+
+    /// True when the provider has valid credentials or file access to
+    /// operate. False means the tile should render a first-run onboarding
+    /// state (paste key, grant access, etc.).
+    var isConfigured: Bool { get }
+
+    /// Timestamp of the most recent successful fetch. Nil before the
+    /// first fetch.
+    var lastUpdated: Date? { get }
+
+    /// One-line human-readable error if the last fetch failed. Nil on
+    /// success or when idle.
+    var errorMessage: String? { get }
+
+    /// Tiles this provider currently renders in the popover. Empty when
+    /// the provider is disabled.
+    var tiles: [UsageTile] { get }
+
+    /// Kick off a fetch. Providers are responsible for their own cadence
+    /// (5-minute Anthropic, 60-second Codex, hourly OpenAI Platform,
+    /// etc.). This method is called by the shared timer in AppDelegate
+    /// and may be called manually via the popover's Refresh button.
+    func fetch()
+
+    /// Clear stored state and (optionally) credentials. Called by the
+    /// per-provider "Clear credentials" button in Settings.
+    func clear()
+}
+
+// MARK: - ProviderBox
+
+/// Type-erasing wrapper for SwiftUI. `@ObservedObject var: any UsageProvider`
+/// does not compile in Swift 6 mode (existential + associated type) — the
+/// box forwards `objectWillChange` from the underlying provider so views
+/// can observe it uniformly.
+///
+/// This is one of the load-bearing catches from the pre-PR adversarial
+/// review; the underlying protocol trial compiled fine, but the SwiftUI
+/// observation site did not. `ProviderBox` is the fix.
+@MainActor
+public final class ProviderBox: ObservableObject, Identifiable {
+    public let provider: any UsageProvider
+    // Cached at construction rather than reaching through `provider.id` on
+    // every access — keeps `id` a nonisolated stored property so the
+    // Identifiable conformance is Swift-6-strict-concurrency clean.
+    public nonisolated let id: String
+
+    private var cancellable: AnyCancellable?
+
+    public init<P: UsageProvider>(_ provider: P) {
+        self.provider = provider
+        self.id = provider.id
+        // Forward the underlying provider's change notifications so
+        // SwiftUI redraws views observing this box.
+        self.cancellable = provider.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+    }
+}
+
+// MARK: - CredentialStore
+
+/// Storage abstraction for provider credentials. Two backends:
+/// `DefaultsStore` (for the legacy Anthropic cookie, retained for
+/// backwards compatibility) and `KeychainStore` (for spending credentials
+/// and any new provider going forward).
+///
+/// Concrete Keychain implementation lands in a follow-up PR once at
+/// least one provider actually needs it. PR 2c ships the abstraction so
+/// downstream PRs have a stable target.
+public protocol CredentialStore {
+    func read(_ key: String) -> Data?
+    func write(_ key: String, _ value: Data)
+    func delete(_ key: String)
+}
+
+/// UserDefaults-backed credential store. Used only for the legacy
+/// Anthropic session cookie. New providers must use `KeychainStore`.
+public struct DefaultsStore: CredentialStore {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func read(_ key: String) -> Data? {
+        defaults.data(forKey: key)
+    }
+
+    public func write(_ key: String, _ value: Data) {
+        defaults.set(value, forKey: key)
+    }
+
+    public func delete(_ key: String) {
+        defaults.removeObject(forKey: key)
+    }
+}

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -107,11 +107,16 @@ public struct XAIBalance: Equatable, Sendable {
 /// One day's usage from the management usage endpoint.
 public struct XAIDailyUsage: Equatable, Sendable {
     public var date: String   // ISO date (YYYY-MM-DD) as returned
-    public var usdSpent: Double
+    public var amountSpent: Double
+    /// Currency code if the response carries one (e.g. "USD", "CNY"). Nil
+    /// when the endpoint does not report a currency — the tile then shows a
+    /// neutral amount rather than assuming a "$" symbol.
+    public var currency: String?
 
-    public init(date: String, usdSpent: Double) {
+    public init(date: String, amountSpent: Double, currency: String? = nil) {
         self.date = date
-        self.usdSpent = usdSpent
+        self.amountSpent = amountSpent
+        self.currency = currency
     }
 }
 
@@ -218,19 +223,22 @@ public struct XAIUsageFetcher: Sendable {
             ?? []
         return buckets.compactMap { bucket in
             guard let date = (bucket["date"] as? String) ?? (bucket["day"] as? String) else { return nil }
-            // USD may be a dollar Double, or a cents Int (same unit as the
-            // balance total). Prefer an explicit dollar field; fall back to a
-            // cents field divided by 100. The exact daily-usage field names
-            // are not documented, so this stays tolerant.
-            let usd: Double
-            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"]) {
-                usd = d
+            // The amount may be a dollar Double, or a cents Int (same unit as
+            // the balance total). Prefer an explicit dollar field; fall back
+            // to a cents field divided by 100. The exact daily-usage field
+            // names are undocumented, so this stays tolerant — and it reads a
+            // currency when one is present rather than assuming USD.
+            let amount: Double
+            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"] ?? bucket["amount"]) {
+                amount = d
             } else if let cents = intOrNil(bucket["cents"] ?? bucket["usd_cents"] ?? bucket["amount_cents"]) {
-                usd = Double(cents) / 100.0
+                amount = Double(cents) / 100.0
             } else {
-                usd = 0
+                amount = 0
             }
-            return XAIDailyUsage(date: date, usdSpent: usd)
+            let currency = (bucket["currency"] as? String)
+                ?? ((bucket["amount"] as? [String: Any])?["currency"] as? String)
+            return XAIDailyUsage(date: date, amountSpent: amount, currency: currency)
         }
     }
 

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -1,0 +1,252 @@
+// PR 6-BE — xAI Developer usage fetcher (two-key, two-host).
+//
+// xAI is the first two-credential provider:
+//   - Tier 1 (mandatory): an INFERENCE key (xai-...). Bootstraps team_id and
+//     the model catalogue from api.x.ai. Gives plan info but no spend.
+//   - Tier 2 (optional): a MANAGEMENT key. Reads the prepaid balance and
+//     daily usage from management-api.x.ai. NB the management key also carries
+//     the `xai-` prefix (it is NOT literally `xai-mgmt-`); it is a distinct
+//     key issued from the console's Management Keys section, not
+//     interchangeable with the inference key. Management keys can create /
+//     rotate / delete API keys, so Tier 2 is gated behind an explicit warning
+//     in the UI (PR 6-UI). Both keys live in the Keychain.
+//
+// Feature posture: features.xai.enabled defaults false; nothing registers a
+// store into the live registry yet (tile + two-key sheet land in PR 6-UI).
+//
+// Hosts and auth (both Bearer):
+//   api.x.ai            — inference key: GET /v1/api-key, GET /v1/language-models
+//   management-api.x.ai — management key: GET  /v1/billing/teams/{team}/prepaid/balance
+//                                          POST /v1/billing/teams/{team}/usage
+//
+// The prepaid-balance `total.val` unit and sign convention are the single
+// riskiest interpretation here (the plan flags a live curl check before
+// ship). To keep that correction cheap, ALL unit/sign logic lives in one
+// documented function, `XAIBalance.remainingUSD`, and the parser stores the
+// raw integer verbatim. See the note there.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// Result of GET /v1/api-key. Bootstraps the team id used for the management
+/// endpoints, and carries the ACL list used to describe the plan/permissions.
+public struct XAIApiKeyInfo: Equatable, Sendable {
+    public var teamId: String?
+    public var acls: [String]
+    /// Redacted key label for display (never the raw key).
+    public var redactedKey: String?
+    public var name: String?
+
+    public init(teamId: String? = nil, acls: [String] = [], redactedKey: String? = nil, name: String? = nil) {
+        self.teamId = teamId
+        self.acls = acls
+        self.redactedKey = redactedKey
+        self.name = name
+    }
+}
+
+/// One model from GET /v1/language-models.
+public struct XAIModel: Equatable, Sendable {
+    public var id: String
+    /// Prompt (input) price per token, in the unit the endpoint returns
+    /// (xAI uses 1e-10 USD ticks per token for completion pricing). Stored
+    /// verbatim; conversion is the tile's concern, not the fetcher's.
+    public var promptTokenPrice: Int?
+    public var completionTokenPrice: Int?
+
+    public init(id: String, promptTokenPrice: Int? = nil, completionTokenPrice: Int? = nil) {
+        self.id = id
+        self.promptTokenPrice = promptTokenPrice
+        self.completionTokenPrice = completionTokenPrice
+    }
+}
+
+/// Prepaid balance from the management API.
+public struct XAIBalance: Equatable, Sendable {
+    /// The raw `total.val` integer, stored verbatim. Interpretation (unit +
+    /// sign) is deliberately isolated in `remainingUSD` so it can be
+    /// corrected after a live account check without touching the parser.
+    public var totalValRaw: Int
+    /// Currency code if the endpoint returns one (e.g. "USD").
+    public var currency: String?
+
+    public init(totalValRaw: Int, currency: String? = nil) {
+        self.totalValRaw = totalValRaw
+        self.currency = currency
+    }
+
+    /// Convert the raw `total.val` into remaining USD.
+    ///
+    /// UNIT + SIGN — the one place this interpretation lives, verified against
+    /// xAI's management-API OpenAPI schema (the `total` object is documented
+    /// as "Representation of USD Cents"):
+    ///   - Unit: `total.val` is USD CENTS (1/100 USD). Divide by 100 for
+    ///     dollars. NOTE: this is NOT the 1e-10 "tick" unit — that unit
+    ///     applies to per-token MODEL PRICING (lineItem.unitPrice, documented
+    ///     as 1/1_000_000 USD cents), not to the balance total. Getting this
+    ///     wrong is an 8-order-of-magnitude error, so it is isolated here.
+    ///   - Sign: the ledger convention makes credit-adding events negative and
+    ///     spend positive, so `total.val` is NEGATIVE when prepaid credit
+    ///     remains. Remaining credit in cents is `-val`; a zero or positive
+    ///     value means no prepaid credit left (clamp to 0).
+    /// `val` arrives as a string-encoded int64 on the wire; the parser stores
+    /// it as an Int. A live curl check against a paid account can still
+    /// correct this single function if the account data contradicts the docs.
+
+    /// Per-token model pricing is expressed in 1/1_000_000 USD cents
+    /// (micro-cents). Distinct from the balance unit above.
+    public static let modelPriceMicroCentsPerCent = 1_000_000.0
+
+    public var remainingUSD: Double {
+        // Negative val = remaining credit; clamp non-negative val to 0.
+        max(-Double(totalValRaw), 0) / 100.0
+    }
+}
+
+/// One day's usage from the management usage endpoint.
+public struct XAIDailyUsage: Equatable, Sendable {
+    public var date: String   // ISO date (YYYY-MM-DD) as returned
+    public var usdSpent: Double
+
+    public init(date: String, usdSpent: Double) {
+        self.date = date
+        self.usdSpent = usdSpent
+    }
+}
+
+/// Aggregate snapshot. Tier-1 fields are always present when configured;
+/// Tier-2 fields (balance, daily) are nil until a management key is added.
+public struct XAIUsageSnapshot: Equatable, Sendable {
+    public var apiKeyInfo: XAIApiKeyInfo?
+    public var models: [XAIModel]
+    public var balance: XAIBalance?
+    public var daily: [XAIDailyUsage]
+
+    public init(
+        apiKeyInfo: XAIApiKeyInfo? = nil,
+        models: [XAIModel] = [],
+        balance: XAIBalance? = nil,
+        daily: [XAIDailyUsage] = []
+    ) {
+        self.apiKeyInfo = apiKeyInfo
+        self.models = models
+        self.balance = balance
+        self.daily = daily
+    }
+}
+
+public enum XAIUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct XAIUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain keys for the two credentials.
+    public static let inferenceKeyKeychainKey = "xai.inference_key"
+    public static let managementKeyKeychainKey = "xai.management_key"
+
+    // MARK: Tier 1 parsing
+
+    /// Parse GET /v1/api-key. Tolerant of absent fields; the team_id is the
+    /// one field the management endpoints depend on.
+    public static func parseApiKey(_ data: Data) throws -> XAIApiKeyInfo {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        var info = XAIApiKeyInfo()
+        // xAI has used both "team_id" and "teamId"; accept either.
+        info.teamId = (json["team_id"] as? String) ?? (json["teamId"] as? String)
+        if let acls = json["acls"] as? [String] {
+            info.acls = acls
+        }
+        info.redactedKey = (json["redacted_api_key"] as? String) ?? (json["redactedApiKey"] as? String)
+        info.name = json["name"] as? String
+        return info
+    }
+
+    /// Parse GET /v1/language-models. The models live under a top-level
+    /// "models" or "data" array depending on API version.
+    public static func parseLanguageModels(_ data: Data) throws -> [XAIModel] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        let arr = (json["models"] as? [[String: Any]]) ?? (json["data"] as? [[String: Any]]) ?? []
+        return arr.compactMap { entry in
+            guard let id = entry["id"] as? String else { return nil }
+            return XAIModel(
+                id: id,
+                promptTokenPrice: intOrNil(entry["prompt_text_token_price"] ?? entry["prompt_token_price"]),
+                completionTokenPrice: intOrNil(entry["completion_text_token_price"] ?? entry["completion_token_price"])
+            )
+        }
+    }
+
+    // MARK: Tier 2 parsing
+
+    /// Parse the prepaid balance. Stores `total.val` verbatim; the unit/sign
+    /// interpretation is in XAIBalance.remainingUSD.
+    public static func parseBalance(_ data: Data) throws -> XAIBalance {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        // Balance may be under "total" or at the top level.
+        let total = (json["total"] as? [String: Any]) ?? json
+        guard let val = intOrNil(total["val"]) else {
+            throw XAIUsageParseError.unexpectedShape("balance total.val missing")
+        }
+        let currency = (total["currency"] as? String) ?? (json["currency"] as? String)
+        return XAIBalance(totalValRaw: val, currency: currency)
+    }
+
+    /// Parse the daily-usage response into date/USD points. Tolerant of the
+    /// exact bucket shape: looks for a list of records each carrying a date
+    /// and a USD amount (in ticks or dollars — see note).
+    public static func parseUsage(_ data: Data) throws -> [XAIDailyUsage] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        // The daily buckets live under "usage", "data", or "daily".
+        let buckets = (json["usage"] as? [[String: Any]])
+            ?? (json["data"] as? [[String: Any]])
+            ?? (json["daily"] as? [[String: Any]])
+            ?? []
+        return buckets.compactMap { bucket in
+            guard let date = (bucket["date"] as? String) ?? (bucket["day"] as? String) else { return nil }
+            // USD may be a dollar Double, or a cents Int (same unit as the
+            // balance total). Prefer an explicit dollar field; fall back to a
+            // cents field divided by 100. The exact daily-usage field names
+            // are not documented, so this stays tolerant.
+            let usd: Double
+            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"]) {
+                usd = d
+            } else if let cents = intOrNil(bucket["cents"] ?? bucket["usd_cents"] ?? bucket["amount_cents"]) {
+                usd = Double(cents) / 100.0
+            } else {
+                usd = 0
+            }
+            return XAIDailyUsage(date: date, usdSpent: usd)
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double { return Int(d) }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+
+    private static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s) }
+        return nil
+    }
+}

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -246,13 +246,19 @@ public struct XAIUsageFetcher: Sendable {
 
     private static func intOrNil(_ value: Any?) -> Int? {
         if let i = value as? Int { return i }
-        if let d = value as? Double { return Int(d) }
+        // Int(Double) TRAPS on a non-finite or out-of-range value (a hostile
+        // API can send 1e300 as a valid JSON number). Int(exactly:) on the
+        // rounded value is crash-safe: it returns nil rather than trapping.
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
         if let s = value as? String { return Int(s) }
         return nil
     }
 
     private static func doubleOrNil(_ value: Any?) -> Double? {
-        if let d = value as? Double { return d }
+        if let d = value as? Double { return d.isFinite ? d : nil }
         if let i = value as? Int { return Double(i) }
         if let s = value as? String { return Double(s) }
         return nil

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -148,13 +148,20 @@ public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvide
         }
 
         // Tier 2: rolled-up recent spend as a text tile (the small chart is a
-        // UI concern for PR 6-UI; the backend surfaces the total here).
+        // UI concern for PR 6-UI; the backend surfaces the total here). The
+        // amount is shown with its reported currency code rather than a bare
+        // "$" — the daily-usage shape is undocumented and may bill in CNY, so
+        // we do not assume USD. When no currency is reported, show a neutral
+        // amount with no symbol.
         if !snap.daily.isEmpty {
-            let total = snap.daily.reduce(0.0) { $0 + $1.usdSpent }
+            let total = snap.daily.reduce(0.0) { $0 + $1.amountSpent }
+            let currency = snap.daily.compactMap { $0.currency }.first
+            let status = currency.map { String(format: "%@ %.2f", $0, total) }
+                ?? String(format: "%.2f", total)
             out.append(UsageTile(
                 id: "xai-daily-usd",
                 title: "xAI usage (recent)",
-                kind: .text(status: String(format: "$%.2f", total), subtitle: "\(snap.daily.count) days")
+                kind: .text(status: status, subtitle: "\(snap.daily.count) days")
             ))
         }
 

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -1,0 +1,299 @@
+// PR 6-BE — xAI Developer UsageProvider conformer (dark code, flag off).
+//
+// Fifth provider, and the first two-credential one. Tier 1 (inference key)
+// is required and yields plan info; Tier 2 (management key) is optional and
+// yields the prepaid balance + daily usage. Both keys live in the Keychain.
+//
+// Feature posture: features.xai.enabled defaults false; nothing registers a
+// store into the live registry yet (two-key sheet + tiles land in PR 6-UI).
+//
+// Credentials never reach a log line; only HTTP status codes are logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class XAIUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "xai"
+    public let displayName: String = "xAI (Grok)"
+    public let featureFlagKey: String = "features.xai.enabled"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: XAIUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: XAIUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: XAIUsageTransport = URLSessionXAITransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// Tier 1 — the inference key (required).
+    public var hasInferenceKey: Bool {
+        !(credentials.read(XAIUsageFetcher.inferenceKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    /// Tier 2 — the management key (optional; unlocks balance + history).
+    public var hasManagementKey: Bool {
+        !(credentials.read(XAIUsageFetcher.managementKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    public func saveInferenceKey(_ raw: String) {
+        saveOrClear(raw, key: XAIUsageFetcher.inferenceKeyKeychainKey)
+    }
+
+    public func saveManagementKey(_ raw: String) {
+        saveOrClear(raw, key: XAIUsageFetcher.managementKeyKeychainKey)
+    }
+
+    private func saveOrClear(_ raw: String, key: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(key)
+        } else {
+            credentials.write(key, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    private func readKey(_ key: String) -> String? {
+        guard let data = credentials.read(key), !data.isEmpty else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured once the required Tier-1 inference key is present.
+    public var isConfigured: Bool {
+        hasInferenceKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "xai-needs-key",
+                title: "xAI (Grok)",
+                kind: .needsAccess(
+                    path: "api.x.ai",
+                    guidance: "Paste an xAI API key (xai-…) in Settings. Add a management key too for balance and usage history."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan / permissions tile from the ACLs.
+        if let info = snap.apiKeyInfo {
+            let acls = info.acls.isEmpty ? "API access" : info.acls.joined(separator: ", ")
+            out.append(UsageTile(
+                id: "xai-plan",
+                title: "xAI API key",
+                kind: .text(status: info.redactedKey ?? "Configured", subtitle: acls)
+            ))
+        }
+
+        // Tier 2: prepaid balance. Only when a management key produced one.
+        if let balance = snap.balance {
+            let currency = balance.currency ?? "USD"
+            // remainingUSD encapsulates the tick unit + credit sign; convert
+            // to minor units for the balance tile.
+            let minorUnits = Int((balance.remainingUSD * 100).rounded())
+            out.append(UsageTile(
+                id: "xai-balance",
+                title: "xAI prepaid balance",
+                kind: .balance(remainingMinorUnits: minorUnits, currency: currency, plan: nil, resetsAt: nil)
+            ))
+        }
+
+        // Tier 2: rolled-up recent spend as a text tile (the small chart is a
+        // UI concern for PR 6-UI; the backend surfaces the total here).
+        if !snap.daily.isEmpty {
+            let total = snap.daily.reduce(0.0) { $0 + $1.usdSpent }
+            out.append(UsageTile(
+                id: "xai-daily-usd",
+                title: "xAI usage (recent)",
+                kind: .text(status: String(format: "$%.2f", total), subtitle: "\(snap.daily.count) days")
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// The transport gathers all endpoints and hands back a combined result
+    /// so the store applies one snapshot. Extracted for synchronous testing.
+    public func apply(_ result: XAIUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            self.lastError = "Invalid xAI API key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let inference = readKey(XAIUsageFetcher.inferenceKeyKeychainKey) else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+        // Tier 2 is optional — pass the management key only if present.
+        let management = readKey(XAIUsageFetcher.managementKeyKeychainKey)
+
+        transport.fetchAll(inferenceKey: inference, managementKey: management) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Clears BOTH keys (the user pasted them here) and the state.
+        credentials.delete(XAIUsageFetcher.inferenceKeyKeychainKey)
+        credentials.delete(XAIUsageFetcher.managementKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum XAIUsageResult: Sendable {
+    case success(XAIUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the multi-endpoint fetch. The completion MUST be on the main
+/// queue.
+public protocol XAIUsageTransport: Sendable {
+    func fetchAll(
+        inferenceKey: String,
+        managementKey: String?,
+        completion: @escaping @Sendable (XAIUsageResult) -> Void
+    )
+}
+
+/// Production transport. Chains: api-key -> language-models (Tier 1), then if
+/// a management key + team id are present, prepaid/balance + usage (Tier 2).
+/// Response bodies are never logged; only status codes.
+public struct URLSessionXAITransport: XAIUsageTransport {
+    private let apiHost = "https://api.x.ai"
+    private let mgmtHost = "https://management-api.x.ai"
+
+    public init() {}
+
+    public func fetchAll(
+        inferenceKey: String,
+        managementKey: String?,
+        completion: @escaping @Sendable (XAIUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (XAIUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Tier 1: GET /v1/api-key
+        get("\(apiHost)/v1/api-key", bearer: inferenceKey) { data, status in
+            guard status == 200, let data = data,
+                  let info = try? XAIUsageFetcher.parseApiKey(data) else {
+                deliver(status == 401 || status == 403 ? .unauthorized
+                        : (status == nil ? .networkError : .httpError(status!)))
+                return
+            }
+
+            // Tier 1: GET /v1/language-models. Build the snapshot immutably,
+            // passing accumulated pieces forward into each nested closure
+            // rather than mutating a captured var (which would not be
+            // Sendable-safe across the async completion boundaries).
+            self.get("\(self.apiHost)/v1/language-models", bearer: inferenceKey) { modelData, _ in
+                let models: [XAIModel] = modelData.flatMap { try? XAIUsageFetcher.parseLanguageModels($0) } ?? []
+                let tier1 = XAIUsageSnapshot(apiKeyInfo: info, models: models)
+
+                // Tier 2 (optional): balance + usage, only with a management
+                // key and a bootstrapped team id.
+                guard let mgmt = managementKey, let team = info.teamId else {
+                    deliver(.success(tier1))
+                    return
+                }
+
+                self.get("\(self.mgmtHost)/v1/billing/teams/\(team)/prepaid/balance", bearer: mgmt) { balData, _ in
+                    let balance: XAIBalance? = balData.flatMap { try? XAIUsageFetcher.parseBalance($0) }
+                    self.post("\(self.mgmtHost)/v1/billing/teams/\(team)/usage", bearer: mgmt) { usageData, _ in
+                        let daily: [XAIDailyUsage] = usageData.flatMap { try? XAIUsageFetcher.parseUsage($0) } ?? []
+                        let full = XAIUsageSnapshot(apiKeyInfo: info, models: models, balance: balance, daily: daily)
+                        deliver(.success(full))
+                    }
+                }
+            }
+        }
+    }
+
+    private func get(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        request(urlString, method: "GET", bearer: bearer, body: nil, done: done)
+    }
+
+    private func post(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        // Empty JSON body; the usage endpoint accepts a default date range.
+        request(urlString, method: "POST", bearer: bearer, body: Data("{}".utf8), done: done)
+    }
+
+    private func request(_ urlString: String, method: String, bearer: String, body: Data?, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        guard let url = URL(string: urlString) else { done(nil, nil); return }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+        if let body = body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("xAI API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -49,14 +49,25 @@ public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvide
 
     // MARK: - Credential management
 
+    /// True when a credential is stored, treating an unreadable (locked)
+    /// keychain as "still configured" so a locked screen does not drop the
+    /// provider back to onboarding.
+    private func hasStoredKey(_ keychainKey: String) -> Bool {
+        switch credentials.readResult(keychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
+    }
+
     /// Tier 1 — the inference key (required).
     public var hasInferenceKey: Bool {
-        !(credentials.read(XAIUsageFetcher.inferenceKeyKeychainKey)?.isEmpty ?? true)
+        hasStoredKey(XAIUsageFetcher.inferenceKeyKeychainKey)
     }
 
     /// Tier 2 — the management key (optional; unlocks balance + history).
     public var hasManagementKey: Bool {
-        !(credentials.read(XAIUsageFetcher.managementKeyKeychainKey)?.isEmpty ?? true)
+        hasStoredKey(XAIUsageFetcher.managementKeyKeychainKey)
     }
 
     public func saveInferenceKey(_ raw: String) {
@@ -200,10 +211,9 @@ public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvide
         let management = readKey(XAIUsageFetcher.managementKeyKeychainKey)
 
         transport.fetchAll(inferenceKey: inference, managementKey: management) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 
@@ -272,8 +282,12 @@ public struct URLSessionXAITransport: XAIUsageTransport {
                 let tier1 = XAIUsageSnapshot(apiKeyInfo: info, models: models)
 
                 // Tier 2 (optional): balance + usage, only with a management
-                // key and a bootstrapped team id.
-                guard let mgmt = managementKey, let team = info.teamId else {
+                // key and a bootstrapped team id. The team id comes from the
+                // api-key response (semi-trusted), so it is percent-encoded as
+                // a single path segment — an id containing "/" or "?" cannot
+                // alter the request path.
+                guard let mgmt = managementKey, let rawTeam = info.teamId,
+                      let team = RequestSafety.pathSegment(rawTeam) else {
                     deliver(.success(tier1))
                     return
                 }

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -14,11 +14,18 @@ import SwiftUI
 import Combine
 
 @MainActor
-public final class XAIUsageStore: @preconcurrency UsageProvider {
+public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvider, SecondaryKeyProvider {
 
     public let id: String = "xai"
     public let displayName: String = "xAI (Grok)"
     public let featureFlagKey: String = "features.xai.enabled"
+
+    // PasteKeyProvider — the required Tier-1 inference key.
+    public let keyPlaceholder: String = "xai-… (inference key)"
+    // SecondaryKeyProvider — the optional, spending-capable management key.
+    public let secondaryKeyPlaceholder: String = "xai-… (management key)"
+    public let secondaryKeyLabel: String = "Enable balance + usage history (needs a management key)"
+    public let secondaryKeyWarning: String = "A management key can create, rotate, and delete your xAI API keys. Only paste one if you understand that. It is stored in your Keychain and used only to read billing."
 
     // MARK: Observable state
 
@@ -59,6 +66,14 @@ public final class XAIUsageStore: @preconcurrency UsageProvider {
     public func saveManagementKey(_ raw: String) {
         saveOrClear(raw, key: XAIUsageFetcher.managementKeyKeychainKey)
     }
+
+    // PasteKeyProvider conformance (primary = inference key).
+    public var hasKey: Bool { hasInferenceKey }
+    public func saveKey(_ raw: String) { saveInferenceKey(raw) }
+
+    // SecondaryKeyProvider conformance (secondary = management key).
+    public var hasSecondaryKey: Bool { hasManagementKey }
+    public func saveSecondaryKey(_ raw: String) { saveManagementKey(raw) }
 
     private func saveOrClear(_ raw: String, key: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/app/ZedUsageFetcher.swift
+++ b/app/ZedUsageFetcher.swift
@@ -79,9 +79,16 @@ public struct ZedCredentials: Equatable, Sendable {
     }
 
     /// The Authorization header value Zed's client uses: user id and token
-    /// separated by a single space (not the Bearer scheme).
-    public var authorizationHeaderValue: String {
-        "\(userId) \(accessToken)"
+    /// separated by a single space (not the Bearer scheme). Returns nil if
+    /// either component contains a control character (CR/LF/etc.) that could
+    /// split or inject an HTTP header — the values come from Zed's Keychain
+    /// item, which we do not control, so they are validated before use.
+    public var authorizationHeaderValue: String? {
+        guard let uid = RequestSafety.headerValue(userId),
+              let tok = RequestSafety.headerValue(accessToken) else {
+            return nil
+        }
+        return "\(uid) \(tok)"
     }
 }
 
@@ -161,8 +168,8 @@ public struct ZedUsageFetcher: Sendable {
             var ep = ZedEditPredictionUsage()
             if let used = edit["used"] as? Int {
                 ep.used = used
-            } else if let used = edit["used"] as? Double {
-                ep.used = Int(used)
+            } else if let used = safeInt(edit["used"]) {
+                ep.used = used
             }
             // limit is Zed's UsageLimit enum, whose wire encoding is
             // non-obvious: Limited(N) serializes as the OBJECT {"limited": N},
@@ -190,7 +197,7 @@ public struct ZedUsageFetcher: Sendable {
     public static func parseUsageLimit(_ value: Any?) -> Int? {
         if let obj = value as? [String: Any] {
             if let n = obj["limited"] as? Int { return n }
-            if let n = obj["limited"] as? Double { return Int(n) }
+            if let n = safeInt(obj["limited"]) { return n }
             return nil
         }
         if let s = value as? String {
@@ -199,7 +206,18 @@ public struct ZedUsageFetcher: Sendable {
             return Int(s)
         }
         if let n = value as? Int { return n }
-        if let n = value as? Double { return Int(n) }
+        return safeInt(value)
+    }
+
+    /// Convert a value that may be a Double to Int WITHOUT trapping. Int(d)
+    /// crashes on a non-finite or out-of-range Double, which a hostile API
+    /// could send (e.g. 1e300 as valid JSON); Int(exactly:) returns nil.
+    static func safeInt(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
         return nil
     }
 
@@ -214,7 +232,10 @@ public struct ZedUsageFetcher: Sendable {
             return iso.date(from: s)
         }
         if let epoch = value as? Int { return Date(timeIntervalSince1970: TimeInterval(epoch)) }
-        if let epoch = value as? Double { return Date(timeIntervalSince1970: epoch) }
+        // A non-finite epoch Double would produce an invalid Date; guard it.
+        if let epoch = value as? Double, epoch.isFinite {
+            return Date(timeIntervalSince1970: epoch)
+        }
         return nil
     }
 }

--- a/app/ZedUsageFetcher.swift
+++ b/app/ZedUsageFetcher.swift
@@ -1,0 +1,220 @@
+// PR 5-BE — Zed usage fetcher + reader for Zed's own Keychain credential.
+//
+// Zed differs from every prior provider: it holds no credential of its own.
+// It reads the access token Zed itself already stored in the login Keychain
+// (an internet-password item for server "zed.dev"), then calls Zed's client
+// API for the current user's plan and edit-prediction usage.
+//
+// The first Keychain read triggers a macOS SecurityAgent prompt ("ClaudeUsage
+// Bar wants to use the zed.dev password"); the user must allow it once. We
+// never write to Zed's Keychain item.
+//
+// Auth is unusual: the Authorization header value is "{user_id} {access_token}"
+// — the user id and token separated by a SPACE, NOT the "Bearer" scheme.
+//
+// Data source: GET https://cloud.zed.dev/client/users/me
+//
+// Response shape (the plan object the tiles consume) is built against Zed's
+// open-source client structs. Fields the parser reads:
+//   plan.plan_v3                              String enum (zed_free, zed_pro, …)
+//   plan.usage.edit_predictions.used / .limit Int
+//   plan.subscription_period.ended_at         reset time
+//   plan.has_overdue_invoices                 Bool
+//   plan.is_account_too_young                 Bool
+// Every field is treated as optional and tolerated when absent — this is an
+// undocumented internal API and the shape can drift.
+
+import Foundation
+import Security
+
+// MARK: - Snapshot
+
+/// Edit-prediction usage from `plan.usage.edit_predictions`.
+public struct ZedEditPredictionUsage: Equatable, Sendable {
+    public var used: Int
+    /// Nil means unlimited (Pro plans have no edit-prediction cap).
+    public var limit: Int?
+
+    public init(used: Int = 0, limit: Int? = nil) {
+        self.used = used
+        self.limit = limit
+    }
+}
+
+/// A parsed snapshot of the Zed `users/me` plan block.
+public struct ZedUsageSnapshot: Equatable, Sendable {
+    /// Raw plan identifier, e.g. "zed_free", "zed_pro". Rendered via a
+    /// friendly label in the tile.
+    public var planV3: String?
+    public var editPredictions: ZedEditPredictionUsage?
+    /// End of the current subscription/usage period — the edit-prediction
+    /// reset time.
+    public var periodEndsAt: Date?
+    public var hasOverdueInvoices: Bool
+    public var isAccountTooYoung: Bool
+
+    public init(
+        planV3: String? = nil,
+        editPredictions: ZedEditPredictionUsage? = nil,
+        periodEndsAt: Date? = nil,
+        hasOverdueInvoices: Bool = false,
+        isAccountTooYoung: Bool = false
+    ) {
+        self.planV3 = planV3
+        self.editPredictions = editPredictions
+        self.periodEndsAt = periodEndsAt
+        self.hasOverdueInvoices = hasOverdueInvoices
+        self.isAccountTooYoung = isAccountTooYoung
+    }
+}
+
+/// Credentials read from Zed's own Keychain item.
+public struct ZedCredentials: Equatable, Sendable {
+    public let userId: String
+    public let accessToken: String
+
+    public init(userId: String, accessToken: String) {
+        self.userId = userId
+        self.accessToken = accessToken
+    }
+
+    /// The Authorization header value Zed's client uses: user id and token
+    /// separated by a single space (not the Bearer scheme).
+    public var authorizationHeaderValue: String {
+        "\(userId) \(accessToken)"
+    }
+}
+
+public enum ZedUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+public enum ZedAuthError: Error, Equatable {
+    /// No zed.dev item in the Keychain (Zed not logged in, or the user
+    /// denied the SecurityAgent prompt).
+    case keychainItemMissing
+    /// The item exists but lacks a usable account (user id) or token.
+    case keychainItemIncomplete
+}
+
+// MARK: - Fetcher
+
+public struct ZedUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: Keychain read (Zed's own internet-password item)
+
+    /// Read Zed's access token from the login Keychain. Zed stores it as an
+    /// internet-password item for server "zed.dev"; the item's account is the
+    /// user id and its data is the access token. We match by server only
+    /// (the user id is not known in advance) and read both attributes back.
+    ///
+    /// The `server` is injectable so tests do not touch the real Keychain.
+    public static func readCredentials(server: String = "zed.dev") throws -> ZedCredentials {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassInternetPassword,
+            kSecAttrServer as String: server,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else {
+            throw ZedAuthError.keychainItemMissing
+        }
+        guard let dict = item as? [String: Any],
+              let account = dict[kSecAttrAccount as String] as? String, !account.isEmpty,
+              let data = dict[kSecValueData as String] as? Data,
+              let token = String(data: data, encoding: .utf8), !token.isEmpty
+        else {
+            throw ZedAuthError.keychainItemIncomplete
+        }
+        return ZedCredentials(userId: account, accessToken: token)
+    }
+
+    // MARK: Pure parsing (this is what the fixtures hit)
+
+    /// Parse the JSON body of `users/me`. The plan block may be nested under
+    /// a top-level "plan" key, or the whole response may itself be the plan
+    /// block depending on Zed's version — accept both by preferring a "plan"
+    /// object when present and falling back to the top level.
+    public static func parse(_ data: Data) throws -> ZedUsageSnapshot {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ZedUsageParseError.invalidJSON
+        }
+
+        // Prefer an explicit "plan" object; otherwise treat the root as the
+        // plan block (tolerant of both documented layouts).
+        let plan = (root["plan"] as? [String: Any]) ?? root
+
+        var snap = ZedUsageSnapshot()
+        snap.planV3 = plan["plan_v3"] as? String
+        snap.hasOverdueInvoices = (plan["has_overdue_invoices"] as? Bool) ?? false
+        snap.isAccountTooYoung = (plan["is_account_too_young"] as? Bool) ?? false
+
+        if let usage = plan["usage"] as? [String: Any],
+           let edit = usage["edit_predictions"] as? [String: Any] {
+            var ep = ZedEditPredictionUsage()
+            if let used = edit["used"] as? Int {
+                ep.used = used
+            } else if let used = edit["used"] as? Double {
+                ep.used = Int(used)
+            }
+            // limit is Zed's UsageLimit enum, whose wire encoding is
+            // non-obvious: Limited(N) serializes as the OBJECT {"limited": N},
+            // and Unlimited serializes as the bare STRING "unlimited". A plain
+            // integer is NOT what this endpoint returns. Map both: an object
+            // with "limited" -> that number; "unlimited" (or absent) -> nil
+            // (unlimited). Accept a bare number too, defensively.
+            ep.limit = Self.parseUsageLimit(edit["limit"])
+            snap.editPredictions = ep
+        }
+
+        if let period = plan["subscription_period"] as? [String: Any] {
+            snap.periodEndsAt = parseDate(period["ended_at"])
+        }
+
+        return snap
+    }
+
+    /// Parse Zed's `UsageLimit` from `usage.edit_predictions.limit`. The wire
+    /// encoding is a serde externally-tagged enum:
+    ///   Limited(i32) -> {"limited": N}   (an OBJECT)
+    ///   Unlimited    -> "unlimited"       (a bare STRING)
+    /// Returns the numeric cap for Limited, or nil for Unlimited / absent /
+    /// unrecognised. Also accepts a bare number defensively.
+    public static func parseUsageLimit(_ value: Any?) -> Int? {
+        if let obj = value as? [String: Any] {
+            if let n = obj["limited"] as? Int { return n }
+            if let n = obj["limited"] as? Double { return Int(n) }
+            return nil
+        }
+        if let s = value as? String {
+            // "unlimited" -> nil. A numeric string (header-style) -> its value.
+            if s == "unlimited" { return nil }
+            return Int(s)
+        }
+        if let n = value as? Int { return n }
+        if let n = value as? Double { return Int(n) }
+        return nil
+    }
+
+    /// Parse a reset timestamp that may be an ISO-8601 string or a Unix epoch
+    /// integer, tolerating both since the wire format is not guaranteed.
+    private static func parseDate(_ value: Any?) -> Date? {
+        if let s = value as? String {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            return iso.date(from: s)
+        }
+        if let epoch = value as? Int { return Date(timeIntervalSince1970: TimeInterval(epoch)) }
+        if let epoch = value as? Double { return Date(timeIntervalSince1970: epoch) }
+        return nil
+    }
+}

--- a/app/ZedUsageStore.swift
+++ b/app/ZedUsageStore.swift
@@ -184,10 +184,9 @@ public final class ZedUsageStore: @preconcurrency UsageProvider {
         }
 
         transport.fetchUser(credentials: creds) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 
@@ -227,17 +226,26 @@ public struct URLSessionZedTransport: ZedUsageTransport {
         credentials: ZedCredentials,
         completion: @escaping @Sendable (ZedUsageResult) -> Void
     ) {
+        let deliver: @Sendable (ZedUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Zed's client auth: "{user_id} {access_token}", NOT Bearer. The value
+        // is validated (no control chars) before use; if the Keychain item is
+        // malformed, treat it as unauthorized rather than sending a header
+        // that could be split/injected.
+        guard let authValue = credentials.authorizationHeaderValue else {
+            deliver(.unauthorized)
+            return
+        }
+
         var request = URLRequest(url: usersMeURL)
         request.httpMethod = "GET"
-        // Zed's client auth: "{user_id} {access_token}", NOT Bearer.
-        request.setValue(credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+        request.setValue(authValue, forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
 
         URLSession.shared.dataTask(with: request) { data, response, error in
-            let deliver: (ZedUsageResult) -> Void = { result in
-                DispatchQueue.main.async { completion(result) }
-            }
 
             if error != nil {
                 deliver(.networkError)

--- a/app/ZedUsageStore.swift
+++ b/app/ZedUsageStore.swift
@@ -1,0 +1,267 @@
+// PR 5-BE — Zed UsageProvider conformer (dark code, feature-flag off).
+//
+// Fourth provider. Zed is the read-from-the-app's-own-Keychain template: it
+// holds no credential of its own, reading the token Zed itself stored. The
+// first read triggers a macOS SecurityAgent prompt the user must allow once.
+//
+// Feature posture: features.zed.enabled defaults false; nothing registers a
+// ZedUsageStore into the live registry yet (tile + toggle land in PR 5-UI).
+//
+// Auth: the Authorization header is "{user_id} {access_token}" — space
+// delimited, NOT Bearer. Credentials never reach a log line; only the HTTP
+// status code is logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class ZedUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "zed"
+    public let displayName: String = "Zed"
+    public let featureFlagKey: String = "features.zed.enabled"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: ZedUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// True when Zed's Keychain item was readable on the last attempt.
+    @Published public private(set) var hasKeychainAccess: Bool = false
+
+    private let transport: ZedUsageTransport
+    private let defaults: UserDefaults
+    // Injected so tests can supply credentials without touching the real
+    // Keychain. Production reads Zed's own item.
+    private let credentialReader: @Sendable () -> Result<ZedCredentials, Error>
+
+    public init(
+        transport: ZedUsageTransport = URLSessionZedTransport(),
+        defaults: UserDefaults = .standard,
+        credentialReader: @escaping @Sendable () -> Result<ZedCredentials, Error> = {
+            Result { try ZedUsageFetcher.readCredentials() }
+        }
+    ) {
+        self.transport = transport
+        self.defaults = defaults
+        self.credentialReader = credentialReader
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured means Zed's Keychain item is readable. Probing it here
+    /// would trigger the SecurityAgent prompt on every access, so we report
+    /// the result of the last fetch attempt instead of probing eagerly.
+    public var isConfigured: Bool {
+        hasKeychainAccess
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Before the first successful Keychain read, show an onboarding card
+        // explaining the one-time prompt.
+        if !hasKeychainAccess && snapshot == nil {
+            return [UsageTile(
+                id: "zed-needs-access",
+                title: "Zed",
+                kind: .needsAccess(
+                    path: "zed.dev (Keychain)",
+                    guidance: "Sign in to Zed, then click Refresh. macOS will ask once to let this app read Zed's saved login."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan tile — friendly label for the raw plan_v3 identifier.
+        out.append(UsageTile(
+            id: "zed-plan",
+            title: "Zed plan",
+            kind: .text(status: Self.planLabel(snap.planV3), subtitle: nil)
+        ))
+
+        // Edit-predictions counter. Shown when the plan reports the bucket.
+        if let ep = snap.editPredictions {
+            out.append(UsageTile(
+                id: "zed-edit-predictions",
+                title: "Edit predictions",
+                kind: .counter(
+                    used: ep.used,
+                    limit: ep.limit,          // nil renders as unlimited
+                    resetsAt: snap.periodEndsAt
+                )
+            ))
+        }
+
+        // Billing warning — only when there is a problem, so healthy accounts
+        // stay uncluttered.
+        if snap.hasOverdueInvoices || snap.isAccountTooYoung {
+            let reason = snap.hasOverdueInvoices
+                ? "You have overdue invoices on your Zed account."
+                : "Your Zed account is too new for this feature yet."
+            out.append(UsageTile(
+                id: "zed-billing",
+                title: "Zed billing",
+                kind: .text(status: "Attention needed", subtitle: reason)
+            ))
+        }
+
+        return out
+    }
+
+    /// Map Zed's raw plan_v3 identifier to a human label. Unknown values are
+    /// shown verbatim so a new plan tier is never hidden.
+    public static func planLabel(_ planV3: String?) -> String {
+        // plan_v3 values from Zed source (cloud_api_types Plan enum):
+        // zed_free, zed_pro, zed_pro_trial, zed_business, zed_vip, zed_student.
+        switch planV3 {
+        case "zed_free":       return "Free"
+        case "zed_pro":        return "Pro"
+        case "zed_pro_trial":  return "Pro (trial)"
+        case "zed_business":   return "Business"
+        case "zed_vip":        return "VIP"
+        case "zed_student":    return "Student"
+        case .some(let other): return other
+        case .none:            return "Unknown"
+        }
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: ZedUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try ZedUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+            } catch {
+                self.lastError = "Could not parse Zed usage"
+            }
+        case .unauthorized:
+            // Zed's stored token was rejected — the user must re-sign-in to
+            // Zed itself; we cannot refresh it.
+            self.lastError = "Zed session expired — sign in again in Zed."
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        let creds: ZedCredentials
+        switch credentialReader() {
+        case .success(let c):
+            creds = c
+            hasKeychainAccess = true
+        case .failure:
+            // Keychain item missing or the prompt was denied. Leave the
+            // onboarding card up; not an error state.
+            hasKeychainAccess = false
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchUser(credentials: creds) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Zed's Keychain item belongs to Zed, not to us — never delete it.
+        // Clearing only drops our in-memory state and the access flag.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        hasKeychainAccess = false
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum ZedUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+public protocol ZedUsageTransport: Sendable {
+    func fetchUser(
+        credentials: ZedCredentials,
+        completion: @escaping @Sendable (ZedUsageResult) -> Void
+    )
+}
+
+/// Production transport. Note the space-delimited Authorization value.
+public struct URLSessionZedTransport: ZedUsageTransport {
+    private let usersMeURL = URL(string: "https://cloud.zed.dev/client/users/me")!
+
+    public init() {}
+
+    public func fetchUser(
+        credentials: ZedCredentials,
+        completion: @escaping @Sendable (ZedUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: usersMeURL)
+        request.httpMethod = "GET"
+        // Zed's client auth: "{user_id} {access_token}", NOT Bearer.
+        request.setValue(credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (ZedUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("Zed users/me API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401, 403:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/build.sh
+++ b/app/build.sh
@@ -57,6 +57,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     OpenAIUsageStore.swift \
     PerplexityUsageFetcher.swift \
     PerplexityUsageStore.swift \
+    CopilotUsageFetcher.swift \
+    CopilotUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -81,6 +83,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     OpenAIUsageStore.swift \
     PerplexityUsageFetcher.swift \
     PerplexityUsageStore.swift \
+    CopilotUsageFetcher.swift \
+    CopilotUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -51,6 +51,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     DeepSeekUsageStore.swift \
     ZedUsageFetcher.swift \
     ZedUsageStore.swift \
+    XAIUsageFetcher.swift \
+    XAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -69,6 +71,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     DeepSeekUsageStore.swift \
     ZedUsageFetcher.swift \
     ZedUsageStore.swift \
+    XAIUsageFetcher.swift \
+    XAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -47,6 +47,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     AnthropicUsageStore.swift \
     CodexUsageFetcher.swift \
     CodexUsageStore.swift \
+    DeepSeekUsageFetcher.swift \
+    DeepSeekUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -61,6 +63,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     AnthropicUsageStore.swift \
     CodexUsageFetcher.swift \
     CodexUsageStore.swift \
+    DeepSeekUsageFetcher.swift \
+    DeepSeekUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -53,6 +53,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ZedUsageStore.swift \
     XAIUsageFetcher.swift \
     XAIUsageStore.swift \
+    OpenAIUsageFetcher.swift \
+    OpenAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -73,6 +75,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ZedUsageStore.swift \
     XAIUsageFetcher.swift \
     XAIUsageStore.swift \
+    OpenAIUsageFetcher.swift \
+    OpenAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -34,15 +34,19 @@ if [ -f "ClaudeUsageBar.icns" ]; then
 fi
 
 # Compile the Swift app for arm64.
-# Log.swift and AnthropicUsageFetcher.swift are compiled alongside
-# ClaudeUsageBar.swift; see the header comments in those files for why
-# the SwiftPM library boundary is drawn where it is.
+# Log.swift, AnthropicUsageFetcher.swift, UsageProvider.swift, and the
+# Codex provider files are compiled alongside ClaudeUsageBar.swift; see the
+# header comments in those files for why the SwiftPM library boundary is
+# drawn where it is. AnthropicUsageStore stays app-only (needs UsageManager);
+# the Codex files are also in the SwiftPM library for unit testing.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
     UsageProvider.swift \
     AnthropicUsageStore.swift \
+    CodexUsageFetcher.swift \
+    CodexUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -55,6 +59,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     AnthropicUsageFetcher.swift \
     UsageProvider.swift \
     AnthropicUsageStore.swift \
+    CodexUsageFetcher.swift \
+    CodexUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -34,11 +34,13 @@ if [ -f "ClaudeUsageBar.icns" ]; then
 fi
 
 # Compile the Swift app for arm64.
-# Log.swift is compiled alongside ClaudeUsageBar.swift; see the header
-# comment in Log.swift for why the split exists.
+# Log.swift and AnthropicUsageFetcher.swift are compiled alongside
+# ClaudeUsageBar.swift; see the header comments in those files for why
+# the SwiftPM library boundary is drawn where it is.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
+    AnthropicUsageFetcher.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -48,6 +50,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
     Log.swift \
+    AnthropicUsageFetcher.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -49,6 +49,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     CodexUsageStore.swift \
     DeepSeekUsageFetcher.swift \
     DeepSeekUsageStore.swift \
+    ZedUsageFetcher.swift \
+    ZedUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -65,6 +67,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     CodexUsageStore.swift \
     DeepSeekUsageFetcher.swift \
     DeepSeekUsageStore.swift \
+    ZedUsageFetcher.swift \
+    ZedUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -33,9 +33,12 @@ if [ -f "ClaudeUsageBar.icns" ]; then
     /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile ClaudeUsageBar" "$APP_PATH/Contents/Info.plist"
 fi
 
-# Compile the Swift app for arm64
+# Compile the Swift app for arm64.
+# Log.swift is compiled alongside ClaudeUsageBar.swift; see the header
+# comment in Log.swift for why the split exists.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
+    Log.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -44,6 +47,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 # Compile for x86_64 (Intel)
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
+    Log.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -41,6 +41,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
+    UsageProvider.swift \
+    AnthropicUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -51,6 +53,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
+    UsageProvider.swift \
+    AnthropicUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -55,6 +55,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     XAIUsageStore.swift \
     OpenAIUsageFetcher.swift \
     OpenAIUsageStore.swift \
+    PerplexityUsageFetcher.swift \
+    PerplexityUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -77,6 +79,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     XAIUsageStore.swift \
     OpenAIUsageFetcher.swift \
     OpenAIUsageStore.swift \
+    PerplexityUsageFetcher.swift \
+    PerplexityUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/create_dmg.sh
+++ b/app/create_dmg.sh
@@ -70,13 +70,18 @@ echo "✅ DMG created: ${DMG_NAME}.dmg"
 DEVELOPER_ID="Developer ID Application: Linkko Technology Pte Ltd (Q467HQ5432)"
 NOTARY_PROFILE="claudeusagebar-notary"
 
-# Sign the DMG itself (the .app inside was already signed in build.sh)
+# Sign the DMG itself (the .app inside was already signed in build.sh).
+# Fail-fast on sign failure: an unsigned DMG will be rejected by notarytool
+# anyway, and the 5–15 min wait for that rejection is worse than aborting
+# here with a clear error. Matches the fail-fast policy in build.sh.
 echo ""
 echo "🔏 Signing DMG with Developer ID..."
 if codesign --force --sign "$DEVELOPER_ID" "${DMG_NAME}.dmg" 2>/dev/null; then
     echo "✅ DMG signed"
 else
-    echo "⚠️  DMG signing failed (continuing — Gatekeeper may reject)"
+    echo "❌ DMG signing failed — aborting before notarization." >&2
+    echo "   Fix the underlying cause (often: cert missing / expired, or stale xattrs on the DMG) and re-run." >&2
+    exit 1
 fi
 
 # Notarize


### PR DESCRIPTION
## Summary

Ships **GitHub Copilot AI-Credit backend** as opt-in dark code — the seventh non-Anthropic provider. Reads GitHub's public REST billing endpoint `GET /users/{username}/settings/billing/ai_credit/usage` via a user-supplied fine-grained PAT with the `Plan (Read)` permission, and surfaces month-to-date USD spend plus the top-three SKU breakdown.

Wire shapes were verified up-front by a 117-agent research workflow (98 confirmed / 7 plausible / 6 refuted claims), driven off the mid-2026 canonical OpenAPI spec (`github/rest-api-description`, API version `2026-03-10`) and the rendered docs at `docs.github.com/en/rest/billing/usage`. **All parser field names below are quoted from those primary sources — no invented shapes.**

`features.copilot.enabled` defaults false; nothing is registered into the live provider registry (tile + Settings PAT-paste sheet land in PR 9-UI).

## Wire contract shipped

**Auth chain (two hops):**
1. `GET https://api.github.com/user` — discover the authenticated user's `login`. Result is cached in the Keychain (`copilot.github_login`) so subsequent fetches skip this hop until the credential rotates.
2. `GET https://api.github.com/users/{login}/settings/billing/ai_credit/usage` — the real billing report.

Headers for both:
```
Authorization: Bearer <fine-grained PAT>
Accept: application/vnd.github+json
X-GitHub-Api-Version: 2026-03-10
User-Agent: ClaudeUsageBar/<version>
```

**Response shape (parsed verbatim from OpenAPI):**
```json
{
  "timePeriod": { "year": 2026, "month": 7 },
  "user": "monalisa",
  "usageItems": [{
    "product": "Copilot AI Credits",
    "sku": "AI Credit",
    "model": "GPT-5",
    "unitType": "ai-credits",
    "pricePerUnit": 0.01,
    "grossQuantity": 100, "grossAmount": 1.0,
    "discountQuantity": 0, "discountAmount": 0.0,
    "netQuantity": 100, "netAmount": 1.0
  }]
}
```

Month-to-date USD spend = `sum(usageItems[].netAmount)`. **1 AI Credit = $0.01 USD** (fixed).

**Documented distinct signal:** `200` with `usageItems: []` means the user's Copilot seat is billed through an org/enterprise — the personal endpoint carries no data. Rendered as a dedicated `.text` tile ("No personal usage — If your Copilot seat is managed by an organisation..."), not as an empty section.

## Explicitly out of scope (deferred)

- **OAuth Device Flow** to a bespoke ClaudeUsageBar GitHub App. Requires a registered `client_id` and a device-code UX (browser hand-off + polling). PAT paste is the shipped path — same UX as DeepSeek / xAI / OpenAI. Device Flow can ship as a follow-up if demand appears.
- **Internal `copilot_internal/*` endpoints.** Undocumented, GitHub explicitly does not permit third-party clients to hit them, abuse detection has suspended accounts using them (github/copilot-language-server-release #10), and their `client_id` gating (`Iv1.b507a08c87ecfe98` — VS Code Copilot's own OAuth App id) would reject a bespoke ClaudeUsageBar token anyway.

## Adversarial review

Three-cycle self+Codex review (`gpt-5.5`, medium effort). **14 findings** across two rounds; every one addressed. Round 3 clean.

**Round 1 (9 findings):**
1. **HIGH** In-flight fetch results not tied to the PAT that launched them → introduced a monotonically-increasing `fetchGeneration` counter; every credential change bumps it; every fetch snapshots the counter into its completion closure; stale completions drop on the floor.
2. **HIGH** `clear()` didn't cancel in-flight fetches → same generation counter also invalidates completions after clear.
3. **HIGH** Per-SKU quantity render trapped on hostile oversize Doubles (`Int(1e300)`) → guarded with `Int(exactly:)` and a `%.2f` fallback.
4. **MEDIUM** `/user` 403 responses were always classified as auth failures — GitHub can rate-limit the discovery hop → added parity `x-ratelimit-remaining` disambiguation.
5. **MEDIUM** No recovery path for a stale cached login → on `httpError(404)` with a cached login, drop the cache so the next fetch re-discovers via `/user`.
6. **MEDIUM** `parseUsage` collapsed a missing `usageItems` field into the documented `[]` "org-billed" signal → made `usageItems` REQUIRED per OpenAPI; missing throws `unexpectedShape`.
7. **LOW** `month: 13` would roll over `Calendar.date(from:)` to January of the next year and label the wrong billing period → validated `1..12` before Date construction.
8. **LOW** Rate-limit hint ignored `x-ratelimit-reset` → shared `retryAfterSeconds` helper falls back to it.
9. **LOW** Missing test coverage for the fixes → added 5 new tests.

**Round 2 (5 findings):**
1. **MEDIUM** Two overlapping same-credential fetches shared the same `launchedAt` → every `fetch()` now bumps the generation BEFORE snapshotting, so overlapping fetches serialise cleanly.
2. **MEDIUM** Stale cached-login invalidation was too narrow (only 404) → broadened to also drop on 401 with a cached login present.
3. **MEDIUM** 403-with-`Retry-After` for GitHub's secondary/abuse rate limit was classified as auth → introduced `isRateLimitResponse` helper that checks `x-ratelimit-remaining == 0` OR `Retry-After` present.
4. **LOW** `retryAfterSeconds` only parsed integer seconds, not HTTP-date `Retry-After` per RFC 9110 → added RFC 1123 date parsing.
5. **LOW** Race tests could pass without proving the delayed completion actually fired → tightened tests to assert on a `completed` flag before checking store state.

## Hardening patterns followed (chk1-audit lineage)

- **KeychainStore** for both the PAT and the cached login.
- **`CredentialReadResult` + `.unavailable`** — locked keychain still counts as configured; fetch surfaces "Keychain locked or unavailable. Unlock your Mac ..." rather than silently no-op'ing.
- **`Task { @MainActor [weak self] }`** async hop — never `assumeIsolated`.
- **`RequestSafety.headerValue` + `pathSegment`** — auth header and the `{login}` path segment both rejected/encoded so a compromised value cannot inject.
- **`Int(exactly:)` + `isFinite`** guards on every Double → Int conversion.
- **Private URLSession** built from `URLSessionConfiguration.ephemeral` — same chk1-audit pattern as Perplexity: in-memory cookie storage isolated from the shared session, bounded 15s / 30s timeouts.
- **Logging** — only `Log.info("GitHub Copilot billing API response", .count(status))`. Zero credential / URL / body interpolation. CI SECRETS alternation extended with `patToken`, `safeToken`, `authHeader`.

## Test coverage

**+70 new checks, 588 / 588 total pass** (+13 from Codex round-1 + round-2 fixes on top of the initial 57).

**Fetcher parsers (9):** happy-path AI Credit + Premium Request line items; org-billed empty (`usageItems: []`); fractional `grossQuantity`; invalid JSON; item missing `product`/`sku` is dropped; forward-compatible extra field; login discovery happy path; missing login throws; missing `usageItems` throws (not org-billed).

**Snapshot helpers (2):** `netAmountMTDUSD` clamps negative sums to zero; `itemsBySkuDescending` sorts by net amount.

**Store (24):** off by default; needsAccess without PAT; locked keychain still configured; saveKey stores + clear deletes both PAT and cached login; new PAT invalidates cached login; locked-keychain fetch surfaces unlock message; org-billed empty tile emitted separately; MTD tile carries USD cents + period label; per-SKU tiles capped at 3, ordered by net descending; 401 clears stale snapshot + surfaces re-generate-PAT; rate-limited emits retry hint; 5xx distinct from generic HTTP N; fetch() discovers login and persists it; background-queue success reaches @Published; PasteKeyProvider conformance with default "Key" noun; saveKey during in-flight fetch discards stale completion (Codex #1); clear() during in-flight fetch discards stale completion (Codex #2); hostile oversize `netQuantity` doesn't trap (Codex #3); hostile `month=13` falls back to bare year (Codex #7); missing `usageItems` throws (Codex #6); 403 with `Retry-After` classified as rate-limited (Codex round-2 #3); HTTP-date `Retry-After` parsed (Codex round-2 #4); stale cached login on billing 401 dropped (Codex round-2 #2); plus the sanity-check helpers.

## Non-breaking guarantee

- [x] Feature flag defaults off (`features.copilot.enabled`).
- [x] No provider registration in `AppDelegate` — dark code until PR 9-UI.
- [x] Existing six non-Anthropic providers still behave identically.
- [x] All 6 CI static-grep guards pass (5 existing + 1 property-path from PR #63); `SECRETS` alternation extended with new Copilot-specific variable names (`patToken`, `safeToken`, `authHeader`).
- [x] Both build paths compile clean: `swift build` + `app/build.sh` (arm64 + x86_64).
- [x] `swift run TestRunner` — 588 / 588 pass.
- [x] Swift 5 language mode preserved until PR 16.

## Files touched

- `app/CopilotUsageFetcher.swift` (new, 275 lines) — Sendable parsers + numeric coercion.
- `app/CopilotUsageStore.swift` (new, 556 lines) — `@MainActor UsageProvider` + private URLSession transport + generation-guarded fetch.
- `Package.swift` — appended two new sources to the library allow-list.
- `app/build.sh` — appended two new sources to both `swiftc` invocations (arm64 + x86_64).
- `.github/workflows/ci.yml` — extended the credential-leak `SECRETS` alternation with Copilot-specific variable names.
- `Tests/TestRunner/main.swift` — 70 new checks.
