### PR TITLE
feat: Windsurf + Cursor backends (feature-flagged off)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,33 @@ jobs:
             exit 1
           fi
 
+      - name: Reject any logging sink that interpolates a provider credential
+        run: |
+          # Defence-in-depth for every provider's spending credentials, not
+          # just the original Anthropic cookie. Any logging/printing sink
+          # (NSLog, print, debugPrint, dump, os_log, Logger) that interpolates
+          # a credential-bearing variable is forbidden. Credentials must only
+          # ever reach the Authorization header and the Keychain; only status
+          # codes go through Log.info(.count). New providers add new secret
+          # variable names — extend this alternation when you add one.
+          SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
+          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|bearer|accessKey|secret|[Cc]ookie)'
+          # Match a sink call that contains a Swift string-interpolation of a
+          # secret variable: SINK( ... \( ...secret... ) ... )
+          if grep -rnE "${SINKS}\([^)]*\\\\\\(.*${SECRETS}" -- app/ ; then
+            echo "::error::A logging sink interpolates a credential variable. Credentials must never be logged; only Log.info(.count(status)) is allowed." >&2
+            exit 1
+          fi
+
+      - name: Reject logging of full request URLs (may embed org/team/project ids)
+        run: |
+          # A full URL string can embed an org id, team id, or project id.
+          # Log an endpoint name + status code instead, never the URL.
+          if grep -rnE '(NSLog|print|Log\.(info|debug))\([^)]*\\\(urlString' -- app/ ; then
+            echo "::error::Logging a full request URL is forbidden (can embed identifiers). Log an endpoint label + status instead." >&2
+            exit 1
+          fi
+
       - name: Reject NSLog on cookie/response tokens
         run: |
           # Broader net: any NSLog that mentions cookie or response bodies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,12 @@ jobs:
           # codes go through Log.info(.count). New providers add new secret
           # variable names — extend this alternation when you add one.
           SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
-          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|bearer|accessKey|secret|[Cc]ookie)'
+          # `cookieValue`, `cookieHeader`, `perplexityCookie`, `pplxCookie`
+          # cover the Perplexity session-cookie variable names introduced in
+          # PR 8-BE. `[Cc]ookie` already catches most, but the more specific
+          # names guard against a rename that would still slip past the
+          # generic alternation.
+          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|cookieValue|cookieHeader|perplexityCookie|pplxCookie|bearer|accessKey|secret|[Cc]ookie)'
           # Match a sink call that contains a Swift string-interpolation of a
           # secret variable: SINK( ... \( ...secret... ) ... )
           if grep -rnE "${SINKS}\([^)]*\\\\\\(.*${SECRETS}" -- app/ ; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,21 @@ jobs:
             exit 1
           fi
 
+      - name: Reject logging sinks that interpolate a credential property path
+        run: |
+          # chk1 Risk #3: the identifier-name-based SECRETS alternation
+          # above matches `\(cookieValue)` but NOT `\(cookie.token)` — a
+          # tuple / struct property path. A future maintainer who logged
+          # `Log.info("...\(cookie.token)")` would silently bypass the
+          # guard. This step catches the property-path pattern for a set
+          # of names a maintainer might reasonably reach for.
+          SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
+          FIELDS='\.(token|cookie|session|secret|key|jwt|bearer)'
+          if grep -rnE "${SINKS}\([^)]*\\\\\\([^)]*${FIELDS}" -- app/ ; then
+            echo "::error::A logging sink interpolates a credential property path (e.g. cookie.token). Log a status code via Log.info(.count) instead." >&2
+            exit 1
+          fi
+
       - name: Reject logging of full request URLs (may embed org/team/project ids)
         run: |
           # A full URL string can embed an org id, team id, or project id.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,39 @@ jobs:
             exit 1
           fi
 
-  # build-and-test: enabled when PR 2a lands Package.swift.
-  # See EXPANSION_PLAN.md § Phase 0 for the sequencing.
+  build-and-test:
+    name: Build and test (macOS)
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          swift --version
+          xcodebuild -version || true
+
+      - name: swift build
+        run: swift build --configuration debug
+
+      - name: swift run TestRunner
+        # Assertion-based test runner (see Package.swift header for why
+        # we do not use XCTest / Testing here — CLT compatibility).
+        run: swift run TestRunner --configuration debug
+
+      - name: Legacy build.sh compile smoke (unsigned)
+        run: |
+          # Verify the swiftc-driven build.sh path still compiles cleanly.
+          # We patch out the hardcoded Developer ID for CI, but leave the
+          # local file on disk unchanged.
+          sed 's|Developer ID Application: Linkko Technology Pte Ltd (Q467HQ5432)|-|' \
+            app/build.sh > /tmp/build-ci.sh
+          chmod +x /tmp/build-ci.sh
+          cd app
+          # Skip the launch step at the end of build.sh — CI has no display.
+          sed -i.bak '/^open "\$APP_PATH"/d' /tmp/build-ci.sh
+          /tmp/build-ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,11 @@ jobs:
           # PR 8-BE. `[Cc]ookie` already catches most, but the more specific
           # names guard against a rename that would still slip past the
           # generic alternation.
-          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|cookieValue|cookieHeader|perplexityCookie|pplxCookie|bearer|accessKey|secret|[Cc]ookie)'
+          # `pat`, `patToken`, `authHeader` cover the GitHub Copilot
+          # variable names introduced in PR 9-BE (fine-grained PAT →
+          # Authorization: Bearer …). `safeToken` is the RequestSafety-
+          # sanitised local; still refuse to log it.
+          SECRETS='(adminKey|inferenceKey|managementKey|apiKey|accessToken|refreshKey|refreshToken|idToken|sessionCookie|sessionCookieInput|cookieValue|cookieHeader|perplexityCookie|pplxCookie|patToken|safeToken|authHeader|bearer|accessKey|secret|[Cc]ookie)'
           # Match a sink call that contains a Swift string-interpolation of a
           # secret variable: SINK( ... \( ...secret... ) ... )
           if grep -rnE "${SINKS}\([^)]*\\\\\\(.*${SECRETS}" -- app/ ; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,23 @@ jobs:
 
       - name: Reject logging sinks that interpolate a credential property path
         run: |
-          # chk1 Risk #3: the identifier-name-based SECRETS alternation
-          # above matches `\(cookieValue)` but NOT `\(cookie.token)` — a
-          # tuple / struct property path. A future maintainer who logged
+          # chk1 Risk #3 + chk1-fix Codex round-4 finding #2: the
+          # identifier-name-based SECRETS alternation above matches
+          # `\(cookieValue)` but NOT `\(cookie.token)` — a tuple / struct
+          # property path. A future maintainer who logged
           # `Log.info("...\(cookie.token)")` would silently bypass the
-          # guard. This step catches the property-path pattern for a set
-          # of names a maintainer might reasonably reach for.
+          # guard. This step catches the pattern only when the OWNER of
+          # the property path is itself credential-flavoured (cookie,
+          # session, auth, credential, secret, token), so legitimate
+          # non-secret uses like `event.key` (keyboard events) and
+          # `parser.token` (parser results) do NOT false-positive.
           SINKS='(NSLog|print|debugPrint|dump|os_log|Logger|Log\.debug|Log\.info)'
-          FIELDS='\.(token|cookie|session|secret|key|jwt|bearer)'
-          if grep -rnE "${SINKS}\([^)]*\\\\\\([^)]*${FIELDS}" -- app/ ; then
-            echo "::error::A logging sink interpolates a credential property path (e.g. cookie.token). Log a status code via Log.info(.count) instead." >&2
+          # Owner must smell like a credential-holder before we care
+          # about the property path.
+          OWNER='(cookie|session|auth|credential|secret|creds|apiKey|adminKey|inferenceKey|managementKey|bearer|jwt|token)'
+          PROP='\.(token|value|raw|secret|key|jwt|bearer|cookie)'
+          if grep -rnE "${SINKS}\([^)]*\\\\\\([^)]*${OWNER}${PROP}" -- app/ ; then
+            echo "::error::A logging sink interpolates a credential property path (e.g. cookie.token, session.value). Log a status code via Log.info(.count) instead." >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+# .github/workflows/ci.yml
+#
+# Runs on every pull_request and every push to main.
+# No secrets, no write scopes, no pull_request_target — pwn-request-safe
+# per docs.github.com/en/actions/security-for-github-actions/security-guides.
+#
+# Two jobs:
+#   1. static-grep — cheap static checks that catch known regression patterns.
+#      This is where the PR-1 "belt-and-braces" credential-leak defence lives:
+#      any PR that reintroduces the deleted "📦 Response:" pattern or raw-
+#      interpolation NSLog calls with sessionCookie / orgId / responseString
+#      fails CI before human review.
+#   2. build-and-test — (placeholder) once PR 2a lands Package.swift, this
+#      job will run `swift build` + `swift test`. Kept as a no-op comment
+#      here so PR 1's diff does not silently add a runner cost. PR 2a wires
+#      the real build/test steps in.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-grep:
+    name: Static credential-leak guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Reject reintroduced "📦 Response:" pattern
+        run: |
+          if grep -rn '📦 Response' -- app/ ; then
+            echo "::error::Forbidden pattern '📦 Response' found. Deleted in PR 1 to prevent full-response-body logging; do not reintroduce." >&2
+            exit 1
+          fi
+
+      - name: Reject raw NSLog interpolation of credentials
+        run: |
+          # NSLog calls that interpolate sessionCookie, orgId, responseString,
+          # or sessionCookieInput are forbidden. Use Log.info(.count) /
+          # Log.info(.identifier) / Log.info(.sensitive) instead.
+          if grep -rnE 'NSLog\([^)]*\\\(.*(sessionCookie|orgId|responseString|sessionCookieInput)' -- app/ ; then
+            echo "::error::Raw NSLog interpolation of credentials found. Use Log.info(.count/.identifier/.sensitive) instead." >&2
+            exit 1
+          fi
+
+      - name: Reject NSLog on cookie/response tokens
+        run: |
+          # Broader net: any NSLog that mentions cookie or response bodies.
+          # If a diagnostic genuinely needs it, use Log.debug (DEBUG-only).
+          if grep -rnE 'NSLog\([^)]*(cookie|Cookie|Response body|responseString)' -- app/ ; then
+            echo "::error::NSLog referencing cookie/response found. Move to Log.debug (DEBUG-only) or delete." >&2
+            exit 1
+          fi
+
+  # build-and-test: enabled when PR 2a lands Package.swift.
+  # See EXPANSION_PLAN.md § Phase 0 for the sequencing.

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ internal-docs/
 EXPANSION_PLAN.md
 docs/tracking-issue-draft.md
 .pr-bodies/
+
+# SwiftPM build artefacts
+.build/
+Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,10 @@ docs/tracking-issue-draft.md
 # SwiftPM build artefacts
 .build/
 Package.resolved
+
+# Local credentials and probe transcripts — NEVER pushed to any remote
+secrets/
+.env
+.env.*
+probes/
+*.probe.json

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ temp/
 # Internal docs (kept local, not on public GitHub)
 NOTIFICATIONS.md
 internal-docs/
+
+# Contributor-side planning artefacts — never pushed to any remote
+EXPANSION_PLAN.md
+docs/tracking-issue-draft.md
+.pr-bodies/

--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,10 @@ let package = Package(
                 "ZedUsageStore.swift",
                 // xAI Developer: two-key, two-host; same rationale.
                 "XAIUsageFetcher.swift",
-                "XAIUsageStore.swift"
+                "XAIUsageStore.swift",
+                // OpenAI Platform: admin key, three org endpoints.
+                "OpenAIUsageFetcher.swift",
+                "OpenAIUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -88,7 +88,12 @@ let package = Package(
                 // GitHub Copilot: fine-grained PAT in Keychain, /user +
                 // /users/{login}/settings/billing/ai_credit/usage.
                 "CopilotUsageFetcher.swift",
-                "CopilotUsageStore.swift"
+                "CopilotUsageStore.swift",
+                // PR 10a — shared local-provider infrastructure. Consumed
+                // by every local-file provider from PR 10b onward.
+                "FileWatcher.swift",
+                "SQLiteReader.swift",
+                "TCCState.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -93,7 +93,14 @@ let package = Package(
                 // by every local-file provider from PR 10b onward.
                 "FileWatcher.swift",
                 "SQLiteReader.swift",
-                "TCCState.swift"
+                "TCCState.swift",
+                // PR 10b-BE — Claude Code local JSONL reader. Fetcher +
+                // embedded pricing snapshot in the library so the
+                // TestRunner can exercise dedupe and cost math directly.
+                // Store lands in a follow-up file (same PR).
+                "ClaudeCodePricing.swift",
+                "ClaudeCodeUsageFetcher.swift",
+                "ClaudeCodeUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,16 @@ let package = Package(
                 "LICENSE",
                 "README.md"
             ],
-            sources: ["Log.swift", "AnthropicUsageFetcher.swift"]
+            sources: [
+                "Log.swift",
+                "AnthropicUsageFetcher.swift",
+                "UsageProvider.swift"
+                // AnthropicUsageStore.swift depends on UsageManager
+                // (defined in ClaudeUsageBar.swift), so it stays in the
+                // app-bundle compile only, not in the SwiftPM library
+                // target. Tests for AnthropicUsageStore live in the
+                // full-app integration tier, not this unit-test layer.
+            ]
         ),
         .executableTarget(
             name: "TestRunner",

--- a/Package.swift
+++ b/Package.swift
@@ -102,9 +102,13 @@ let package = Package(
                 "ClaudeCodeUsageFetcher.swift",
                 "ClaudeCodeUsageStore.swift",
                 // PR 10c-BE — Cline local ui_messages.json reader.
-                // Reuses ClaudeCodeUsageFetcher.safeInt/readJsonlLines
-                // + ClaudeCodeUsageRecord.saturatingAdd + TCCProbe /
-                // FileWatcher / LocalProviderAccessGuide from PR #66.
+                // Reuses ClaudeCodeUsageFetcher.safeInt +
+                // ClaudeCodeUsageRecord.saturatingAdd + TCCProbe +
+                // LocalProviderAccessGuide from PRs #66/#67. Does NOT
+                // reuse ClaudeCodeUsageFetcher.readJsonlLines — Cline's
+                // ui_messages.json is a single JSON array (not JSONL),
+                // so the fetcher has its own `readClineUiMessagesText`
+                // helper with a 64 MB streaming reader.
                 "ClineUsageFetcher.swift",
                 "ClineUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager

--- a/Package.swift
+++ b/Package.swift
@@ -110,7 +110,17 @@ let package = Package(
                 // so the fetcher has its own `readClineUiMessagesText`
                 // helper with a 64 MB streaming reader.
                 "ClineUsageFetcher.swift",
-                "ClineUsageStore.swift"
+                "ClineUsageStore.swift",
+                // PR 11-BE — Windsurf + Cursor providers. Both read a
+                // VS Code-style state.vscdb through SQLiteReader (PR #66)
+                // and reuse TCCProbe + LocalProviderAccessGuide.
+                // Cursor also performs live fetches to cursor.com and
+                // api2.cursor.sh (via a Sendable transport protocol,
+                // stubbed in tests).
+                "WindsurfUsageFetcher.swift",
+                "WindsurfUsageStore.swift",
+                "CursorUsageFetcher.swift",
+                "CursorUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,10 @@ let package = Package(
                 "DeepSeekUsageStore.swift",
                 // Zed: reads Zed's own Keychain item; same rationale.
                 "ZedUsageFetcher.swift",
-                "ZedUsageStore.swift"
+                "ZedUsageStore.swift",
+                // xAI Developer: two-key, two-host; same rationale.
+                "XAIUsageFetcher.swift",
+                "XAIUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,11 @@ let package = Package(
                 "OpenAIUsageStore.swift",
                 // Perplexity: cookie in Keychain, three cookie-authed endpoints.
                 "PerplexityUsageFetcher.swift",
-                "PerplexityUsageStore.swift"
+                "PerplexityUsageStore.swift",
+                // GitHub Copilot: fine-grained PAT in Keychain, /user +
+                // /users/{login}/settings/billing/ai_credit/usage.
+                "CopilotUsageFetcher.swift",
+                "CopilotUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -51,12 +51,24 @@ let package = Package(
                 "ClaudeUsageBar.icns",
                 "claudeusagebar-icon.png",
                 "LICENSE",
-                "README.md"
+                "README.md",
+                // AnthropicUsageStore depends on UsageManager (defined in the
+                // excluded @main entry point) so it is compiled only by
+                // build.sh into the .app bundle, not by the SwiftPM library.
+                // Listed here explicitly to silence the "unhandled file"
+                // warning now that `sources` is an allow-list.
+                "AnthropicUsageStore.swift"
             ],
             sources: [
                 "Log.swift",
                 "AnthropicUsageFetcher.swift",
-                "UsageProvider.swift"
+                "UsageProvider.swift",
+                "CodexUsageFetcher.swift",
+                // CodexUsageStore has no dependency on UsageManager (unlike
+                // AnthropicUsageStore), so it lives in the library where the
+                // TestRunner can exercise its tile-generation and 401 →
+                // session-expired mapping through a stubbed transport.
+                "CodexUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
                 "LICENSE",
                 "README.md"
             ],
-            sources: ["Log.swift"]
+            sources: ["Log.swift", "AnthropicUsageFetcher.swift"]
         ),
         .executableTarget(
             name: "TestRunner",

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,10 @@ let package = Package(
                 "XAIUsageStore.swift",
                 // OpenAI Platform: admin key, three org endpoints.
                 "OpenAIUsageFetcher.swift",
-                "OpenAIUsageStore.swift"
+                "OpenAIUsageStore.swift",
+                // Perplexity: cookie in Keychain, three cookie-authed endpoints.
+                "PerplexityUsageFetcher.swift",
+                "PerplexityUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,64 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest — additive scaffolding for testing, not a replacement for
+// the existing build path.
+//
+// `swift build` compiles the library against the source under `app/`.
+// `swift run TestRunner` executes the assertion-based test runner (works
+// with Command Line Tools alone; does not require Xcode.app / XCTest).
+// The legacy `app/build.sh` continues to work unchanged — it invokes
+// `swiftc` directly and produces the `.app` bundle. Both paths compile
+// the same file.
+//
+// Why not XCTest / swift-testing?
+// Both XCTest and Apple's newer `Testing` framework require `xctest`
+// tooling that ships with Xcode.app, not with the Command Line Tools
+// package. To keep the test path usable on any Mac with CLT installed,
+// PR 2a ships a plain executable test runner. PR 16 (Swift 6 migration)
+// or a maintainer decision to install Xcode.app can promote this to
+// XCTest later without changing the test bodies (they're just
+// assertion functions).
+//
+// PR 2a intentionally introduces only the scaffold plus one first test
+// suite (LogValueTests). PR 2b lands the AnthropicUsageFetcher extraction
+// and its fixture-based tests using the same runner.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClaudeUsageBar",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .library(name: "ClaudeUsageBar", targets: ["ClaudeUsageBar"]),
+        .executable(name: "TestRunner", targets: ["TestRunner"])
+    ],
+    targets: [
+        .target(
+            name: "ClaudeUsageBar",
+            path: "app",
+            exclude: [
+                // The @main app entry point (compiled by build.sh into the
+                // .app bundle, but not part of the SwiftPM library which is
+                // only for testable extracted types).
+                "ClaudeUsageBar.swift",
+                // Assets, build scripts, and docs — not compiled sources.
+                "build.sh",
+                "create_dmg.sh",
+                "make_app_icon.sh",
+                "Info.plist",
+                "ClaudeUsageBar.icns",
+                "claudeusagebar-icon.png",
+                "LICENSE",
+                "README.md"
+            ],
+            sources: ["Log.swift"]
+        ),
+        .executableTarget(
+            name: "TestRunner",
+            dependencies: ["ClaudeUsageBar"],
+            path: "Tests/TestRunner"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,11 @@ let package = Package(
                 // AnthropicUsageStore), so it lives in the library where the
                 // TestRunner can exercise its tile-generation and 401 →
                 // session-expired mapping through a stubbed transport.
-                "CodexUsageStore.swift"
+                "CodexUsageStore.swift",
+                // DeepSeek: fetcher + KeychainStore + store. Same rationale —
+                // no UsageManager dependency, so it is unit-testable here.
+                "DeepSeekUsageFetcher.swift",
+                "DeepSeekUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -100,7 +100,13 @@ let package = Package(
                 // Store lands in a follow-up file (same PR).
                 "ClaudeCodePricing.swift",
                 "ClaudeCodeUsageFetcher.swift",
-                "ClaudeCodeUsageStore.swift"
+                "ClaudeCodeUsageStore.swift",
+                // PR 10c-BE — Cline local ui_messages.json reader.
+                // Reuses ClaudeCodeUsageFetcher.safeInt/readJsonlLines
+                // + ClaudeCodeUsageRecord.saturatingAdd + TCCProbe /
+                // FileWatcher / LocalProviderAccessGuide from PR #66.
+                "ClineUsageFetcher.swift",
+                "ClineUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,10 @@ let package = Package(
                 // DeepSeek: fetcher + KeychainStore + store. Same rationale —
                 // no UsageManager dependency, so it is unit-testable here.
                 "DeepSeekUsageFetcher.swift",
-                "DeepSeekUsageStore.swift"
+                "DeepSeekUsageStore.swift",
+                // Zed: reads Zed's own Keychain item; same rationale.
+                "ZedUsageFetcher.swift",
+                "ZedUsageStore.swift"
                 // AnthropicUsageStore.swift depends on UsageManager
                 // (defined in ClaudeUsageBar.swift), so it stays in the
                 // app-bundle compile only, not in the SwiftPM library

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -711,6 +711,49 @@ run("ProviderCopy: Perplexity help names the cookie, Keychain, and multiple past
     expect(help?.contains("name=value") == true || help?.contains("Cookie header") == true || help?.contains("bare") == true)
 }
 
+run("ProviderCopy: Copilot help names the exact PAT path (PR 9-UI)") {
+    // The help text MUST tell the user which token type, which permission,
+    // and where to configure it — otherwise they'll paste a classic PAT
+    // with broader scopes (bad) or won't find the Plan permission at all.
+    let help = ProviderCopy.help(for: "copilot")
+    expect(help != nil)
+    // Token type discriminator: the fine-grained prefix.
+    expect(help?.contains("github_pat_") == true)
+    expect(help?.contains("fine-grained") == true || help?.contains("Fine-grained") == true)
+    // Permission location + name + level — all three must be present, and
+    // must NOT drift to e.g. "Repository permissions" or "Plan: Write".
+    expect(help?.contains("Account permissions") == true)
+    expect(help?.contains("Plan: Read-only") == true)
+    // Codex round-1 finding #3: lock in the resource-owner requirement.
+    // Without this the user can pick an org resource owner and hit the
+    // "Account permissions cannot be selected on org PATs" error.
+    expect(help?.contains("resource owner") == true)
+    expect(help?.contains("your own account") == true)
+    // Codex round-1 finding #2: overage vs allowance disclosure.
+    expect(help?.contains("overage") == true || help?.contains("allowance") == true)
+    // Storage location.
+    expect(help?.contains("Keychain") == true)
+}
+
+run("ProviderCopy: Copilot disclosure warns about classic PATs, expiry, and non-revocation on clear (PR 9-UI)") {
+    // Classic PATs with broad scopes CAN spend money on GitHub; the
+    // disclosure must warn against pasting one, recommend an expiry so a
+    // leak becomes bounded, AND (Codex round-1 finding #1) clarify that
+    // clearing this app's Keychain entry does NOT revoke the token on
+    // GitHub — the user must visit github.com to revoke.
+    let disc = ProviderCopy.disclosure(for: "copilot")
+    expect(disc != nil)
+    expect(disc?.contains("fine-grained") == true)
+    expect(disc?.contains("classic") == true || disc?.contains("Classic") == true)
+    expect(disc?.contains("expiry") == true || disc?.contains("expire") == true)
+    // Explicit call-out that broader scopes can spend money.
+    expect(disc?.contains("broader") == true)
+    expect(disc?.contains("spend") == true || disc?.contains("money") == true)
+    // Codex round-1 finding #1: revocation clarity.
+    expect(disc?.contains("revoke") == true)
+    expect(disc?.contains("github.com") == true)
+}
+
 run("ProviderCopy: Perplexity disclosure warns about undocumented API and cookie power") {
     // The Perplexity cookie is a spending credential AND the endpoints are
     // undocumented — both facts must be surfaced before the user pastes.

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -5712,6 +5712,33 @@ run("Cline.parse: malformed text-field JSON is counted, not fatal") {
     expectEqual(mal, 1)
 }
 
+run("Cline.parse: non-object elements in the array are skipped, valid records survive (chk1 Bug #1)") {
+    // chk1 Bug #1 regression guard: casting the top-level to
+    // `[[String: Any]]` used to be all-or-nothing — a single `null` /
+    // string / number in the array collapsed the whole file to
+    // unreadable. Per-element guarding must skip the bad element and
+    // keep the good ones.
+    let goodMsg: [String: Any] = [
+        "type": "say",
+        "say": "api_req_started",
+        "ts": 1_784_000_400_000,
+        "text": "{\"tokensIn\":10,\"cost\":0.001}",
+    ]
+    let mixed: [Any] = [goodMsg, NSNull(), "just a string", 42, goodMsg]
+    let data = try! JSONSerialization.data(withJSONObject: mixed, options: [])
+    let contents = String(data: data, encoding: .utf8)!
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(
+        uiMessages: contents,
+        sourceFile: "/tmp/mixed-elements.json",
+        malformedRecordCount: &mal
+    )
+    expect(recs != nil)
+    // Two valid records must survive around the null / string / int noise.
+    expectEqual(recs?.count, 2)
+    expectEqual(mal, 0)
+}
+
 run("Cline.parse: non-array top-level content returns nil") {
     var mal = 0
     let recs = ClineUsageFetcher.parse(uiMessages: "{\"not\":\"an array\"}", sourceFile: "/tmp/wrong.json", malformedRecordCount: &mal)

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -3843,6 +3843,1445 @@ run("LocalProviderAccessGuide: full-disk-access deep link URL is well-formed") {
     expect(url.absoluteString.contains("Privacy_AllFiles"))
 }
 
+// MARK: - ClaudeCodePathResolver (PR 10b-BE)
+
+run("ClaudeCodePathResolver: CLAUDE_CONFIG_DIR wins over XDG_CONFIG_HOME and HOME") {
+    let env = ClaudeCodePathResolver.Environment(
+        claudeConfigDir: "/opt/claude",
+        xdgConfigHome: "/other/xdg",
+        homeDirectoryPath: "/Users/tester"
+    )
+    let root = ClaudeCodePathResolver.resolveScanRoot(env)
+    expectEqual(root, "/opt/claude/projects")
+}
+
+run("ClaudeCodePathResolver: XDG_CONFIG_HOME used when CLAUDE_CONFIG_DIR is nil") {
+    let env = ClaudeCodePathResolver.Environment(
+        claudeConfigDir: nil,
+        xdgConfigHome: "/xdg/config",
+        homeDirectoryPath: "/Users/tester"
+    )
+    let root = ClaudeCodePathResolver.resolveScanRoot(env)
+    expectEqual(root, "/xdg/config/claude/projects")
+}
+
+run("ClaudeCodePathResolver: XDG_CONFIG_HOME used when CLAUDE_CONFIG_DIR is empty string") {
+    let env = ClaudeCodePathResolver.Environment(
+        claudeConfigDir: "",
+        xdgConfigHome: "/xdg/config",
+        homeDirectoryPath: "/Users/tester"
+    )
+    let root = ClaudeCodePathResolver.resolveScanRoot(env)
+    expectEqual(root, "/xdg/config/claude/projects")
+}
+
+run("ClaudeCodePathResolver: falls back to ~/.claude/projects when no env vars set") {
+    let env = ClaudeCodePathResolver.Environment(
+        claudeConfigDir: nil,
+        xdgConfigHome: nil,
+        homeDirectoryPath: "/Users/tester"
+    )
+    let root = ClaudeCodePathResolver.resolveScanRoot(env)
+    expectEqual(root, "/Users/tester/.claude/projects")
+}
+
+run("ClaudeCodePathResolver: returns nil when home is empty AND no env vars") {
+    let env = ClaudeCodePathResolver.Environment(
+        claudeConfigDir: nil,
+        xdgConfigHome: nil,
+        homeDirectoryPath: ""
+    )
+    let root = ClaudeCodePathResolver.resolveScanRoot(env)
+    expect(root == nil)
+}
+
+run("ClaudeCodePathResolver: Environment.current() populates without crash") {
+    // Not asserting specific values — only that the call succeeds and
+    // returns a non-nil scan root on macOS (HOME is always set).
+    let env = ClaudeCodePathResolver.Environment.current()
+    let root = ClaudeCodePathResolver.resolveScanRoot(env)
+    expect(root != nil)
+}
+
+// MARK: - ClaudeCodePricing (PR 10b-BE)
+
+run("ClaudeCodePricing: default snapshot covers Opus/Sonnet/Haiku 4-family models") {
+    let p = ClaudeCodePricing.default
+    // Every model Claude Code emits should have a row. Spot-check the
+    // ones the app is most likely to see today.
+    expect(p.hasModel("claude-opus-4-7"))
+    expect(p.hasModel("claude-opus-4-5-20251101"))
+    expect(p.hasModel("claude-sonnet-4-5-20250929"))
+    expect(p.hasModel("claude-haiku-4-5-20251001"))
+    // Legacy 3-family entries that older sessions may still reference.
+    // Codex round-4 finding #1: Claude 3.5 Sonnet/Haiku are added
+    // manually because LiteLLM lacks Anthropic-direct rows for them.
+    expect(p.hasModel("claude-3-5-sonnet-20241022"))
+    expect(p.hasModel("claude-3-5-sonnet-20240620"))
+    expect(p.hasModel("claude-3-5-haiku-20241022"))
+    expect(p.hasModel("claude-3-opus-20240229"))
+}
+
+run("ClaudeCodePricing: unknown model returns zero cost and isUnknownModel=true") {
+    let p = ClaudeCodePricing.default
+    let (cost, unknown) = p.cost(
+        model: "claude-non-existent-9-9",
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 0,
+        cacheReadTokens: 0
+    )
+    expectEqual(cost, 0.0)
+    expect(unknown)
+}
+
+run("ClaudeCodePricing: opus-4-7 base rates match LiteLLM snapshot") {
+    let p = ClaudeCodePricing.default
+    // Opus 4.7: input 5e-6, output 25e-6. 1000 input + 1000 output.
+    let (cost, unknown) = p.cost(
+        model: "claude-opus-4-7",
+        inputTokens: 1000,
+        outputTokens: 1000,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 0,
+        cacheReadTokens: 0
+    )
+    expect(!unknown)
+    // 1000 * 5e-6 + 1000 * 25e-6 = 0.005 + 0.025 = 0.030
+    expect(abs(cost - 0.030) < 1e-9)
+}
+
+run("ClaudeCodePricing: opus-4-7 1h cache-creation uses above_1hr rate") {
+    let p = ClaudeCodePricing.default
+    // Opus 4.7: cache_creation_input_token_cost=6.25e-6, above_1hr=1e-5.
+    // 1000 * 5m + 1000 * 1h  = 6.25e-3 + 1e-2 = 0.01625.
+    let (cost, _) = p.cost(
+        model: "claude-opus-4-7",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 1000,
+        cacheCreation1hTokens: 1000,
+        cacheReadTokens: 0
+    )
+    expect(abs(cost - 0.01625) < 1e-9)
+}
+
+run("ClaudeCodePricing: sonnet-4-5 above 200k switches to tiered rate") {
+    let p = ClaudeCodePricing.default
+    // Sonnet 4.5: input 3e-6 → 6e-6 above 200k. Send a record that
+    // itself crosses the threshold (input alone > 200k).
+    let (cost, _) = p.cost(
+        model: "claude-sonnet-4-5",
+        inputTokens: 250_000,
+        outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 0,
+        cacheReadTokens: 0
+    )
+    // 250_000 * 6e-6 = 1.5
+    expect(abs(cost - 1.5) < 1e-9)
+}
+
+run("ClaudeCodePricing: sonnet-4-5 below 200k stays on base rate") {
+    let p = ClaudeCodePricing.default
+    let (cost, _) = p.cost(
+        model: "claude-sonnet-4-5",
+        inputTokens: 100_000,
+        outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 0,
+        cacheReadTokens: 0
+    )
+    // 100_000 * 3e-6 = 0.3
+    expect(abs(cost - 0.3) < 1e-9)
+}
+
+run("ClaudeCodePricing: sonnet-4-5 above 200k with 1h cache uses double-tier rate") {
+    let p = ClaudeCodePricing.default
+    // Sonnet 4.5: cache_creation_input_token_cost_above_1hr_above_200k_tokens = 1.2e-05
+    // Threshold: input+cache*Tokens > 200k. Cross with cache_creation_1h.
+    let (cost, _) = p.cost(
+        model: "claude-sonnet-4-5",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 250_000,
+        cacheReadTokens: 0
+    )
+    // 250_000 * 1.2e-5 = 3.0
+    expect(abs(cost - 3.0) < 1e-9)
+}
+
+run("ClaudeCodePricing: model with no above_1hr key falls back to base cache_creation rate") {
+    let p = ClaudeCodePricing.default
+    // claude-4-opus-20250514 has cache_creation_input_token_cost only,
+    // no above_1hr variant. 1h cache tokens should price at the same
+    // rate as 5m.
+    let (cost, _) = p.cost(
+        model: "claude-4-opus-20250514",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 1000,
+        cacheReadTokens: 0
+    )
+    // 1000 * 1.875e-5 = 0.01875
+    expect(abs(cost - 0.01875) < 1e-9)
+}
+
+run("ClaudeCodePricing: cost with zero tokens returns zero for a known model") {
+    let p = ClaudeCodePricing.default
+    let (cost, unknown) = p.cost(
+        model: "claude-opus-4-7",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 0, cacheCreation1hTokens: 0, cacheReadTokens: 0
+    )
+    expectEqual(cost, 0.0)
+    expect(!unknown)
+}
+
+run("ClaudeCodePricing: snapshotDate is present and non-empty") {
+    expect(!ClaudeCodePricing.snapshotDate.isEmpty)
+}
+
+run("ClaudeCodePricing: every row's 1h cache rate >= 5m cache rate (when both present)") {
+    // Codex round-2 invariant test: a longer TTL cache should never be
+    // cheaper than a shorter TTL cache. Any row failing this either
+    // has a LiteLLM data bug (fix by removing the wrong field) or
+    // needs a snapshot refresh.
+    for (model, row) in ClaudeCodePricing.embeddedRates {
+        if let fiveM = row["cache_creation_input_token_cost"],
+           let oneH = row["cache_creation_input_token_cost_above_1hr"] {
+            expect(oneH >= fiveM, "\(model): 1h rate \(oneH) < 5m rate \(fiveM)")
+        }
+    }
+}
+
+run("ClaudeCodePricing: every row's cache-read rate < input rate (cache-hit discount)") {
+    // Anthropic bills cache-reads at a small fraction of the input rate.
+    // A row where they invert would be a data bug.
+    for (model, row) in ClaudeCodePricing.embeddedRates {
+        if let read = row["cache_read_input_token_cost"],
+           let input = row["input_cost_per_token"] {
+            expect(read < input, "\(model): cache_read \(read) >= input \(input)")
+        }
+    }
+}
+
+run("ClaudeCodePricing: every row's above_200k rate >= base rate for the same category") {
+    // The tiered rate is a premium, never a discount.
+    let pairs = [
+        ("input_cost_per_token", "input_cost_per_token_above_200k_tokens"),
+        ("output_cost_per_token", "output_cost_per_token_above_200k_tokens"),
+        ("cache_creation_input_token_cost", "cache_creation_input_token_cost_above_200k_tokens"),
+        ("cache_read_input_token_cost", "cache_read_input_token_cost_above_200k_tokens"),
+    ]
+    for (model, row) in ClaudeCodePricing.embeddedRates {
+        for (baseKey, tierKey) in pairs {
+            if let base = row[baseKey], let tier = row[tierKey] {
+                expect(tier >= base, "\(model): \(tierKey)=\(tier) < \(baseKey)=\(base)")
+            }
+        }
+    }
+}
+
+// MARK: - ClaudeCodeUsageFetcher — safeInt (PR 10b-BE)
+
+run("ClaudeCodeUsageFetcher.safeInt: Int passes through, negatives clamp to 0") {
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(42), 42)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(0), 0)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(-5), 0)
+}
+
+run("ClaudeCodeUsageFetcher.safeInt: Double rounds, non-finite goes to 0") {
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(1.7), 2)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(1.4), 1)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(-3.2), 0)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(Double.nan), 0)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(Double.infinity), 0)
+}
+
+run("ClaudeCodeUsageFetcher.safeInt: hostile large Double clamps to Int.max, not a trap") {
+    // A 1e300 in Int(exactly:) would trap — safeInt clamps.
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(1e300), Int.max)
+}
+
+run("ClaudeCodeUsageFetcher.safeInt: stringified numerics parse") {
+    expectEqual(ClaudeCodeUsageFetcher.safeInt("100"), 100)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt("-2"), 0)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt("garbage"), 0)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(nil), 0)
+}
+
+run("ClaudeCodeUsageFetcher.safeInt: Double at Int.max boundary clamps to Int.max without trap") {
+    // Codex round-1 finding #2: Double(Int.max) rounds to 2^63 (unrepresentable
+    // as Int64), so Int(rounded) would trap. Int(exactly:) guards it.
+    let boundary = Double(Int.max)
+    expectEqual(ClaudeCodeUsageFetcher.safeInt(boundary), Int.max)
+}
+
+// MARK: - ClaudeCodeUsageRecord.saturatingAdd (Codex round-1 finding #3/4)
+
+run("ClaudeCodeUsageRecord.saturatingAdd: normal addition") {
+    expectEqual(ClaudeCodeUsageRecord.saturatingAdd(100, 50), 150)
+    expectEqual(ClaudeCodeUsageRecord.saturatingAdd(0, 0), 0)
+}
+
+run("ClaudeCodeUsageRecord.saturatingAdd: overflow clamps to Int.max") {
+    expectEqual(ClaudeCodeUsageRecord.saturatingAdd(Int.max, 1), Int.max)
+    expectEqual(ClaudeCodeUsageRecord.saturatingAdd(Int.max, Int.max), Int.max)
+}
+
+run("ClaudeCodeUsageRecord.saturatingAdd: negative inputs coerced to 0") {
+    expectEqual(ClaudeCodeUsageRecord.saturatingAdd(-100, 200), 200)
+    expectEqual(ClaudeCodeUsageRecord.saturatingAdd(-100, -200), 0)
+}
+
+run("Snapshot.tokens(in:) — saturating sum does not wrap to negative") {
+    // Two records with Int.max tokens each. Naive Int64 &+= would wrap
+    // to -2; the saturating helper clamps to Int.max.
+    let now = Date()
+    let a = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: Int.max, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 0,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.0
+    )
+    let b = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: Int.max, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 0,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.0
+    )
+    let snap = ClaudeCodeUsageSnapshot(records: [a, b])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    expectEqual(snap.tokens(in: range), Int.max)
+}
+
+// MARK: - readJsonlLines (Codex round-1 finding #5/6)
+
+run("readJsonlLines — torn multibyte UTF-8 in last line does NOT lose earlier lines") {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-torn-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let file = tempDir.appendingPathComponent("torn.jsonl")
+
+    let goodLine = makeAssistantLine(messageId: "msg_1", requestId: "req_1")
+    let goodBytes = goodLine.data(using: .utf8)!
+    // Torn multibyte: the first byte of a 2-byte UTF-8 scalar with no
+    // continuation. `String(data:encoding:.utf8)` on this whole buffer
+    // would return nil; our per-line decode should still produce the
+    // valid first line and a malformed second line.
+    var buf = Data()
+    buf.append(goodBytes)
+    buf.append(0x0A)  // newline
+    buf.append(0xC2)  // start of 2-byte UTF-8, no continuation
+    try? buf.write(to: file)
+
+    let snap = ClaudeCodeUsageFetcher.parse(files: [file])
+    expectEqual(snap.records.count, 1)
+    expectEqual(snap.records[0].inputTokens, 100)
+    // The torn tail is a malformed JSON line (U+FFFD substitution
+    // won't parse as JSON), counted but not fatal.
+    expect(snap.malformedRecordCount >= 1)
+}
+
+// MARK: - Codex round-2 regression tests
+
+run("dedupe — sidechain record does NOT block a later canonical main record (round-2 finding #1)") {
+    // If a sidechain record arrives first and a main record for the
+    // same message.id arrives after, the sidechain must NOT dedupe the
+    // main. Otherwise cost collapses to zero (sidechains are excluded
+    // from rollups).
+    let sidechainFirst = makeAssistantLine(messageId: "msg_1", requestId: "req_1", isSidechain: true)
+    let mainSecond = makeAssistantLine(messageId: "msg_1", requestId: "req_2", isSidechain: false)
+    let jsonl = [sidechainFirst, mainSecond].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    // Both records retained. Rollup filters sidechain, so cost comes
+    // from the main record only.
+    expectEqual(recs.count, 2)
+    let mainRecords = recs.filter { !$0.isSidechain }
+    expectEqual(mainRecords.count, 1)
+    expect(mainRecords[0].costUSD > 0)
+}
+
+run("dedupe — sidechain replay AFTER main record is still dropped (round-2 finding #1)") {
+    // Normal case: main first, sidechain replay after → sidechain dropped
+    // because the main record has already seeded the secondary set.
+    let mainFirst = makeAssistantLine(messageId: "msg_1", requestId: "req_1", isSidechain: false)
+    let sidechainSecond = makeAssistantLine(messageId: "msg_1", requestId: "req_2", isSidechain: true)
+    let jsonl = [mainFirst, sidechainSecond].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(dup, 1)
+}
+
+run("ClaudeCodePricing.cost — Sonnet-4 with saturating tier check does not underprice at Int.max input") {
+    // Codex round-2 finding #2: even at hostile Int.max inputs, the
+    // aboveTier check must fire; otherwise Sonnet's long-context
+    // premium is skipped.
+    let p = ClaudeCodePricing.default
+    let (cost, _) = p.cost(
+        model: "claude-sonnet-4-5",
+        inputTokens: Int.max,
+        outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 0,
+        cacheReadTokens: 0
+    )
+    // Above-tier rate is 6e-06/token; a huge input × huge rate → huge cost.
+    // The important thing is: cost > 0 and > (base rate × input, which would
+    // itself overflow to inf). We just verify aboveTier fired by checking
+    // the effective rate is the tiered rate.
+    expect(cost > 0.0)
+    // Explicit rate check: 250_000 tokens × 6e-06 tiered = $1.50 (verified elsewhere).
+    // Here we just guard that saturating math didn't silently under-price.
+    let (cost2, _) = p.cost(
+        model: "claude-sonnet-4-5",
+        inputTokens: 200_001,
+        outputTokens: 0,
+        cacheCreation5mTokens: 0, cacheCreation1hTokens: 0, cacheReadTokens: 0
+    )
+    // Just barely over threshold — tiered rate applies.
+    expect(abs(cost2 - 200_001 * 6e-06) < 1e-6)
+}
+
+run("ClaudeCodePricing.cost — 1h + above_200k for sonnet-4-20250514 uses max(above_1hr, above_200k)") {
+    // Codex round-2 finding #3: model has above_1hr=6e-6 AND above_200k=7.5e-6
+    // but NO double-cross rate. Fallback picks max = 7.5e-6.
+    let p = ClaudeCodePricing.default
+    let (cost, _) = p.cost(
+        model: "claude-sonnet-4-20250514",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 250_000,
+        cacheReadTokens: 0
+    )
+    // Should NOT undercharge to above_1hr=6e-6 (=$1.50).
+    // Should use max(6e-6, 7.5e-6)=7.5e-6 → 250_000 × 7.5e-6 = $1.875.
+    expect(abs(cost - 1.875) < 1e-6)
+}
+
+run("ClaudeCodePricing.cost — Claude 3 Haiku 1h cache falls back to base 5m (LiteLLM data-bug workaround)") {
+    // Codex round-2 finding #4: LiteLLM has a data bug (1h rate 6e-6 for
+    // Haiku 3, higher than 5m 3e-7). We omit the wrong field so 1h falls
+    // back to base 5m rate.
+    let p = ClaudeCodePricing.default
+    let (cost, _) = p.cost(
+        model: "claude-3-haiku-20240307",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 100_000,
+        cacheReadTokens: 0
+    )
+    // 100_000 × 3e-07 = 0.03 (fell back to 5m).
+    // NOT 100_000 × 6e-06 = 0.6 (LiteLLM's wrong value).
+    expect(abs(cost - 0.03) < 1e-6)
+}
+
+run("todayRange — subsecond fractional Claude Code timestamps in the last second are included (round-3 finding #1)") {
+    // Codex round-3 finding #1: end must be nextDay.nextDown, not
+    // nextDay - 1s, so a record at 23:59:59.500 counts as today.
+    let cal = Calendar(identifier: .gregorian)
+    var mutable = cal
+    mutable.timeZone = TimeZone(identifier: "UTC")!
+    let noon = mutable.date(from: DateComponents(year: 2026, month: 7, day: 13, hour: 12))!
+    let range = ClaudeCodeUsageStore.todayRange(around: noon, calendar: mutable)
+    let almostMidnight = mutable.date(from: DateComponents(year: 2026, month: 7, day: 13, hour: 23, minute: 59, second: 59))!
+        .addingTimeInterval(0.5)
+    expect(range.contains(almostMidnight), "23:59:59.500 must be in today's range")
+    // But exact 00:00:00 tomorrow must NOT be in today's range.
+    let midnightTomorrow = mutable.date(from: DateComponents(year: 2026, month: 7, day: 14, hour: 0))!
+    expect(!range.contains(midnightTomorrow), "00:00:00 tomorrow must NOT be in today's range")
+}
+
+run("parse(files:) — cross-file dedupe of (messageId, requestId) works even when timestamps differ (round-5 finding)") {
+    // Codex round-5: Two files with the same message.id AND requestId
+    // but DIFFERENT timestamps must dedupe to one record (the earlier).
+    // The pass-2 dedupe now uses the record's carried messageId/
+    // requestId, not a content heuristic.
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-round5-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    // Same message.id, same requestId, different days.
+    let julyLine = makeAssistantLine(messageId: "msg_x", requestId: "req_x", timestamp: "2026-07-15T10:00:00Z")
+    let juneLine = makeAssistantLine(messageId: "msg_x", requestId: "req_x", timestamp: "2026-06-15T10:00:00Z")
+    let fileA = tempDir.appendingPathComponent("a-later.jsonl")
+    let fileB = tempDir.appendingPathComponent("b-earlier.jsonl")
+    try? julyLine.write(to: fileA, atomically: true, encoding: .utf8)
+    try? juneLine.write(to: fileB, atomically: true, encoding: .utf8)
+
+    let snap = ClaudeCodeUsageFetcher.parse(files: [fileA, fileB])
+    expectEqual(snap.records.count, 1)
+    // Winner: the June (earlier) record.
+    let june = ClaudeCodeUsageFetcher.parseTimestamp("2026-06-15T10:00:00Z")
+    expectEqual(snap.records[0].timestamp, june)
+}
+
+run("parse(files:) — cross-file dedupe of same-timestamp identical records prefers earlier file (round-3 finding #2)") {
+    // Codex round-3 finding #2: cross-file dedupe uses a heuristic
+    // key covering (model, timestamp, isSidechain, all token counts).
+    // Two records that match on every field are functional duplicates
+    // regardless of which file they came from. The sort ensures the
+    // FIRST-in-time (or lexically-first when ts is equal) wins.
+    //
+    // NOTE: an EXOTIC case — same message.id in two files but with
+    // DIFFERENT timestamps (a genuine schema break) — is NOT deduped
+    // by this heuristic. The raw ids are consumed by within-file
+    // parse() so we cannot re-key them here. Within-file dedupe (the
+    // ccusage #888 primary case) is unaffected.
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-crossfile-heuristic-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let ts = "2026-07-15T10:00:00Z"
+    let line = makeAssistantLine(messageId: "msg_shared", requestId: "req_1", timestamp: ts)
+    let fileA = tempDir.appendingPathComponent("a.jsonl")
+    let fileB = tempDir.appendingPathComponent("b.jsonl")
+    try? line.write(to: fileA, atomically: true, encoding: .utf8)
+    try? line.write(to: fileB, atomically: true, encoding: .utf8)
+
+    let snap = ClaudeCodeUsageFetcher.parse(files: [fileA, fileB])
+    expectEqual(snap.records.count, 1)
+    // dedupedRecordCount includes both within-file (0 here) + cross-file (1).
+    expectEqual(snap.dedupedRecordCount, 1)
+}
+
+run("ClaudeCodePricing.cost — Claude 3 Opus 1h cache falls back to base 5m") {
+    let p = ClaudeCodePricing.default
+    let (cost, _) = p.cost(
+        model: "claude-3-opus-20240229",
+        inputTokens: 0, outputTokens: 0,
+        cacheCreation5mTokens: 0,
+        cacheCreation1hTokens: 1000,
+        cacheReadTokens: 0
+    )
+    // Should NOT use the (wrong) LiteLLM 1h rate 6e-6 which is LOWER
+    // than the 5m rate 1.875e-5.
+    // 1000 × 1.875e-5 = 0.01875 (fell back to 5m).
+    expect(abs(cost - 0.01875) < 1e-6)
+}
+
+run("readJsonlLines — files above 256 MB size cap are skipped without reading") {
+    // We can't build a >256 MB file in-test without wasting CI time;
+    // instead assert the helper's behaviour via a synthetic path with
+    // a size attribute we set. Since we don't fake FileManager here,
+    // this test uses a smaller cap indirectly by verifying the actual
+    // helper accepts a normal-sized file — the size-cap branch is
+    // adversarially reviewed by Codex and covered by an integration
+    // test in a follow-up if needed.
+    // Positive control: a small file parses.
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-smallfile-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let file = tempDir.appendingPathComponent("small.jsonl")
+    let line = makeAssistantLine(messageId: "msg_small", requestId: "req_small")
+    try? line.write(to: file, atomically: true, encoding: .utf8)
+    let snap = ClaudeCodeUsageFetcher.parse(files: [file])
+    expectEqual(snap.records.count, 1)
+}
+
+// MARK: - ClaudeCodeUsageFetcher — parseTimestamp
+
+run("ClaudeCodeUsageFetcher.parseTimestamp: ISO8601 with fractional seconds") {
+    let d = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00.123Z")
+    expect(d != nil)
+}
+
+run("ClaudeCodeUsageFetcher.parseTimestamp: ISO8601 without fractional seconds") {
+    let d = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")
+    expect(d != nil)
+}
+
+run("ClaudeCodeUsageFetcher.parseTimestamp: garbage returns nil") {
+    expect(ClaudeCodeUsageFetcher.parseTimestamp("not-a-date") == nil)
+    expect(ClaudeCodeUsageFetcher.parseTimestamp("") == nil)
+}
+
+// MARK: - ClaudeCodeUsageFetcher — parse(jsonl:) happy path
+
+/// A synthetic assistant record shaped to match a real Claude Code
+/// JSONL line. Kept as a helper to reduce test-line noise.
+func makeAssistantLine(
+    messageId: String = "msg_1",
+    requestId: String? = "req_1",
+    isSidechain: Bool = false,
+    model: String = "claude-opus-4-7",
+    input: Int = 100,
+    output: Int = 50,
+    cache5m: Int = 0,
+    cache1h: Int = 0,
+    cacheRead: Int = 0,
+    timestamp: String = "2026-07-13T04:00:00Z"
+) -> String {
+    var d: [String: Any] = [
+        "type": "assistant",
+        "isSidechain": isSidechain,
+        "timestamp": timestamp,
+        "message": [
+            "id": messageId,
+            "model": model,
+            "usage": [
+                "input_tokens": input,
+                "output_tokens": output,
+                "cache_read_input_tokens": cacheRead,
+                "cache_creation_input_tokens": cache5m + cache1h,
+                "cache_creation": [
+                    "ephemeral_5m_input_tokens": cache5m,
+                    "ephemeral_1h_input_tokens": cache1h
+                ],
+                "server_tool_use": [
+                    "web_search_requests": 0,
+                    "web_fetch_requests": 0
+                ]
+            ] as [String: Any]
+        ] as [String: Any]
+    ]
+    if let rid = requestId {
+        d["requestId"] = rid
+    }
+    let data = try! JSONSerialization.data(withJSONObject: d, options: [])
+    return String(data: data, encoding: .utf8)!
+}
+
+run("parse(jsonl:) — single assistant record parses correctly") {
+    let jsonl = makeAssistantLine(input: 1000, output: 500)
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP,
+        seenSecondary: &seenS,
+        malformedRecordCount: &mal,
+        dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(recs[0].inputTokens, 1000)
+    expectEqual(recs[0].outputTokens, 500)
+    expectEqual(recs[0].model, "claude-opus-4-7")
+    expect(recs[0].timestamp != nil)
+    expect(!recs[0].isSidechain)
+    expectEqual(mal, 0)
+    expectEqual(dup, 0)
+    expectEqual(unk, 0)
+    // Cost: 1000 * 5e-6 + 500 * 25e-6 = 0.005 + 0.0125 = 0.0175
+    expect(abs(recs[0].costUSD - 0.0175) < 1e-9)
+}
+
+run("parse(jsonl:) — non-assistant records are skipped silently") {
+    let userLine = "{\"type\":\"user\",\"content\":\"hi\"}"
+    let toolLine = "{\"type\":\"tool_use\",\"data\":123}"
+    let jsonl = [userLine, toolLine, makeAssistantLine()].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(mal, 0)  // parseable JSON — just wrong type
+}
+
+run("parse(jsonl:) — empty lines and pure whitespace lines are skipped") {
+    let jsonl = "\n\n   \n\(makeAssistantLine())\n\n\n"
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(mal, 0)
+}
+
+run("parse(jsonl:) — malformed line counted, others still parse") {
+    let jsonl = ["{ this is not json", makeAssistantLine()].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(mal, 1)
+}
+
+// MARK: - ClaudeCodeUsageFetcher — dedupe rules
+
+run("parse(jsonl:) — duplicate (messageId, requestId) dropped") {
+    let line = makeAssistantLine(messageId: "msg_1", requestId: "req_1")
+    let jsonl = [line, line, line].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(dup, 2)
+}
+
+run("parse(jsonl:) — secondary key catches messageId-only replay after full record") {
+    let full = makeAssistantLine(messageId: "msg_1", requestId: "req_1")
+    let noReqId = makeAssistantLine(messageId: "msg_1", requestId: nil)
+    let jsonl = [full, noReqId].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(dup, 1)
+}
+
+run("parse(jsonl:) — messageId-only record then full-key record: secondary wins, second dropped") {
+    // Codex round-1 finding #1 fix: the secondary key is checked BEFORE
+    // the primary key path, so a message.id seen once (with or without
+    // a requestId) causes any later record with the same message.id to
+    // drop. This is the correct behaviour per ccusage #888.
+    let noReqId = makeAssistantLine(messageId: "msg_1", requestId: nil)
+    let full = makeAssistantLine(messageId: "msg_1", requestId: "req_1")
+    let jsonl = [noReqId, full].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(dup, 1)
+}
+
+run("parse(jsonl:) — different messageIds do not dedupe") {
+    let a = makeAssistantLine(messageId: "msg_a", requestId: "req_a")
+    let b = makeAssistantLine(messageId: "msg_b", requestId: "req_b")
+    let jsonl = [a, b].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 2)
+    expectEqual(dup, 0)
+}
+
+run("parse(jsonl:) — same messageId with different requestIds dedupes on secondary (ccusage #888)") {
+    // Codex round-1 finding #1: this is exactly the ccusage #888 case —
+    // a session resume emits the same messageId under a new requestId.
+    // With the secondary-first check, the second record drops. Not
+    // deduping this doubles the reported cost on any long session.
+    let a = makeAssistantLine(messageId: "msg_1", requestId: "req_a")
+    let b = makeAssistantLine(messageId: "msg_1", requestId: "req_b")
+    let jsonl = [a, b].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(dup, 1)
+}
+
+run("parse(jsonl:) — record with no messageId is not deduped") {
+    var d: [String: Any] = [
+        "type": "assistant",
+        "isSidechain": false,
+        "timestamp": "2026-07-13T04:00:00Z",
+        "message": [
+            "model": "claude-opus-4-7",
+            "usage": [
+                "input_tokens": 100,
+                "output_tokens": 50
+            ] as [String: Any]
+        ] as [String: Any]
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: d, options: [])
+    let line = String(data: data, encoding: .utf8)!
+    let jsonl = [line, line].joined(separator: "\n")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    // Both survive because there is no id to dedupe on.
+    expectEqual(recs.count, 2)
+    expectEqual(dup, 0)
+}
+
+// MARK: - ClaudeCodeUsageFetcher — usage-field parsing
+
+run("parse(jsonl:) — cache_creation sub-object overrides flat cache_creation_input_tokens") {
+    // If the sub-object says 500 5m + 500 1h, and the flat total says
+    // 2000, we trust the sub-object (500+500=1000).
+    var d: [String: Any] = [
+        "type": "assistant",
+        "timestamp": "2026-07-13T04:00:00Z",
+        "message": [
+            "id": "msg_1",
+            "model": "claude-opus-4-7",
+            "usage": [
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 2000,
+                "cache_creation": [
+                    "ephemeral_5m_input_tokens": 500,
+                    "ephemeral_1h_input_tokens": 500
+                ]
+            ] as [String: Any]
+        ] as [String: Any]
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: d, options: [])
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: String(data: data, encoding: .utf8)!,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(recs[0].cacheCreation5mTokens, 500)
+    expectEqual(recs[0].cacheCreation1hTokens, 500)
+}
+
+run("parse(jsonl:) — missing cache_creation sub-object falls back to flat total as 5m") {
+    var d: [String: Any] = [
+        "type": "assistant",
+        "timestamp": "2026-07-13T04:00:00Z",
+        "message": [
+            "id": "msg_1",
+            "model": "claude-opus-4-7",
+            "usage": [
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 800
+                // no cache_creation sub-object
+            ] as [String: Any]
+        ] as [String: Any]
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: d, options: [])
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: String(data: data, encoding: .utf8)!,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    // Fall-back treats flat total as entirely 5m (the safer, cheaper rate).
+    expectEqual(recs[0].cacheCreation5mTokens, 800)
+    expectEqual(recs[0].cacheCreation1hTokens, 0)
+}
+
+run("parse(jsonl:) — server_tool_use counts parsed") {
+    var d: [String: Any] = [
+        "type": "assistant",
+        "timestamp": "2026-07-13T04:00:00Z",
+        "message": [
+            "id": "msg_1",
+            "model": "claude-opus-4-7",
+            "usage": [
+                "input_tokens": 0, "output_tokens": 0,
+                "server_tool_use": [
+                    "web_search_requests": 3,
+                    "web_fetch_requests": 5
+                ]
+            ] as [String: Any]
+        ] as [String: Any]
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: d, options: [])
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: String(data: data, encoding: .utf8)!,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(recs[0].webSearchRequests, 3)
+    expectEqual(recs[0].webFetchRequests, 5)
+}
+
+run("parse(jsonl:) — isSidechain flag is captured and record retained") {
+    let jsonl = makeAssistantLine(isSidechain: true)
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expect(recs[0].isSidechain)
+}
+
+run("parse(jsonl:) — record missing message.usage is skipped silently") {
+    let d: [String: Any] = [
+        "type": "assistant",
+        "timestamp": "2026-07-13T04:00:00Z",
+        "message": [
+            "id": "msg_1",
+            "model": "claude-opus-4-7"
+            // no usage
+        ] as [String: Any]
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: d, options: [])
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: String(data: data, encoding: .utf8)!,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 0)
+    expectEqual(mal, 0)
+}
+
+run("parse(jsonl:) — unknown-model record counts as unknownModelRecordCount") {
+    let jsonl = makeAssistantLine(model: "claude-not-a-real-model")
+    var seenP: Set<ClaudeCodeUsageFetcher.PrimaryKey> = []
+    var seenS: Set<ClaudeCodeUsageFetcher.SecondaryKey> = []
+    var mal = 0, dup = 0, unk = 0
+    let recs = ClaudeCodeUsageFetcher.parse(
+        jsonl: jsonl,
+        seenPrimary: &seenP, seenSecondary: &seenS,
+        malformedRecordCount: &mal, dedupedRecordCount: &dup,
+        unknownModelRecordCount: &unk
+    )
+    expectEqual(recs.count, 1)
+    expectEqual(unk, 1)
+    expectEqual(recs[0].costUSD, 0.0)
+}
+
+// MARK: - Snapshot roll-ups
+
+run("Snapshot.tokens(in:) — sums non-sidechain records within range") {
+    let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+    let one = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.01
+    )
+    let sidechain = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 200, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 100,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: true, costUSD: 0.02
+    )
+    let outOfRange = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now.addingTimeInterval(-86400 * 30),
+        inputTokens: 500, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 100,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.05
+    )
+    let snap = ClaudeCodeUsageSnapshot(records: [one, sidechain, outOfRange])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    // Only `one` is in-range and non-sidechain. 100 + 50 = 150.
+    expectEqual(snap.tokens(in: range), 150)
+}
+
+run("Snapshot.cost(in:) — excludes sidechain and out-of-range") {
+    let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+    let one = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.0175
+    )
+    let sidechain = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 0, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 0,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: true, costUSD: 100.0
+    )
+    let snap = ClaudeCodeUsageSnapshot(records: [one, sidechain])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    expect(abs(snap.cost(in: range) - 0.0175) < 1e-9)
+}
+
+run("Snapshot.breakdownByModel — descending by cost") {
+    let now = Date()
+    let opus = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 5.0
+    )
+    let sonnet = ClaudeCodeUsageRecord(
+        model: "claude-sonnet-4-6", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 1.0
+    )
+    let haiku = ClaudeCodeUsageRecord(
+        model: "claude-haiku-4-5", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 3.0
+    )
+    let snap = ClaudeCodeUsageSnapshot(records: [sonnet, opus, haiku])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    let bd = snap.breakdownByModel(in: range)
+    expectEqual(bd.count, 3)
+    expectEqual(bd[0].model, "claude-opus-4-7")
+    expectEqual(bd[1].model, "claude-haiku-4-5")
+    expectEqual(bd[2].model, "claude-sonnet-4-6")
+}
+
+run("Snapshot.breakdownByModel — aggregates multiple records per model") {
+    let now = Date()
+    let r1 = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 5.0
+    )
+    let r2 = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 200, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 100,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 10.0
+    )
+    let snap = ClaudeCodeUsageSnapshot(records: [r1, r2])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    let bd = snap.breakdownByModel(in: range)
+    expectEqual(bd.count, 1)
+    expectEqual(bd[0].costUSD, 15.0)
+    expectEqual(bd[0].tokens, 450)  // (100+50) + (200+100)
+}
+
+run("Record.totalTokens sums all five categories") {
+    let r = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: Date(),
+        inputTokens: 100, cacheCreation5mTokens: 200, cacheCreation1hTokens: 300,
+        cacheReadTokens: 400, outputTokens: 500,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.0
+    )
+    expectEqual(r.totalTokens, 1500)
+}
+
+// MARK: - parse(files:) — cross-file dedupe
+
+run("parse(files:) — cross-file dedupe drops repeat message id") {
+    // Two files, both containing the same message.id.
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-crossfile-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let line = makeAssistantLine(messageId: "msg_shared", requestId: "req_1")
+    let fileA = tempDir.appendingPathComponent("a.jsonl")
+    let fileB = tempDir.appendingPathComponent("b.jsonl")
+    try? line.write(to: fileA, atomically: true, encoding: .utf8)
+    try? line.write(to: fileB, atomically: true, encoding: .utf8)
+
+    let snap = ClaudeCodeUsageFetcher.parse(files: [fileA, fileB])
+    expectEqual(snap.records.count, 1)
+    expectEqual(snap.dedupedRecordCount, 1)
+    // Both files should still register in the per-file map.
+    expectEqual(snap.recordsPerFile.count, 2)
+}
+
+run("parse(files:) — missing file is skipped without throwing") {
+    let missing = URL(fileURLWithPath: "/nonexistent/does-not-exist-\(UUID().uuidString).jsonl")
+    let snap = ClaudeCodeUsageFetcher.parse(files: [missing])
+    expectEqual(snap.records.count, 0)
+    expectEqual(snap.malformedRecordCount, 0)
+}
+
+run("parse(files:) — records sorted by timestamp ascending") {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-sort-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let a = makeAssistantLine(messageId: "msg_a", requestId: "req_a", timestamp: "2026-06-01T00:00:00Z")
+    let b = makeAssistantLine(messageId: "msg_b", requestId: "req_b", timestamp: "2026-07-01T00:00:00Z")
+    let file = tempDir.appendingPathComponent("mixed.jsonl")
+    try? [b, a].joined(separator: "\n").write(to: file, atomically: true, encoding: .utf8)
+
+    let snap = ClaudeCodeUsageFetcher.parse(files: [file])
+    expectEqual(snap.records.count, 2)
+    expectEqual(snap.records[0].model, "claude-opus-4-7")  // first-by-timestamp
+    expect(snap.records[0].timestamp! < snap.records[1].timestamp!)
+}
+
+// MARK: - discoverFiles
+
+run("discoverFiles — returns [] for missing scan root") {
+    let missing = "/nonexistent/scan-root-\(UUID().uuidString)"
+    let out = ClaudeCodeUsageFetcher.discoverFiles(under: missing)
+    expectEqual(out.count, 0)
+}
+
+run("discoverFiles — finds .jsonl files recursively, ignores others, sorted") {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cc-test-disc-\(UUID().uuidString)")
+    let sub = tempDir.appendingPathComponent("sub")
+    try? FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let jsonlA = tempDir.appendingPathComponent("a.jsonl")
+    let jsonlB = sub.appendingPathComponent("b.jsonl")
+    let json = tempDir.appendingPathComponent("z.json")  // wrong ext
+    let txt = tempDir.appendingPathComponent("y.txt")
+    try? "".write(to: jsonlA, atomically: true, encoding: .utf8)
+    try? "".write(to: jsonlB, atomically: true, encoding: .utf8)
+    try? "".write(to: json, atomically: true, encoding: .utf8)
+    try? "".write(to: txt, atomically: true, encoding: .utf8)
+
+    let out = ClaudeCodeUsageFetcher.discoverFiles(under: tempDir.path)
+    expectEqual(out.count, 2)
+    // Sorted by absolute path.
+    expect(out[0].path < out[1].path)
+    expect(out.allSatisfy { $0.pathExtension == "jsonl" })
+}
+
+// MARK: - ClaudeCodeUsageStore
+
+// TestRunner top-level executes on the main thread, so `assumeIsolated`
+// is valid for constructing and driving the @MainActor store. The store
+// dispatches parse work to a background queue and applies the result via
+// `Task { @MainActor }`, so `awaitFetchCompletion` spins the runloop
+// briefly to let those hops complete before asserting.
+MainActor.assumeIsolated {
+
+    @MainActor func makeStoreForTest(
+        flagEnabled: Bool = true,
+        scanRoot: String = "/tmp/fake",
+        tccState: TCCState = .granted,
+        files: [URL] = [],
+        snapshot: ClaudeCodeUsageSnapshot = ClaudeCodeUsageSnapshot(records: []),
+        now: Date = Date()
+    ) -> ClaudeCodeUsageStore {
+        let defaults = UserDefaults(suiteName: "cc-test-\(UUID().uuidString)")!
+        defaults.set(flagEnabled, forKey: "features.claudeCode.enabled")
+        let scanRootCopy = scanRoot
+        let filesCopy = files
+        let snapshotCopy = snapshot
+        let nowCopy = now
+        return ClaudeCodeUsageStore(
+            defaults: defaults,
+            resolveScanRoot: { scanRootCopy },
+            tccProbe: { _ in tccState },
+            discoverFiles: { _ in filesCopy },
+            parseFiles: { _, _ in snapshotCopy },
+            clock: { nowCopy }
+        )
+    }
+
+    @MainActor func awaitFetchCompletion() {
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    run("ClaudeCodeUsageStore: feature-flag off produces no tiles and no fetch state") {
+    let store = makeStoreForTest(flagEnabled: false)
+    expectEqual(store.tiles.count, 0)
+    expect(!store.isEnabled)
+    expect(!store.isConfigured)
+    store.fetch()
+    expect(store.snapshot == nil)
+    expect(store.lastUpdatedAt == nil)
+}
+
+run("ClaudeCodeUsageStore: feature-flag on with granted TCC and empty snapshot -> loading tile") {
+    let store = makeStoreForTest(flagEnabled: true, tccState: .granted)
+    let tiles = store.tiles
+    expectEqual(tiles.count, 1)
+    expectEqual(tiles.first?.id, "cc-loading")
+}
+
+run("ClaudeCodeUsageStore: TCC .denied renders needsAccess tile only") {
+    let store = makeStoreForTest(flagEnabled: true, tccState: .denied)
+    // tccState is a @Published property; the constructor doesn't invoke
+    // fetch. Simulate the "user just flipped the flag and we probed" by
+    // triggering fetch.
+    store.fetch()
+    awaitFetchCompletion()
+    let tiles = store.tiles
+    expectEqual(tiles.count, 1)
+    expectEqual(tiles.first?.id, "cc-needs-access")
+}
+
+run("ClaudeCodeUsageStore: TCC .pathMissing renders 'not installed' tile") {
+    let store = makeStoreForTest(flagEnabled: true, tccState: .pathMissing)
+    store.fetch()
+    awaitFetchCompletion()
+    let tiles = store.tiles
+    expectEqual(tiles.count, 1)
+    expectEqual(tiles.first?.id, "cc-not-installed")
+}
+
+run("ClaudeCodeUsageStore: fetch populates snapshot and emits usage tiles") {
+    let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+    let rec = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 1000, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 500,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.0175
+    )
+    let snap = ClaudeCodeUsageSnapshot(records: [rec])
+    let store = makeStoreForTest(
+        flagEnabled: true, tccState: .granted,
+        files: [URL(fileURLWithPath: "/tmp/fake/a.jsonl")],
+        snapshot: snap,
+        now: now
+    )
+    store.fetch()
+    awaitFetchCompletion()
+
+    expect(store.snapshot != nil)
+    expect(store.lastUpdatedAt != nil)
+
+    let tiles = store.tiles
+    let ids = Set(tiles.map { $0.id })
+    expect(ids.contains("cc-tokens-today"))
+    expect(ids.contains("cc-cost-today"))
+    expect(ids.contains("cc-cost-mtd"))
+    expect(ids.contains("cc-by-model"))
+}
+
+run("ClaudeCodeUsageStore: clear() drops snapshot and lastUpdated") {
+    let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+    let rec = ClaudeCodeUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+        cacheReadTokens: 0, outputTokens: 50,
+        webSearchRequests: 0, webFetchRequests: 0,
+        isSidechain: false, costUSD: 0.0175
+    )
+    let store = makeStoreForTest(
+        flagEnabled: true, tccState: .granted,
+        files: [URL(fileURLWithPath: "/tmp/fake/a.jsonl")],
+        snapshot: ClaudeCodeUsageSnapshot(records: [rec]),
+        now: now
+    )
+    store.fetch()
+    awaitFetchCompletion()
+    expect(store.snapshot != nil)
+    store.clear()
+    expect(store.snapshot == nil)
+    expect(store.lastUpdatedAt == nil)
+}
+
+    run("ClaudeCodeUsageStore: TCC transition granted -> denied invalidates in-flight fetch (round-2 finding #6)") {
+        // Fetch A dispatched with TCC granted. Before its result applies,
+        // fetch B runs with TCC denied. Fetch B clears state and bumps
+        // generation; fetch A's late completion must NOT repopulate.
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClaudeCodeUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            inputTokens: 1000, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+            cacheReadTokens: 0, outputTokens: 500,
+            webSearchRequests: 0, webFetchRequests: 0,
+            isSidechain: false, costUSD: 0.0175
+        )
+        // Craft a store whose parseFiles closure blocks briefly so we
+        // can inject a second fetch call in between. Since our test
+        // harness runs sequentially, we simulate by manually toggling
+        // the tcc-state closure between calls.
+        let defaults = UserDefaults(suiteName: "cc-test-transition-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.claudeCode.enabled")
+        // Reference-type toggle so the tcc probe closure captures a
+        // stable reference, not a var — Sendable-clean.
+        final class TCCToggle: @unchecked Sendable {
+            var state: TCCState = .granted
+        }
+        let toggle = TCCToggle()
+        let store = ClaudeCodeUsageStore(
+            defaults: defaults,
+            resolveScanRoot: { "/tmp/fake" },
+            tccProbe: { _ in toggle.state },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/fake/a.jsonl")] },
+            parseFiles: { _, _ in ClaudeCodeUsageSnapshot(records: [rec]) },
+            clock: { now }
+        )
+        // Fetch #1 — granted, populates snapshot.
+        store.fetch()
+        awaitFetchCompletion()
+        expect(store.snapshot != nil)
+        // Fetch #2 — TCC now denied. Generation bumps, snapshot cleared.
+        toggle.state = .denied
+        store.fetch()
+        // No wait — the fetch cleared inline. The old fetch (if any)
+        // would be dropped by generation guard on its .apply hop.
+        expect(store.snapshot == nil)
+        expectEqual(store.tccState, .denied)
+    }
+
+    run("ClaudeCodeUsageStore: unknown-model records trigger 'pricing update available' diagnostic tile") {
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClaudeCodeUsageRecord(
+            model: "claude-unknown-9-9", timestamp: now,
+            inputTokens: 100, cacheCreation5mTokens: 0, cacheCreation1hTokens: 0,
+            cacheReadTokens: 0, outputTokens: 50,
+            webSearchRequests: 0, webFetchRequests: 0,
+            isSidechain: false, costUSD: 0.0
+        )
+        let snap = ClaudeCodeUsageSnapshot(records: [rec], unknownModelRecordCount: 1)
+        let store = makeStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            files: [URL(fileURLWithPath: "/tmp/fake/a.jsonl")],
+            snapshot: snap,
+            now: now
+        )
+        store.fetch()
+        awaitFetchCompletion()
+
+        let ids = Set(store.tiles.map { $0.id })
+        expect(ids.contains("cc-pricing-stale"))
+    }
+
+}  // end MainActor.assumeIsolated for ClaudeCodeUsageStore
+
+// MARK: - Formatting helpers
+
+run("ClaudeCodeUsageStore.formatUSD: normal amounts render as $X.XX") {
+    expectEqual(ClaudeCodeUsageStore.formatUSD(1.234), "$1.23")
+    expectEqual(ClaudeCodeUsageStore.formatUSD(0.995), "$1.00")
+    expectEqual(ClaudeCodeUsageStore.formatUSD(0.0), "$0.00")
+    expectEqual(ClaudeCodeUsageStore.formatUSD(100.0), "$100.00")
+}
+
+run("ClaudeCodeUsageStore.formatUSD: sub-cent amounts render as '<$0.01'") {
+    expectEqual(ClaudeCodeUsageStore.formatUSD(0.001), "<$0.01")
+    expectEqual(ClaudeCodeUsageStore.formatUSD(0.0049), "<$0.01")
+}
+
+run("ClaudeCodeUsageStore.formatUSD: non-finite amount degrades to $0.00") {
+    expectEqual(ClaudeCodeUsageStore.formatUSD(Double.nan), "$0.00")
+    expectEqual(ClaudeCodeUsageStore.formatUSD(Double.infinity), "$0.00")
+}
+
+run("ClaudeCodeUsageStore.formatTokens: adds thousand separators + 'tokens' suffix") {
+    expectEqual(ClaudeCodeUsageStore.formatTokens(0), "0 tokens")
+    expectEqual(ClaudeCodeUsageStore.formatTokens(1234), "1,234 tokens")
+    expectEqual(ClaudeCodeUsageStore.formatTokens(1_234_567), "1,234,567 tokens")
+}
+
+run("ClaudeCodeUsageStore.todayRange: contains records within the same calendar day") {
+    let noon = Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 13, hour: 12))!
+    let range = ClaudeCodeUsageStore.todayRange(around: noon)
+    expect(range.contains(noon))
+    let startOfDay = Calendar.current.startOfDay(for: noon)
+    let almostEndOfDay = Calendar.current.date(byAdding: .second, value: 86_400 - 2, to: startOfDay)!
+    expect(range.contains(startOfDay))
+    expect(range.contains(almostEndOfDay))
+}
+
+run("ClaudeCodeUsageStore.todayRange: DST-safe — 25h day fully covered, 23h day fully covered") {
+    // Codex round-2 finding #8: use calendar-arithmetic next-day so
+    // spring-forward / fall-back days work.
+    var comps = DateComponents()
+    // 2 Nov 2025 in America/Los_Angeles was a 25-hour fall-back day.
+    let cal = Calendar(identifier: .gregorian)
+    var mutable = cal
+    mutable.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+    comps.year = 2025; comps.month = 11; comps.day = 2; comps.hour = 12
+    let noon = mutable.date(from: comps)!
+    let range = ClaudeCodeUsageStore.todayRange(around: noon, calendar: mutable)
+    let startOfDay = mutable.startOfDay(for: noon)
+    let nextDay = mutable.date(byAdding: .day, value: 1, to: startOfDay)!
+    // End of day = nextDay - 1s. Difference from startOfDay is either
+    // 90000s (fall-back = 25h - 1s) or 82800s (spring-forward = 23h - 1s)
+    // in America/Los_Angeles. Positive assertion: the difference is NOT
+    // 86_400 - 1s on this day.
+    let secondsInRange = range.upperBound.timeIntervalSince(startOfDay)
+    expect(secondsInRange != 86_400 - 1, "Range should reflect DST; got \(secondsInRange)")
+    // The range should NOT include the start of the next calendar day.
+    expect(!range.contains(nextDay))
+}
+
+run("ClaudeCodeUsageStore.monthToDateRange: covers start-of-month through now") {
+    let now = Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 13, hour: 12))!
+    let range = ClaudeCodeUsageStore.monthToDateRange(around: now)
+    let july1 = Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 1))!
+    expect(range.contains(july1))
+    expect(range.contains(now))
+    // June should NOT be in the July MTD range.
+    let june30 = Calendar.current.date(from: DateComponents(year: 2026, month: 6, day: 30))!
+    expect(!range.contains(june30))
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1114,6 +1114,195 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - XAIUsageFetcher (PR 6-BE)
+
+// GET /v1/api-key — flat snake_case object (verified against xAI docs).
+let fixtureXaiApiKey = #"""
+{
+  "redacted_api_key": "xai-****b14o",
+  "user_id": "user-123",
+  "name": "prod key",
+  "create_time": "2026-01-01T00:00:00Z",
+  "modify_time": "2026-01-02T00:00:00Z",
+  "team_id": "team-abc",
+  "api_key_id": "key-xyz",
+  "acls": ["api-key:model:*", "api-key:endpoint:*"]
+}
+"""#
+
+run("parse xAI api-key: team_id, acls, redacted key") {
+    let info = try! XAIUsageFetcher.parseApiKey(fixtureXaiApiKey.data(using: .utf8)!)
+    expectEqual(info.teamId, "team-abc")
+    expectEqual(info.acls.count, 2)
+    expectEqual(info.redactedKey, "xai-****b14o")
+    expectEqual(info.name, "prod key")
+}
+
+// GET /v1/language-models — models[] with token prices.
+let fixtureXaiModels = #"""
+{
+  "models": [
+    {"id": "grok-4.5", "prompt_text_token_price": 3000, "completion_text_token_price": 15000},
+    {"id": "grok-4.20", "prompt_text_token_price": 5000, "completion_text_token_price": 25000}
+  ]
+}
+"""#
+
+run("parse xAI language-models catalogue") {
+    let models = try! XAIUsageFetcher.parseLanguageModels(fixtureXaiModels.data(using: .utf8)!)
+    expectEqual(models.count, 2)
+    expectEqual(models[0].id, "grok-4.5")
+    expectEqual(models[0].promptTokenPrice, 3000)
+    expectEqual(models[1].completionTokenPrice, 25000)
+}
+
+run("parse xAI language-models tolerates data[] wrapper") {
+    let bytes = #"{"data": [{"id": "grok-4.5"}]}"#.data(using: .utf8)!
+    let models = try! XAIUsageFetcher.parseLanguageModels(bytes)
+    expectEqual(models.count, 1)
+    expectEqual(models[0].id, "grok-4.5")
+}
+
+// Prepaid balance — total.val is a STRING-encoded int64 in USD CENTS, and is
+// NEGATIVE when credit remains. Verified against xAI's OpenAPI schema.
+let fixtureXaiBalanceCredit = #"""
+{
+  "changes": [],
+  "total": { "val": "-12345" }
+}
+"""#
+
+run("parse xAI balance: negative cents = remaining credit") {
+    let balance = try! XAIUsageFetcher.parseBalance(fixtureXaiBalanceCredit.data(using: .utf8)!)
+    expectEqual(balance.totalValRaw, -12345)
+    // -12345 cents credit => 123.45 USD remaining.
+    expect(abs(balance.remainingUSD - 123.45) < 0.001)
+}
+
+run("parse xAI balance: zero or positive val = depleted (clamped to 0)") {
+    let zero = try! XAIUsageFetcher.parseBalance(#"{"total": {"val": "0"}}"#.data(using: .utf8)!)
+    expectEqual(zero.remainingUSD, 0.0)
+    let positive = try! XAIUsageFetcher.parseBalance(#"{"total": {"val": "500"}}"#.data(using: .utf8)!)
+    expectEqual(positive.remainingUSD, 0.0)   // no remaining prepaid credit
+}
+
+run("parse xAI balance throws when total.val missing") {
+    do {
+        _ = try XAIUsageFetcher.parseBalance(#"{"total": {}}"#.data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("parse xAI usage daily buckets (dollar and cents forms)") {
+    let bytes = #"""
+    {"usage": [
+      {"date": "2026-07-10", "usd": 1.50},
+      {"date": "2026-07-11", "usd_cents": 275}
+    ]}
+    """#.data(using: .utf8)!
+    let daily = try! XAIUsageFetcher.parseUsage(bytes)
+    expectEqual(daily.count, 2)
+    expect(abs(daily[0].usdSpent - 1.50) < 0.001)
+    expect(abs(daily[1].usdSpent - 2.75) < 0.001)  // 275 cents
+}
+
+run("parse xAI api-key throws on array top-level") {
+    do {
+        _ = try XAIUsageFetcher.parseApiKey("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - XAIUsageStore (in-memory credentials + stubbed transport)
+
+final class StubXAITransport: XAIUsageTransport, @unchecked Sendable {
+    let result: XAIUsageResult
+    init(_ result: XAIUsageResult) { self.result = result }
+    func fetchAll(inferenceKey: String, managementKey: String?, completion: @escaping @Sendable (XAIUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "xai-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.xai.enabled")
+
+    run("xAI store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("xAI enabled without inference key emits needsAccess card") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("xAI two-key management: hasInferenceKey and hasManagementKey") {
+        let creds = InMemoryCredentialStore()
+        let store = XAIUsageStore(credentials: creds, transport: StubXAITransport(.networkError), defaults: defaults)
+        expectEqual(store.hasInferenceKey, false)
+        expectEqual(store.hasManagementKey, false)
+        store.saveInferenceKey("xai-inference")
+        store.saveManagementKey("xai-mgmt-secret")
+        expectEqual(store.hasInferenceKey, true)
+        expectEqual(store.hasManagementKey, true)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("xAI Tier 1 only: plan tile, no balance tile") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-inference")
+        var snap = XAIUsageSnapshot()
+        snap.apiKeyInfo = XAIApiKeyInfo(teamId: "team-abc", acls: ["api-key:model:*"], redactedKey: "xai-****b14o")
+        store.apply(.success(snap))
+        let tiles = store.tiles
+        expect(tiles.contains { $0.id == "xai-plan" })
+        expect(!tiles.contains { $0.id == "xai-balance" })
+    }
+
+    run("xAI Tier 2: balance tile from negative-cents credit") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-inference")
+        var snap = XAIUsageSnapshot()
+        snap.apiKeyInfo = XAIApiKeyInfo(teamId: "team-abc")
+        snap.balance = XAIBalance(totalValRaw: -12345, currency: "USD")
+        store.apply(.success(snap))
+        let balanceTile = store.tiles.first { $0.id == "xai-balance" }
+        expect(balanceTile != nil)
+        if case let .balance(minor, currency, _, _) = balanceTile?.kind {
+            expectEqual(minor, 12345)   // 123.45 USD => 12345 minor units
+            expectEqual(currency, "USD")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("xAI 401 maps to invalid-key error") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.unauthorized), defaults: defaults)
+        store.saveInferenceKey("xai-bad")
+        store.fetch()
+        expectEqual(store.errorMessage, "Invalid xAI API key")
+    }
+
+    run("xAI clear deletes both keys") {
+        let creds = InMemoryCredentialStore()
+        let store = XAIUsageStore(credentials: creds, transport: StubXAITransport(.networkError), defaults: defaults)
+        store.saveInferenceKey("xai-i"); store.saveManagementKey("xai-mgmt-m")
+        store.clear()
+        expectEqual(store.hasInferenceKey, false)
+        expectEqual(store.hasManagementKey, false)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import ClaudeUsageBar
+import SQLite3
 
 // MARK: - Minimal assertion API
 
@@ -3207,6 +3208,639 @@ MainActor.assumeIsolated {
     }
 
     defaults.removePersistentDomain(forName: suiteName)
+}
+
+// MARK: - SQLiteReader — mandatory 7-scenario matrix (PR 10a)
+
+// Shared helper: run `sqlite3` CLI to build a fixture database.
+func runSqliteCLI(dbPath: String, sql: String) -> Bool {
+    let p = Process()
+    p.launchPath = "/usr/bin/sqlite3"
+    p.arguments = [dbPath]
+    let stdin = Pipe()
+    p.standardInput = stdin
+    p.standardOutput = Pipe()
+    p.standardError = Pipe()
+    do {
+        try p.run()
+        stdin.fileHandleForWriting.write(sql.data(using: .utf8) ?? Data())
+        try? stdin.fileHandleForWriting.close()
+        p.waitUntilExit()
+        return p.terminationStatus == 0
+    } catch {
+        return false
+    }
+}
+
+// Shared helper: temp directory unique per test invocation. The whole
+// directory tree is removed on function exit.
+func withTempDir(_ body: (String) throws -> Void) rethrows {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("clud-sqlite-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try body(dir.path)
+}
+
+// Scenario 1 — no-WAL: default rollback journal. Baseline case.
+run("SQLiteReader scenario 1: no-WAL database opens and reads") {
+    withTempDir { dir in
+        let db = dir + "/no-wal.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE t(k TEXT PRIMARY KEY, v INTEGER);
+            INSERT INTO t VALUES('a', 1), ('b', 2), ('c', 3);
+            """))
+        do {
+            let reader = try SQLiteReader(path: db)
+            let rows: [(String, Int64)] = try reader.query("SELECT k, v FROM t ORDER BY k") { row in
+                guard let k = row.string("k"), let v = row.int("v") else { return nil }
+                return (k, v)
+            }
+            expectEqual(rows.count, 3)
+            expectEqual(rows[0].0, "a"); expectEqual(rows[0].1, 1)
+        } catch {
+            expect(false, "no-WAL read threw: \(error)")
+        }
+    }
+}
+
+// Scenario 2 — hot-WAL: WAL mode enabled, uncommitted changes in the WAL
+// sidecar. SQLite in read-only mode with a hot WAL is a documented edge
+// case (see sqlite.org/wal.html §7). Our reader must not choke on the
+// -wal / -shm sidecars.
+run("SQLiteReader scenario 2: hot-WAL database with sidecar files") {
+    withTempDir { dir in
+        let db = dir + "/hot-wal.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE t(k TEXT PRIMARY KEY, v INTEGER);
+            INSERT INTO t VALUES('a', 1), ('b', 2);
+            """))
+        // Confirm the sidecars exist (WAL doesn't kick in until a page
+        // has been evicted, so INSERT + `.quit` may or may not leave a
+        // WAL — either way our reader must succeed).
+        do {
+            let reader = try SQLiteReader(path: db)
+            let count: [Int64] = try reader.query("SELECT COUNT(*) AS c FROM t") { row in
+                row.int("c")
+            }
+            expectEqual(count.first, 2)
+        } catch {
+            expect(false, "hot-WAL read threw: \(error)")
+        }
+    }
+}
+
+// Scenario 3 — sidecar-perms-denied: WAL sidecar exists but is
+// unreadable. VS Code has been observed writing WAL sidecars owned by
+// root when it starts as root after a system update; our reader should
+// still open the main file (SQLite falls back to reading from the
+// non-WAL pages) OR raise .openFailed cleanly — either is acceptable.
+run("SQLiteReader scenario 3: WAL sidecar with restricted permissions") {
+    withTempDir { dir in
+        let db = dir + "/sidecar-denied.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE t(k TEXT PRIMARY KEY, v INTEGER);
+            INSERT INTO t VALUES('a', 1);
+            """))
+        // If the sidecar didn't materialise, create one artificially so
+        // we can chmod it. Empty is fine — SQLite reads the header
+        // regardless.
+        let walSidecar = db + "-wal"
+        if !FileManager.default.fileExists(atPath: walSidecar) {
+            FileManager.default.createFile(atPath: walSidecar, contents: Data(), attributes: nil)
+        }
+        // Strip read permission from the WAL sidecar.
+        _ = try? FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: walSidecar)
+        defer { _ = try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: walSidecar) }
+        // The reader must NOT crash. Either result is acceptable — the
+        // invariant is that opening a database with a denied WAL sidecar
+        // is a well-defined outcome, not a UB scenario.
+        do {
+            let reader = try SQLiteReader(path: db)
+            let _: [Int64] = try reader.query("SELECT v FROM t LIMIT 1") { row in row.int("v") }
+            expect(true)
+        } catch is SQLiteReaderError {
+            expect(true)  // clean throw is fine
+        } catch {
+            expect(false, "unexpected error class: \(error)")
+        }
+    }
+}
+
+// Scenario 4 — SQLITE_BUSY: a concurrent writer holds an EXCLUSIVE lock
+// longer than our busy timeout. Codex round-1 finding #9: the previous
+// test never actually contended the DB, so a regression that dropped
+// the busy_timeout would still pass. This test forks a background
+// sqlite3 CLI process holding a BEGIN EXCLUSIVE for 8s (past the 5s
+// timeout), then attempts a read and asserts .busy is raised.
+run("SQLiteReader scenario 4: SQLITE_BUSY under real concurrent write lock") {
+    withTempDir { dir in
+        let db = dir + "/busy.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE t(k TEXT PRIMARY KEY, v INTEGER);
+            INSERT INTO t VALUES('a', 1);
+            """))
+        // Spawn a subprocess that holds an EXCLUSIVE lock for 8s. The
+        // reader's busy_timeout is 5s, so the read must time out and
+        // surface either .busy or an sqlError with an SQLITE_BUSY code.
+        let holder = Process()
+        holder.launchPath = "/usr/bin/sqlite3"
+        holder.arguments = [db]
+        let holderIn = Pipe()
+        holder.standardInput = holderIn
+        holder.standardOutput = Pipe()
+        holder.standardError = Pipe()
+        do {
+            try holder.run()
+        } catch {
+            expect(false, "could not spawn sqlite3 subprocess")
+            return
+        }
+        // Ask the subprocess to grab an EXCLUSIVE lock, then sleep.
+        // Timeout is 8s so the lock is held past our 5s busy_timeout.
+        let lockScript = """
+            PRAGMA busy_timeout=0;
+            BEGIN EXCLUSIVE;
+            SELECT strftime('%s','now');
+            .system sleep 8
+            COMMIT;
+            .quit
+            """
+        holderIn.fileHandleForWriting.write(lockScript.data(using: .utf8) ?? Data())
+        // Small delay so the subprocess has time to actually acquire the
+        // lock before we probe.
+        Thread.sleep(forTimeInterval: 0.3)
+        // Now attempt a read. The busy timeout is 5s; the subprocess
+        // holds the lock for ~8s. Reader must fail cleanly (not hang or
+        // crash) within a bounded time.
+        do {
+            let reader = try SQLiteReader(path: db)
+            let start = Date()
+            do {
+                let _: [Int64] = try reader.query("SELECT v FROM t") { row in row.int("v") }
+                let elapsed = Date().timeIntervalSince(start)
+                // Some SQLite builds may complete the read via the WAL/
+                // snapshot even under an exclusive lock — that's fine,
+                // just assert the read didn't hang past the busy timeout.
+                expect(elapsed < 7.0, "read took \(elapsed)s, expected < 7s (unbounded busy timeout regressed?)")
+            } catch SQLiteReaderError.busy {
+                let elapsed = Date().timeIntervalSince(start)
+                // .busy is the expected result — but must not have
+                // taken longer than the busy timeout to raise.
+                expect(elapsed < 7.0, "busy took \(elapsed)s, expected < 7s")
+            } catch let SQLiteReaderError.sqlError(rc, _) {
+                // Some contention paths surface as sqlError(SQLITE_BUSY)
+                // if a nested WAL condition raises before our translation
+                // step catches SQLITE_BUSY. Accept it as long as the
+                // code is a lock-family error.
+                expect(rc == SQLITE_BUSY || rc == SQLITE_LOCKED,
+                       "expected SQLITE_BUSY/LOCKED, got rc \(rc)")
+            }
+        } catch {
+            expect(false, "reader init threw unexpectedly: \(error)")
+        }
+        // Clean up the subprocess.
+        holder.terminate()
+        holder.waitUntilExit()
+    }
+}
+
+// Scenario 5 — schema-migrated: an app updated its schema between our
+// releases. Our schema-sentinel guard must throw .schemaMismatch, and
+// the throw must include both observed and expected values in the
+// message so the user knows to update ClaudeUsageBar.
+run("SQLiteReader scenario 5: schema drift caught by sentinel") {
+    withTempDir { dir in
+        let db = dir + "/schema.db"
+        // The app under observation ships version "2.0" today. We ship
+        // ClaudeUsageBar against "1.0". Sentinel must fire.
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE meta(k TEXT PRIMARY KEY, v TEXT);
+            INSERT INTO meta VALUES('schema_version', '2.0');
+            CREATE TABLE t(k TEXT, v INTEGER);
+            """))
+        let sentinel = SQLiteSchemaSentinel(
+            table: "meta", keyColumn: "k",
+            key: "schema_version", valueColumn: "v",
+            expected: "1.0"
+        )
+        do {
+            _ = try SQLiteReader(path: db, sentinel: sentinel)
+            expect(false, "sentinel should have thrown")
+        } catch let SQLiteReaderError.schemaMismatch(observed, expected) {
+            expectEqual(observed, "2.0")
+            expectEqual(expected, "1.0")
+        } catch {
+            expect(false, "wrong error type: \(error)")
+        }
+    }
+}
+
+// Scenario 5b — sentinel matches → open succeeds.
+run("SQLiteReader scenario 5b: matching sentinel opens successfully") {
+    withTempDir { dir in
+        let db = dir + "/schema-ok.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE meta(k TEXT PRIMARY KEY, v TEXT);
+            INSERT INTO meta VALUES('schema_version', '1.0');
+            """))
+        let sentinel = SQLiteSchemaSentinel(
+            table: "meta", keyColumn: "k",
+            key: "schema_version", valueColumn: "v",
+            expected: "1.0"
+        )
+        do {
+            _ = try SQLiteReader(path: db, sentinel: sentinel)
+            expect(true)
+        } catch {
+            expect(false, "matching sentinel should have opened: \(error)")
+        }
+    }
+}
+
+// Scenario 6 — SQLITE_NOTADB: file exists but isn't SQLite. VS Code
+// state files have been observed corrupted this way after abrupt
+// shutdowns.
+run("SQLiteReader scenario 6: SQLITE_NOTADB raised as .notADatabase") {
+    withTempDir { dir in
+        let path = dir + "/junk.db"
+        // 32 bytes of ASCII printable — not the SQLite magic header.
+        FileManager.default.createFile(atPath: path, contents: Data("this is not a sqlite database!!!".utf8), attributes: nil)
+        do {
+            _ = try SQLiteReader(path: path)
+            expect(false, "expected .notADatabase")
+        } catch SQLiteReaderError.notADatabase {
+            expect(true)
+        } catch {
+            expect(false, "wrong error: \(error)")
+        }
+    }
+}
+
+// Scenario 7 — SQLCipher-encrypted: header is random bytes, not the
+// SQLite magic. We surface .encrypted rather than letting sqlite3 emit
+// a misleading "file is not a database" error.
+run("SQLiteReader scenario 7: SQLCipher-encrypted database → .encrypted") {
+    withTempDir { dir in
+        let path = dir + "/encrypted.db"
+        // 16 random-looking bytes (chosen manually to be non-printable —
+        // matches the encrypted-header heuristic).
+        var bytes = Data(count: 16)
+        bytes.withUnsafeMutableBytes { buf in
+            let raw = buf.bindMemory(to: UInt8.self)
+            for i in 0 ..< 16 { raw[i] = UInt8((i * 47 + 13) & 0xFF) | 0x80 }
+        }
+        FileManager.default.createFile(atPath: path, contents: bytes, attributes: nil)
+        do {
+            _ = try SQLiteReader(path: path)
+            expect(false, "expected .encrypted")
+        } catch SQLiteReaderError.encrypted {
+            expect(true)
+        } catch {
+            expect(false, "wrong error: \(error)")
+        }
+    }
+}
+
+// Additional coverage — .notFound must be distinct from .openFailed so
+// the UI can render "app not installed" vs "grant Full Disk Access".
+run("SQLiteReader: missing path throws .notFound") {
+    do {
+        _ = try SQLiteReader(path: "/tmp/this/path/does/not/exist-\(UUID().uuidString).db")
+        expect(false, "expected .notFound")
+    } catch SQLiteReaderError.notFound {
+        expect(true)
+    } catch {
+        expect(false, "wrong error: \(error)")
+    }
+}
+
+// Additional — query_only enforcement. Even against a read-only file,
+// query_only must reject a write attempt with a clean error.
+run("SQLiteReader: query_only=1 rejects mutating statements") {
+    withTempDir { dir in
+        let db = dir + "/ro.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE t(k INTEGER);
+            INSERT INTO t VALUES(1);
+            """))
+        do {
+            let reader = try SQLiteReader(path: db)
+            let _: [Int64] = try reader.query("INSERT INTO t VALUES(2)") { row in
+                row.int("k")
+            }
+            expect(false, "INSERT should have thrown")
+        } catch is SQLiteReaderError {
+            expect(true)
+        } catch {
+            expect(false, "wrong error class: \(error)")
+        }
+    }
+}
+
+// Additional — parameterised binds are actually bound, not interpolated.
+run("SQLiteReader: binds are typed and cannot inject via string") {
+    withTempDir { dir in
+        let db = dir + "/binds.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE t(k TEXT PRIMARY KEY, v INTEGER);
+            INSERT INTO t VALUES('a', 1), ('b', 2);
+            """))
+        let reader = try? SQLiteReader(path: db)
+        expect(reader != nil)
+        // A hostile key like "a' OR '1'='1" must NOT match every row.
+        let rows: [Int64]? = try? reader?.query(
+            "SELECT v FROM t WHERE k = ?",
+            binds: [.text("a' OR '1'='1")]
+        ) { $0.int("v") }
+        expectEqual(rows?.count, 0)
+    }
+}
+
+// MARK: - FileWatcher tests (PR 10a)
+
+// Shared thread-safe event collector — Codex round-1 finding #10:
+// event/count arrays touched by watcher callbacks (on the private queue)
+// AND by test assertions (on main) must have a consistent locking
+// discipline. This wraps that up.
+final class WatcherEventBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [FileWatcherEvent] = []
+    func append(_ ev: FileWatcherEvent) {
+        lock.lock(); defer { lock.unlock() }
+        events.append(ev)
+    }
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return events.count
+    }
+    var snapshot: [FileWatcherEvent] {
+        lock.lock(); defer { lock.unlock() }
+        return events
+    }
+}
+
+run("FileWatcher: poll fallback fires when a file is created") {
+    withTempDir { dir in
+        let watcher = FileWatcher(paths: [dir], backend: .pollOnly(interval: 1.0))
+        let box = WatcherEventBox()
+        watcher.start { ev in box.append(ev) }
+        // Wait for the initial synthetic event.
+        let initDeadline = Date().addingTimeInterval(2.0)
+        while box.count == 0 && Date() < initDeadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        expect(box.count >= 1)
+        expectEqual(box.snapshot.first?.isInitial, true)
+        // Create a new file — the next poll tick should include it.
+        FileManager.default.createFile(atPath: dir + "/new.txt",
+                                       contents: Data("hi".utf8), attributes: nil)
+        let deadline = Date().addingTimeInterval(4.0)
+        while box.count < 2 && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        expect(box.count >= 2)
+        let changePaths = box.snapshot.dropFirst().flatMap { $0.paths }
+        expect(changePaths.contains { $0.hasSuffix("new.txt") })
+        watcher.stop()
+    }
+}
+
+// Codex round-1 finding #11: the actually-critical race is a file
+// created BETWEEN start() and the first tick. Baseline capture is
+// synchronous now; this test proves it.
+run("FileWatcher: file created immediately after start() is detected on first tick (baseline race)") {
+    withTempDir { dir in
+        let watcher = FileWatcher(paths: [dir], backend: .pollOnly(interval: 1.0))
+        let box = WatcherEventBox()
+        watcher.start { ev in box.append(ev) }
+        // No wait — create the file BEFORE the first poll tick fires.
+        // If baseline is captured async, the file lands in baseline AND
+        // in every subsequent snapshot, and the diff misses it entirely.
+        FileManager.default.createFile(atPath: dir + "/race.txt",
+                                       contents: Data("hi".utf8), attributes: nil)
+        // Wait long enough for the initial event + one poll tick.
+        let deadline = Date().addingTimeInterval(3.0)
+        while box.count < 2 && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        expect(box.count >= 2, "poll tick must detect a file created immediately after start()")
+        let changePaths = box.snapshot.dropFirst().flatMap { $0.paths }
+        expect(changePaths.contains { $0.hasSuffix("race.txt") },
+               "created file must appear in a change event")
+        watcher.stop()
+    }
+}
+
+run("FileWatcher: stop() is idempotent") {
+    let watcher = FileWatcher(paths: ["/tmp"], backend: .pollOnly(interval: 1.0))
+    watcher.start { _ in }
+    watcher.stop()
+    watcher.stop()  // must not crash
+    watcher.stop()
+    expect(true)
+}
+
+// Codex round-1 finding #4: stop() + start() reuses the same watcher.
+// Stale ticks from the first start() must not fire against the second.
+run("FileWatcher: stop then start again drops stale ticks (generation guard)") {
+    withTempDir { dir in
+        let watcher = FileWatcher(paths: [dir], backend: .pollOnly(interval: 1.0))
+        let box1 = WatcherEventBox()
+        watcher.start { ev in box1.append(ev) }
+        // Wait for the initial event of run 1.
+        let d1 = Date().addingTimeInterval(1.0)
+        while box1.count == 0 && Date() < d1 {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        watcher.stop()
+        // Start again with a different callback.
+        let box2 = WatcherEventBox()
+        watcher.start { ev in box2.append(ev) }
+        // Any stale tick from run 1 would fire on `box1` — which we
+        // check stayed at exactly 1 (the initial event only). Meanwhile
+        // box2 should receive its own initial event.
+        let d2 = Date().addingTimeInterval(2.0)
+        while box2.count == 0 && Date() < d2 {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(box2.count >= 1, "second start must fire its own initial")
+        // Critical assertion: box1 never received more events after stop.
+        expectEqual(box1.count, 1)
+        watcher.stop()
+    }
+}
+
+run("FileWatcher: empty paths list starts without crashing (pollOnly)") {
+    let watcher = FileWatcher(paths: [], backend: .pollOnly(interval: 1.0))
+    let box = WatcherEventBox()
+    watcher.start { ev in box.append(ev) }
+    let deadline = Date().addingTimeInterval(0.5)
+    while box.count == 0 && Date() < deadline {
+        RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+    }
+    expect(box.count >= 1)
+    watcher.stop()
+}
+
+run("FileWatcher: interval clamped to at least 1s (0 or negative would busy-loop)") {
+    let watcher = FileWatcher(paths: [], backend: .pollOnly(interval: 0))
+    let box = WatcherEventBox()
+    watcher.start { ev in box.append(ev) }
+    let deadline = Date().addingTimeInterval(0.3)
+    while Date() < deadline {
+        RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+    }
+    watcher.stop()
+    // With a 1s minimum interval, we should have at most 1 fire in 300ms
+    // (the initial synthetic). Anything much higher means the clamp
+    // regressed.
+    expect(box.count <= 2, "unexpected fire count \(box.count) — interval clamp may have regressed")
+}
+
+// MARK: - TCCProbe tests (PR 10a)
+
+run("TCCProbe: probes a missing path as .pathMissing") {
+    let state = TCCProbe.probe(path: "/tmp/tcc-missing-\(UUID().uuidString)")
+    expectEqual(state, .pathMissing)
+}
+
+run("TCCProbe: probes a readable directory as .granted") {
+    withTempDir { dir in
+        let state = TCCProbe.probe(path: dir)
+        expectEqual(state, .granted)
+    }
+}
+
+run("TCCProbe: probes a readable file as .granted") {
+    withTempDir { dir in
+        let file = dir + "/x.txt"
+        FileManager.default.createFile(atPath: file, contents: Data("hi".utf8), attributes: nil)
+        let state = TCCProbe.probe(path: file)
+        expectEqual(state, .granted)
+    }
+}
+
+run("TCCProbe: probes a mode-0 file as .denied") {
+    withTempDir { dir in
+        let file = dir + "/locked.txt"
+        FileManager.default.createFile(atPath: file, contents: Data("nope".utf8), attributes: nil)
+        _ = try? FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: file)
+        defer { _ = try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file) }
+        let state = TCCProbe.probe(path: file)
+        expectEqual(state, .denied)
+    }
+}
+
+// MARK: - LocalProviderAccessGuide copy tests (PR 10a)
+
+run("LocalProviderAccessGuide: copy varies by state and names the target app") {
+    for state in [TCCState.granted, .denied, .pathMissing] {
+        let copy = LocalProviderAccessGuide.copy(for: state, appName: "Claude Code")
+        expect(copy.title.contains("Claude Code"), "title missed app name for \(state)")
+        expect(!copy.guidance.isEmpty)
+        if state != .granted {
+            let names = copy.guidance.contains("System Settings") ||
+                        copy.guidance.contains("launch") ||
+                        copy.guidance.contains("Refresh")
+            expect(names, "guidance for \(state) missed the action pointer")
+        }
+    }
+}
+
+// Codex round-1 finding #5: pathMissing must NOT be returned when the
+// containing directory is itself unreadable. Add a directed test.
+run("TCCProbe: unreadable containing directory promotes 'missing' to '.denied'") {
+    withTempDir { dir in
+        // Create a subdirectory with mode 0 — enumeration is denied.
+        let sub = dir + "/locked-parent"
+        try? FileManager.default.createDirectory(atPath: sub, withIntermediateDirectories: false, attributes: nil)
+        _ = try? FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: sub)
+        defer { _ = try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sub) }
+        // Probe a hypothetical file INSIDE the locked directory. The
+        // file doesn't exist, but the parent isn't readable, so we
+        // must NOT return .pathMissing.
+        let state = TCCProbe.probe(path: sub + "/some-file.txt")
+        expectEqual(state, .denied)
+    }
+}
+
+// Codex round-1 finding #7: SQL identifier validation. Sentinel with a
+// hostile identifier must be rejected at init, not silently interpolated.
+run("SQLiteReader: sentinel with hostile identifier throws sqlError") {
+    withTempDir { dir in
+        let db = dir + "/inject.db"
+        expect(runSqliteCLI(dbPath: db, sql: """
+            CREATE TABLE meta(k TEXT PRIMARY KEY, v TEXT);
+            INSERT INTO meta VALUES('schema_version', '1.0');
+            """))
+        // A caller passing a table name like "meta; DROP TABLE meta; --"
+        // would break the sentinel query; assertIsValidIdentifier must
+        // reject it before it reaches SQL.
+        let evil = SQLiteSchemaSentinel(
+            table: "meta; DROP TABLE meta; --", keyColumn: "k",
+            key: "schema_version", valueColumn: "v", expected: "1.0"
+        )
+        do {
+            _ = try SQLiteReader(path: db, sentinel: evil)
+            expect(false, "sentinel with hostile identifier should have thrown")
+        } catch is SQLiteReaderError {
+            expect(true)
+        } catch {
+            expect(false, "wrong error class: \(error)")
+        }
+    }
+}
+
+run("SQLiteReader.assertIsValidIdentifier: accepts letters/digits/underscore; rejects the rest") {
+    // Valid identifiers must not throw.
+    for name in ["t", "T", "table1", "_x", "abc_def_123"] {
+        do { try SQLiteReader.assertIsValidIdentifier(name) } catch {
+            expect(false, "\(name) should be valid: \(error)")
+        }
+    }
+    // Invalid identifiers must throw. Codex round-2 nit: unicode letters
+    // are NOT accepted — strict ASCII contract.
+    for name in ["", "1abc", "a-b", "a b", "a;b", "a'b", "\"a\"", String(repeating: "x", count: 128), "café", "𝓉ℯ𝓈𝓉"] {
+        do {
+            try SQLiteReader.assertIsValidIdentifier(name)
+            expect(false, "\(name) should have thrown")
+        } catch is SQLiteReaderError {
+            expect(true)
+        } catch {
+            expect(false, "wrong error class for \(name): \(error)")
+        }
+    }
+}
+
+// Codex round-2 finding #2: re-entrant lifecycle from within a callback
+// used to deadlock. runSerial now detects "on the queue" and runs inline.
+run("FileWatcher: stop() called from inside onChange does NOT deadlock (Codex round-2 #2)") {
+    withTempDir { dir in
+        let watcher = FileWatcher(paths: [dir], backend: .pollOnly(interval: 1.0))
+        let done = DispatchSemaphore(value: 0)
+        // Wrap the stop call so we can observe whether it returned.
+        watcher.start { ev in
+            if ev.isInitial {
+                // Call stop from within the callback. Old code would
+                // deadlock here because start() itself grabbed queue.sync
+                // and stop() would nested-sync into the same queue.
+                watcher.stop()
+                done.signal()
+            }
+        }
+        // Wait bounded — a deadlock would fail the test via timeout.
+        let outcome = done.wait(timeout: .now() + 2.0)
+        expect(outcome == .success, "stop() from inside onChange appears to have deadlocked")
+    }
+}
+
+run("LocalProviderAccessGuide: full-disk-access deep link URL is well-formed") {
+    let url = LocalProviderAccessGuide.fullDiskAccessURL
+    expectEqual(url.scheme, "x-apple.systempreferences")
+    expect(url.absoluteString.contains("Privacy_AllFiles"))
 }
 
 // MARK: - Summary

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -690,6 +690,56 @@ run("ProviderCopy: OpenAI help + admin-key disclosure") {
     expect(disc?.contains("cannot make inference") == true)
 }
 
+run("ProviderCopy: Perplexity help names the cookie, Keychain, and multiple paste forms (PR 8-UI)") {
+    // The user needs to know exactly which cookie to copy from DevTools;
+    // the guidance MUST name it verbatim so a search inside the browser's
+    // cookie inspector finds it. It also must mention the paste flexibility
+    // (bare value, name=value, or full Cookie header) or valid pastes will
+    // look wrong to the user.
+    let help = ProviderCopy.help(for: "perplexity")
+    expect(help != nil)
+    expect(help?.contains("__Secure-next-auth.session-token") == true)
+    expect(help?.contains("perplexity.ai") == true)
+    expect(help?.contains("Keychain") == true)
+    // At least one of the four Perplexity modes is named so the user knows
+    // what they'll see once configured.
+    expect(help?.contains("Pro Search") == true || help?.contains("Deep Research") == true)
+    // Codex adversarial review #5: copy softened from "Shows" to "Can show"
+    // so we do not over-promise tiles that may be Cloudflare-challenged.
+    expect(help?.contains("Can show") == true || help?.contains("When available") == true)
+    // Codex adversarial review #4: paste flexibility must be documented.
+    expect(help?.contains("name=value") == true || help?.contains("Cookie header") == true || help?.contains("bare") == true)
+}
+
+run("ProviderCopy: Perplexity disclosure warns about undocumented API and cookie power") {
+    // The Perplexity cookie is a spending credential AND the endpoints are
+    // undocumented — both facts must be surfaced before the user pastes.
+    // Codex adversarial review #1: the disclosure must not under-state the
+    // cookie's authority ("Sonar credits" alone is too narrow — it is a
+    // full web session cookie). #2: the revocation promise must be
+    // conditional, not absolute.
+    let disc = ProviderCopy.disclosure(for: "perplexity")
+    expect(disc != nil)
+    expect(disc?.contains("private") == true || disc?.contains("undocumented") == true || disc?.contains("may stop") == true)
+    // Framed as a full session cookie, not just a Sonar-credit token.
+    expect(disc?.contains("session cookie") == true || disc?.contains("act as your signed-in account") == true)
+    // Revocation described conditionally, not absolutely.
+    expect(disc?.contains("until it expires") == true || disc?.contains("revoked") == true)
+}
+
+run("PasteKeyProvider.secretKindNoun defaults to Key and Perplexity overrides to Cookie") {
+    // Codex adversarial review #3: the generic Settings row would have
+    // said "Key saved in Keychain" even for Perplexity's cookie paste.
+    // The optional secretKindNoun on PasteKeyProvider lets a provider
+    // rename that noun without any downstream code change.
+    MainActor.assumeIsolated {
+        let deepseek = DeepSeekUsageStore(credentials: InMemoryCredentialStore())
+        let perplexity = PerplexityUsageStore(credentials: InMemoryCredentialStore())
+        expectEqual((deepseek as PasteKeyProvider).secretKindNoun, "Key")
+        expectEqual((perplexity as PasteKeyProvider).secretKindNoun, "Cookie")
+    }
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
@@ -1787,6 +1837,33 @@ run("Perplexity cookie: paste with `;` but no supported session cookie → nil (
     // whole blob as a token.
     let raw = "_ga=1; theme=dark"
     expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+run("Perplexity cookie: strips a leading Cookie: header prefix (PR 8-UI Codex round 2)") {
+    // Browsers' "Copy request headers" often prefixes the line with "Cookie:".
+    // The extractor must tolerate that so pasted HAR fragments still work
+    // — matching what the Perplexity ProviderCopy help text now promises.
+    let raw = "Cookie: __Secure-next-auth.session-token=HEADERTOK; _ga=1"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "HEADERTOK")
+}
+
+run("Perplexity cookie: strips a case-varied cookie: prefix and extra whitespace") {
+    let raw = "  cookie:   __Secure-next-auth.session-token=WSTOK  "
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "WSTOK")
+}
+
+run("Perplexity cookie: strips a MiXeD-case Cookie: prefix (PR 8-UI Codex round 3)") {
+    // Codex round-3 caught that enumerating spellings ("Cookie:"/"cookie:"/"COOKIE:")
+    // let a MiXeD casing slip through the strip logic and fall into the
+    // bare-token fallback. The strip is now truly case-insensitive.
+    let raw = "CoOkIe: __Secure-next-auth.session-token=MIXTOK"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "MIXTOK")
 }
 
 // MARK: - PerplexityUsageFetcher.parseCredits

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2152,6 +2152,49 @@ MainActor.assumeIsolated {
         }
     }
 
+    run("Perplexity plan tile omitted when only subscription_source is present (chk1 Bug #3)") {
+        // subscription_source is the BILLING PROVIDER, not a plan name.
+        // Rendering "Stripe (active)" as the Perplexity plan tile misleads
+        // the user about their account state. The fix omits the tile
+        // entirely when subscription_tier is absent.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.settings = PerplexityUserSettings(
+            subscriptionStatus: "active",
+            subscriptionSource: "stripe",
+            subscriptionTier: nil    // no tier reported
+        )
+        store.apply(.success(snap))
+        expect(!store.tiles.contains { $0.id == "perplexity-plan" })
+    }
+
+    run("Perplexity plan tile omitted when subscription_tier is 'none' or empty") {
+        // Additional coverage: "none" and "" should not slip through and
+        // render as unknown-tier plan labels either.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        for badTier in ["none", "  none  ", "", "   "] {
+            var snap = PerplexityUsageSnapshot()
+            snap.settings = PerplexityUserSettings(subscriptionTier: badTier)
+            store.apply(.success(snap))
+            expect(!store.tiles.contains { $0.id == "perplexity-plan" }, "expected no plan tile for '\(badTier)'")
+        }
+    }
+
+    run("Perplexity fetch() on a locked keychain surfaces an unlock message (chk1 Bug #2)") {
+        // UnavailableCredentialStore reports `.unavailable` for readResult,
+        // so hasKey is true (round-2 fix) but a bare read() returns nil.
+        // Before the chk1 Bug #2 fix, fetch() collapsed .unavailable into
+        // .missing and cleared lastError silently. Now it distinguishes.
+        let store = PerplexityUsageStore(credentials: UnavailableCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, true)
+        store.fetch()
+        expect(store.errorMessage?.contains("Keychain") == true || store.errorMessage?.contains("Unlock") == true)
+        // Snapshot cleared, not stale-preserved.
+        expect(store.snapshot == nil)
+    }
+
     run("Perplexity credits tile carries USD cents + Max plan hint from large recurring grant") {
         let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
         store.saveKey("cookie")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -635,6 +635,35 @@ MainActor.assumeIsolated {
 
 // MARK: - ProviderCopy (Settings toggle copy — PR 3-UI)
 
+run("ProviderCopy id matches ClaudeCodeUsageStore.id — exercises the real Settings path (PR 10b-UI regression guard)") {
+    // Codex round-2 finding: a raw-string test locks in the wrong side
+    // of the contract. If either the store id or the ProviderCopy case
+    // drifts, ProviderToggleRow (which calls
+    // `ProviderCopy.help(for: box.id)` at
+    // app/ClaudeUsageBar.swift:2401) silently loses the row's help and
+    // disclosure. Read the store's OWN id so drift on either side is
+    // caught.
+    MainActor.assumeIsolated {
+        let store = ClaudeCodeUsageStore()
+        expect(ProviderCopy.help(for: store.id) != nil)
+        expect(ProviderCopy.disclosure(for: store.id) != nil)
+        // Also guard via ProviderBox — the wrapping layer between the
+        // store and the Settings row.
+        let box = ProviderBox(store)
+        expect(ProviderCopy.help(for: box.id) != nil)
+        expect(ProviderCopy.disclosure(for: box.id) != nil)
+    }
+    // Pin the literal too so any refactor of the store id must update
+    // both sides in lockstep.
+    expect(ProviderCopy.help(for: "claudeCode") != nil)
+    expect(ProviderCopy.disclosure(for: "claudeCode") != nil)
+    // Guard against near-miss casings that would still round-trip
+    // through Settings but drop the strings.
+    expect(ProviderCopy.help(for: "claude-code") == nil)
+    expect(ProviderCopy.help(for: "claudecode") == nil)
+    expect(ProviderCopy.help(for: "ClaudeCode") == nil)
+}
+
 run("ProviderCopy.help returns Codex copy and nil for unknown") {
     let codex = ProviderCopy.help(for: "codex")
     expect(codex != nil)
@@ -753,6 +782,41 @@ run("ProviderCopy: Copilot disclosure warns about classic PATs, expiry, and non-
     // Codex round-1 finding #1: revocation clarity.
     expect(disc?.contains("revoke") == true)
     expect(disc?.contains("github.com") == true)
+}
+
+run("ProviderCopy: Claude Code help names the JSONL path and 'nothing leaves your Mac' guarantee (PR 10b-UI)") {
+    // The user needs to know that (1) this reads a local file, (2) it
+    // reads Claude Code's OWN file — no key required, (3) costs are
+    // computed locally from a bundled snapshot, (4) NOTHING is
+    // transmitted. Any of these being unclear at Settings time is a
+    // trust hazard for a menu-bar app.
+    let help = ProviderCopy.help(for: "claudeCode")
+    expect(help != nil)
+    // Path is named verbatim so a user searching Finder / a shell can
+    // find it.
+    expect(help?.contains("~/.claude/projects") == true)
+    // The privacy guarantee must be stated explicitly.
+    expect(help?.contains("Nothing leaves your Mac") == true || help?.contains("nothing leaves your Mac") == true)
+    // No key / no sign-in — anticipates the user asking "what do I paste?".
+    expect(help?.contains("no key") == true || help?.contains("no sign-in") == true || help?.contains("No key") == true || help?.contains("No sign-in") == true)
+    // Cost method is disclosed — bundled snapshot of Anthropic rates.
+    expect(help?.contains("bundled snapshot") == true || help?.contains("Anthropic") == true)
+}
+
+run("ProviderCopy: Claude Code disclosure states 'estimate not receipt' + unpriced-model behaviour (PR 10b-UI)") {
+    // Costs are estimates. If we don't say so, a user could see $47 in
+    // the tile and be surprised when their Anthropic bill says $52. The
+    // disclosure must (1) explicitly call the numbers estimates, (2)
+    // clarify they are NOT a receipt from Anthropic, (3) explain the
+    // unpriced-model fallback so a new Claude release doesn't look like
+    // free tokens.
+    let disc = ProviderCopy.disclosure(for: "claudeCode")
+    expect(disc != nil)
+    expect(disc?.contains("estimate") == true || disc?.contains("Estimates") == true || disc?.contains("estimates") == true)
+    expect(disc?.contains("receipt") == true)
+    // The unpriced-fallback behaviour surfaced so the user is not
+    // confused when a new Claude release shows $0 despite heavy usage.
+    expect(disc?.contains("$0") == true || disc?.contains("Pricing update available") == true || disc?.contains("unpriced") == true)
 }
 
 run("ProviderCopy: Perplexity disclosure warns about undocumented API and cookie power") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1,0 +1,112 @@
+// PR 2a — assertion-based test runner.
+//
+// Runs with `swift run TestRunner` from the repo root. Works with
+// Command Line Tools alone; does not require Xcode.app / XCTest.
+// Prints one line per test and exits nonzero if any assertion fails.
+//
+// When Xcode.app is installed, this runner can be promoted to XCTest
+// or Apple's Testing framework without changing the assertion bodies.
+
+import Foundation
+import ClaudeUsageBar
+
+// MARK: - Minimal assertion API
+
+var failed = 0
+var total = 0
+
+func expect(_ condition: @autoclosure () -> Bool,
+            _ message: String = "",
+            file: StaticString = #file, line: UInt = #line) {
+    total += 1
+    if !condition() {
+        failed += 1
+        let where_ = "\(file):\(line)"
+        if message.isEmpty {
+            print("  FAIL  \(where_)")
+        } else {
+            print("  FAIL  \(where_) — \(message)")
+        }
+    }
+}
+
+func expectEqual<T: Equatable>(_ actual: T, _ expected: T,
+                                file: StaticString = #file, line: UInt = #line) {
+    expect(actual == expected,
+           "expected \(expected), got \(actual)",
+           file: file, line: line)
+}
+
+func run(_ name: String, _ body: () -> Void) {
+    let before = failed
+    body()
+    let outcome = failed == before ? "PASS" : "FAIL"
+    print("\(outcome)  \(name)")
+}
+
+// MARK: - LogValue tests
+
+run("LogValue.public emits verbatim") {
+    expectEqual(LogValue.public("HTTP 200").rendered, "HTTP 200")
+    expectEqual(LogValue.public("").rendered, "")
+    expectEqual(LogValue.public("emoji ✅ ok").rendered, "emoji ✅ ok")
+}
+
+run("LogValue.sensitive redacts to length only") {
+    expectEqual(LogValue.sensitive("abc").rendered, "<redacted: 3 chars>")
+    expectEqual(LogValue.sensitive("").rendered, "<redacted: 0 chars>")
+    expectEqual(LogValue.sensitive("sk-1234567890abcdef").rendered,
+                "<redacted: 19 chars>")
+}
+
+run("LogValue.sensitive never emits the raw value") {
+    let secret = "super-secret-cookie-value-that-must-not-leak"
+    let rendered = LogValue.sensitive(secret).rendered
+    expect(!rendered.contains(secret))
+    expect(!rendered.contains("super"))
+    expect(!rendered.contains("secret"))
+    expect(!rendered.contains("cookie"))
+}
+
+run("LogValue.identifier emits short SHA-256 prefix") {
+    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    expectEqual(LogValue.identifier("hello").rendered, "<id: 2cf24dba>")
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expectEqual(LogValue.identifier("").rendered, "<id: e3b0c442>")
+}
+
+run("LogValue.identifier is deterministic") {
+    let orgId = "8f2c3d1a-e5b9-4a01-9d3c-7e1f5b2c3d4a"
+    expectEqual(LogValue.identifier(orgId).rendered,
+                LogValue.identifier(orgId).rendered)
+}
+
+run("LogValue.identifier is not reversible to raw value") {
+    let orgId = "8f2c3d1a-e5b9-4a01-9d3c-7e1f5b2c3d4a"
+    let rendered = LogValue.identifier(orgId).rendered
+    expect(!rendered.contains(orgId))
+    expect(!rendered.contains("8f2c"))
+    expect(!rendered.contains("e5b9"))
+}
+
+run("LogValue.identifier distinguishes different inputs") {
+    let a = LogValue.identifier("org-a").rendered
+    let b = LogValue.identifier("org-b").rendered
+    expect(a != b)
+}
+
+run("LogValue.count emits numeric literal") {
+    expectEqual(LogValue.count(0).rendered, "0")
+    expectEqual(LogValue.count(42).rendered, "42")
+    expectEqual(LogValue.count(-1).rendered, "-1")
+    expectEqual(LogValue.count(823).rendered, "823")
+}
+
+// MARK: - Summary
+
+print("")
+print("\(total - failed)/\(total) checks passed")
+if failed > 0 {
+    print("\(failed) FAILED")
+    exit(1)
+}

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -803,6 +803,81 @@ run("ProviderCopy: Claude Code help names the JSONL path and 'nothing leaves you
     expect(help?.contains("bundled snapshot") == true || help?.contains("Anthropic") == true)
 }
 
+run("ProviderCopy: Cline help names every supported host + CLI env-vars + file + privacy (PR 10c-UI)") {
+    // Codex round-1 finding #2: assert EVERY supported host by name,
+    // not just three. If a copy edit drops Insiders or VSCodium the
+    // Settings text would no longer match the resolver's coverage.
+    let help = ProviderCopy.help(for: "cline")
+    expect(help != nil)
+    // The exact file — a Cline user Googling this cannot be steered
+    // to the wrong file.
+    expect(help?.contains("ui_messages.json") == true)
+    // The extension identifier the file lives under — pinning this
+    // guards against a Cline rename or a fork with a different id.
+    expect(help?.contains("saoudrizwan.claude-dev") == true)
+    // Every VS Code family host the resolver enumerates.
+    // Codex round-2 finding: `contains("VS Code")` matches "VS Code
+    // Insiders" too, so a copy edit that dropped VS Code stable but
+    // kept Insiders would still pass. Strip "VS Code Insiders" first,
+    // THEN check for a remaining "VS Code" occurrence — that proves
+    // the stable host is named separately.
+    let helpMinusInsiders = help?.replacingOccurrences(of: "VS Code Insiders", with: "")
+    expect(helpMinusInsiders?.contains("VS Code") == true, "must name VS Code stable specifically, not just via 'VS Code Insiders'")
+    expect(help?.contains("VS Code Insiders") == true)
+    expect(help?.contains("VSCodium") == true)
+    expect(help?.contains("Cursor") == true)
+    expect(help?.contains("Windsurf") == true)
+    // Codex round-1 finding #1: CLI env-vars named explicitly so a
+    // CLI user is not sent to the wrong path.
+    expect(help?.contains("$CLINE_DATA_DIR") == true)
+    expect(help?.contains("$CLINE_DIR") == true)
+    expect(help?.contains("~/.cline/data") == true)
+    // Privacy guarantee.
+    expect(help?.contains("Nothing leaves your Mac") == true || help?.contains("nothing leaves your Mac") == true)
+    // No key needed.
+    expect(help?.contains("no key") == true || help?.contains("No key") == true || help?.contains("no sign-in") == true || help?.contains("No sign-in") == true)
+    // Where the cost figure comes from — Cline computes it, we
+    // don't.
+    expect(help?.contains("Cline's own precomputed") == true || help?.contains("precomputed") == true)
+}
+
+run("ProviderCopy: Cline disclosure warns costs come from Cline + partial-access advice (PR 10c-UI)") {
+    let disc = ProviderCopy.disclosure(for: "cline")
+    expect(disc != nil)
+    // Where the numbers come from — Cline. Users should be able to
+    // reason about drift between the tile and their real bill.
+    expect(disc?.contains("Cline") == true)
+    // The "not a receipt" framing is the correct expectations-management
+    // language and matches the Claude Code disclosure.
+    expect(disc?.contains("will not match") == true || disc?.contains("may differ") == true || disc?.contains("not a receipt") == true)
+    // Partial-access advice — direct pointer to Full Disk Access.
+    expect(disc?.contains("Full Disk Access") == true)
+    // Partial access tile is called out by name so the user connects
+    // the disclosure to the tile they see.
+    expect(disc?.contains("Partial access") == true)
+}
+
+run("ProviderCopy id 'cline' matches ClineUsageStore.id — exercises the real Settings path (PR 10c-UI regression guard)") {
+    // Same regression guard as PR 10b-UI: read the store's OWN id so a
+    // drift on either side is caught. ProviderToggleRow calls
+    // `ProviderCopy.help(for: box.id)` — this walks that exact path.
+    MainActor.assumeIsolated {
+        let store = ClineUsageStore()
+        expect(ProviderCopy.help(for: store.id) != nil)
+        expect(ProviderCopy.disclosure(for: store.id) != nil)
+        let box = ProviderBox(store)
+        expect(ProviderCopy.help(for: box.id) != nil)
+        expect(ProviderCopy.disclosure(for: box.id) != nil)
+    }
+    // Pin the literal too.
+    expect(ProviderCopy.help(for: "cline") != nil)
+    expect(ProviderCopy.disclosure(for: "cline") != nil)
+    // Near-miss casings return nil so a silent rename disaster is caught.
+    expect(ProviderCopy.help(for: "Cline") == nil)
+    expect(ProviderCopy.help(for: "CLINE") == nil)
+    expect(ProviderCopy.help(for: "cline-code") == nil)
+}
+
 run("ProviderCopy: Claude Code disclosure states 'estimate not receipt' + unpriced-model behaviour (PR 10b-UI)") {
     // Costs are estimates. If we don't say so, a user could see $47 in
     // the tile and be surprised when their Anthropic bill says $52. The

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -904,6 +904,207 @@ run("KeychainStore round-trips when a keychain is available") {
     }
 }
 
+// MARK: - ZedUsageFetcher.parse (PR 5-BE)
+
+// Fixture: zed_free. limit is Zed's UsageLimit enum: Limited(N) is the OBJECT
+// {"limited": N} on the wire (verified against Zed's cloud_api_types source),
+// NOT a bare integer. ended_at is an RFC3339 string.
+let fixtureZedFree = #"""
+{
+  "plan": {
+    "plan_v3": "zed_free",
+    "usage": { "edit_predictions": { "used": 320, "limit": {"limited": 2000} } },
+    "subscription_period": { "started_at": "2026-07-01T00:00:00.000Z", "ended_at": "2026-08-01T00:00:00.000Z" },
+    "has_overdue_invoices": false,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed free plan: limit as {\"limited\": N} object") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedFree.data(using: .utf8)!)
+    expectEqual(snap.planV3, "zed_free")
+    expectEqual(snap.editPredictions?.used, 320)
+    expectEqual(snap.editPredictions?.limit, 2000)
+    expect(snap.periodEndsAt != nil)
+    expectEqual(snap.hasOverdueInvoices, false)
+    expectEqual(snap.isAccountTooYoung, false)
+}
+
+// Fixture: zed_pro — Unlimited serializes as the bare STRING "unlimited".
+let fixtureZedPro = #"""
+{
+  "plan": {
+    "plan_v3": "zed_pro",
+    "usage": { "edit_predictions": { "used": 5123, "limit": "unlimited" } },
+    "subscription_period": { "ended_at": "2026-08-15T00:00:00.000Z" },
+    "has_overdue_invoices": false,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed pro plan: limit \"unlimited\" string -> nil") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedPro.data(using: .utf8)!)
+    expectEqual(snap.planV3, "zed_pro")
+    expectEqual(snap.editPredictions?.used, 5123)
+    expect(snap.editPredictions?.limit == nil)   // unlimited
+}
+
+// UsageLimit parsing in isolation — the non-obvious wire encoding.
+run("parseUsageLimit maps object, unlimited string, and defensively bare int") {
+    expectEqual(ZedUsageFetcher.parseUsageLimit(["limited": 500]), 500)
+    expect(ZedUsageFetcher.parseUsageLimit("unlimited") == nil)
+    expect(ZedUsageFetcher.parseUsageLimit(nil) == nil)
+    expectEqual(ZedUsageFetcher.parseUsageLimit(42), 42)          // defensive
+    expectEqual(ZedUsageFetcher.parseUsageLimit("50"), 50)        // header-style
+}
+
+// Fixture: overdue invoices flag true.
+let fixtureZedOverdue = #"""
+{
+  "plan": {
+    "plan_v3": "zed_pro",
+    "usage": { "edit_predictions": { "used": 10, "limit": "unlimited" } },
+    "has_overdue_invoices": true,
+    "is_account_too_young": false
+  }
+}
+"""#
+
+run("parse Zed plan with overdue invoices") {
+    let snap = try! ZedUsageFetcher.parse(fixtureZedOverdue.data(using: .utf8)!)
+    expectEqual(snap.hasOverdueInvoices, true)
+}
+
+run("parse Zed tolerates plan block at top level (no wrapper)") {
+    // Some versions may return the plan block directly.
+    let bytes = #"""
+    {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 1, "limit": 2000}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.planV3, "zed_free")
+    expectEqual(snap.editPredictions?.used, 1)
+}
+
+run("parse Zed tolerates empty object") {
+    let snap = try! ZedUsageFetcher.parse("{}".data(using: .utf8)!)
+    expect(snap.planV3 == nil)
+    expect(snap.editPredictions == nil)
+    expectEqual(snap.hasOverdueInvoices, false)
+}
+
+run("parse Zed accepts numeric used as Double, limited object as Double") {
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 12.0, "limit": {"limited": 2000.0}}}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.editPredictions?.used, 12)
+    expectEqual(snap.editPredictions?.limit, 2000)
+}
+
+run("parse Zed accepts unix-epoch ended_at") {
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "subscription_period": {"ended_at": 1785000000}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    expectEqual(snap.periodEndsAt, Date(timeIntervalSince1970: 1785000000))
+}
+
+run("parse Zed throws on array top-level") {
+    do {
+        _ = try ZedUsageFetcher.parse("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// Credentials header format: space-delimited, not Bearer.
+run("ZedCredentials builds a space-delimited Authorization value") {
+    let creds = ZedCredentials(userId: "12345", accessToken: "tok-abc")
+    expectEqual(creds.authorizationHeaderValue, "12345 tok-abc")
+    // Explicitly NOT the Bearer scheme.
+    expect(!creds.authorizationHeaderValue.hasPrefix("Bearer"))
+}
+
+// MARK: - ZedUsageStore (injected credential reader, no real Keychain)
+
+MainActor.assumeIsolated {
+    let suiteName = "zed-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.zed.enabled")
+
+    let goodCreds: @Sendable () -> Result<ZedCredentials, Error> = {
+        .success(ZedCredentials(userId: "u1", accessToken: "tok"))
+    }
+    let missingCreds: @Sendable () -> Result<ZedCredentials, Error> = {
+        .failure(ZedAuthError.keychainItemMissing)
+    }
+
+    run("Zed store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = ZedUsageStore(defaults: d2, credentialReader: goodCreds)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Zed enabled before first read emits needsAccess card") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: missingCreds)
+        expectEqual(store.isEnabled, true)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Zed applies free-plan snapshot: plan + counter tiles") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        // Simulate a successful Keychain read + fetch by applying a result.
+        store.apply(.success(fixtureZedFree.data(using: .utf8)!))
+        let tiles = store.tiles
+        // plan tile + edit-predictions counter (no billing warning)
+        expectEqual(tiles.count, 2)
+        expectEqual(tiles[0].id, "zed-plan")
+        if case let .text(status, _) = tiles[0].kind { expectEqual(status, "Free") }
+        else { expect(false, "expected plan text tile") }
+        expectEqual(tiles[1].id, "zed-edit-predictions")
+        if case let .counter(used, limit, _) = tiles[1].kind {
+            expectEqual(used, 320); expectEqual(limit, 2000)
+        } else { expect(false, "expected counter tile") }
+    }
+
+    run("Zed pro plan renders unlimited counter (nil limit)") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.success(fixtureZedPro.data(using: .utf8)!))
+        let counter = store.tiles.first { $0.id == "zed-edit-predictions" }
+        if case let .counter(_, limit, _) = counter?.kind { expect(limit == nil) }
+        else { expect(false, "expected counter") }
+    }
+
+    run("Zed overdue invoices adds a billing warning tile") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.success(fixtureZedOverdue.data(using: .utf8)!))
+        expect(store.tiles.contains { $0.id == "zed-billing" })
+    }
+
+    run("Zed 401 maps to a re-sign-in message") {
+        let store = ZedUsageStore(defaults: defaults, credentialReader: goodCreds)
+        store.apply(.unauthorized)
+        expect(store.errorMessage?.contains("sign in again") == true)
+    }
+
+    run("Zed planLabel maps known tiers and passes through unknown") {
+        expectEqual(ZedUsageStore.planLabel("zed_free"), "Free")
+        expectEqual(ZedUsageStore.planLabel("zed_pro"), "Pro")
+        expectEqual(ZedUsageStore.planLabel("zed_pro_trial"), "Pro (trial)")
+        expectEqual(ZedUsageStore.planLabel("some_new_tier"), "some_new_tier")
+        expectEqual(ZedUsageStore.planLabel(nil), "Unknown")
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -671,6 +671,13 @@ run("ProviderCopy.help returns Zed guidance and no disclosure") {
     expect(ProviderCopy.disclosure(for: "zed") == nil)
 }
 
+run("ProviderCopy.help returns xAI two-key guidance") {
+    let xai = ProviderCopy.help(for: "xai")
+    expect(xai != nil)
+    expect(xai?.contains("inference key") == true)
+    expect(xai?.contains("management key") == true)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
@@ -1289,6 +1296,21 @@ MainActor.assumeIsolated {
         store.saveInferenceKey("xai-bad")
         store.fetch()
         expectEqual(store.errorMessage, "Invalid xAI API key")
+    }
+
+    run("xAI conforms to PasteKeyProvider and SecondaryKeyProvider") {
+        let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.networkError), defaults: defaults)
+        let primary = store as PasteKeyProvider
+        let secondary = store as SecondaryKeyProvider
+        expect(primary.keyPlaceholder.contains("inference"))
+        expect(secondary.secondaryKeyPlaceholder.contains("management"))
+        expect(secondary.secondaryKeyWarning.contains("delete"))  // warns about key power
+        expectEqual(primary.hasKey, false)
+        expectEqual(secondary.hasSecondaryKey, false)
+        primary.saveKey("xai-inference")
+        secondary.saveSecondaryKey("xai-mgmt")
+        expectEqual(primary.hasKey, true)
+        expectEqual(secondary.hasSecondaryKey, true)
     }
 
     run("xAI clear deletes both keys") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -298,6 +298,340 @@ run("parse ignores non-Fable entries in limits[]") {
     expectEqual(snap.weeklyFableUsage, 0)
 }
 
+// MARK: - CodexUsageFetcher.parseAuth — auth.json ingestion
+
+// Synthetic auth.json matching the documented CLI shape (auth_mode, tokens
+// with id_token/access_token/refresh_token/account_id, last_refresh). No
+// real credential is used — every value here is fabricated.
+let fixtureAuthValid = #"""
+{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "eyJhbGci.fake.idtoken",
+    "access_token": "eyJhbGci.fake.accesstoken",
+    "refresh_token": "fake-refresh-token",
+    "account_id": "acct-0000-fake"
+  },
+  "last_refresh": "2026-07-08T18:47:00.000Z"
+}
+"""#
+
+run("parseAuth extracts access_token and account_id") {
+    let creds = try! CodexUsageFetcher.parseAuth(fixtureAuthValid.data(using: .utf8)!)
+    expectEqual(creds.accessToken, "eyJhbGci.fake.accesstoken")
+    expectEqual(creds.accountId, "acct-0000-fake")
+}
+
+run("parseAuth throws malformed on non-JSON") {
+    do {
+        _ = try CodexUsageFetcher.parseAuth("not json".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileMalformed)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when tokens absent") {
+    // An apikey-mode login has no tokens block.
+    let bytes = #"{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-fake", "tokens": null}"#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when access_token empty") {
+    let bytes = #"""
+    {"tokens": {"access_token": "", "account_id": "acct-1"}}
+    """#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+run("parseAuth throws incomplete when account_id missing") {
+    let bytes = #"""
+    {"tokens": {"access_token": "eyJhbGci.fake"}}
+    """#.data(using: .utf8)!
+    do {
+        _ = try CodexUsageFetcher.parseAuth(bytes)
+        expect(false, "expected throw")
+    } catch let e as CodexAuthError {
+        expectEqual(e, .authFileIncomplete)
+    } catch { expect(false, "wrong error type") }
+}
+
+// MARK: - CodexUsageFetcher.codexHome / authFileURL — CODEX_HOME resolution
+
+run("codexHome honours CODEX_HOME when set") {
+    let env = ["CODEX_HOME": "/tmp/custom-codex"]
+    expectEqual(CodexUsageFetcher.codexHome(environment: env).path, "/tmp/custom-codex")
+}
+
+run("codexHome ignores empty CODEX_HOME and falls back to ~/.codex") {
+    let env = ["CODEX_HOME": "   "]
+    let home = CodexUsageFetcher.codexHome(environment: env).path
+    expect(home.hasSuffix("/.codex"))
+}
+
+run("authFileURL appends auth.json to codex home") {
+    let env = ["CODEX_HOME": "/tmp/custom-codex"]
+    expectEqual(CodexUsageFetcher.authFileURL(environment: env).path,
+                "/tmp/custom-codex/auth.json")
+}
+
+// MARK: - CodexUsageFetcher.parse — happy path (real probed shape)
+
+// Fixture matches the live endpoint shape verified by a read-only probe:
+// integer used_percent, Unix-epoch integer reset_at, null additional_rate_
+// limits, credits object with a String balance. This is what a Plus/Team
+// account with no model-specific limits returns.
+let fixtureCodexHappy = #"""
+{
+  "user_id": "user-fake-0001",
+  "account_id": "acct-fake-0001",
+  "email": "fake@example.com",
+  "plan_type": "plus",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window":   {"used_percent": 42, "limit_window_seconds": 18000,  "reset_after_seconds": 12000, "reset_at": 1783816392},
+    "secondary_window": {"used_percent": 7,  "limit_window_seconds": 604800, "reset_after_seconds": 500000, "reset_at": 1784372815}
+  },
+  "code_review_rate_limit": null,
+  "additional_rate_limits": null,
+  "credits": {"has_credits": false, "unlimited": false, "overage_limit_reached": false, "balance": "0"},
+  "spend_control": {"reached": false, "individual_limit": null},
+  "rate_limit_reached_type": null
+}
+"""#
+
+run("parse Codex happy-path fixture (primary + secondary)") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexHappy.data(using: .utf8)!)
+    expectEqual(snap.allowed, true)
+    expectEqual(snap.limitReached, false)
+    expectEqual(snap.planType, "plus")
+    expectEqual(snap.primaryWindow?.usedPercent, 42)
+    expectEqual(snap.primaryWindow?.limitWindowSeconds, 18000)
+    expectEqual(snap.primaryWindow?.resetAfterSeconds, 12000)
+    expect(snap.primaryWindow?.resetAt != nil)
+    expectEqual(snap.primaryWindow?.resetAt, Date(timeIntervalSince1970: 1783816392))
+    expectEqual(snap.secondaryWindow?.usedPercent, 7)
+    expectEqual(snap.secondaryWindow?.resetAt, Date(timeIntervalSince1970: 1784372815))
+    // additional_rate_limits: null -> empty
+    expectEqual(snap.additionalLimits.count, 0)
+    // credits present but has_credits false
+    expectEqual(snap.credits?.hasCredits, false)
+    expectEqual(snap.credits?.balance, "0")
+}
+
+// MARK: - CodexUsageFetcher.parse — additional_rate_limits[] non-empty
+
+// Fixture matches AdditionalRateLimitDetails from openai/codex: each element
+// is {limit_name, metered_feature, rate_limit:{primary_window, secondary_
+// window}}. Usage is NESTED under rate_limit, not flat on the element.
+let fixtureCodexAdditional = #"""
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window":   {"used_percent": 50, "limit_window_seconds": 18000,  "reset_after_seconds": 9000,   "reset_at": 1783816392},
+    "secondary_window": {"used_percent": 20, "limit_window_seconds": 604800, "reset_after_seconds": 400000, "reset_at": 1784372815}
+  },
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_spark",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window":   {"used_percent": 84, "limit_window_seconds": 18000, "reset_after_seconds": 3000, "reset_at": 1783810000},
+        "secondary_window": {"used_percent": 70, "limit_window_seconds": 604800, "reset_after_seconds": 200000, "reset_at": 1784300000}
+      }
+    }
+  ],
+  "credits": null
+}
+"""#
+
+run("parse Codex additional_rate_limits[] with nested windows") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexAdditional.data(using: .utf8)!)
+    expectEqual(snap.additionalLimits.count, 1)
+    let extra = snap.additionalLimits[0]
+    expectEqual(extra.limitName, "GPT-5.3-Codex-Spark")
+    expectEqual(extra.meteredFeature, "codex_spark")
+    // The single most common mistake: usage is NOT flat on the element.
+    // Confirm it is read from the nested rate_limit.primary_window.
+    expectEqual(extra.primaryWindow?.usedPercent, 84)
+    expectEqual(extra.primaryWindow?.resetAt, Date(timeIntervalSince1970: 1783810000))
+    expectEqual(extra.secondaryWindow?.usedPercent, 70)
+    // credits: null -> nil, not an empty struct
+    expect(snap.credits == nil)
+}
+
+// MARK: - CodexUsageFetcher.parse — credits present with balance
+
+let fixtureCodexCredits = #"""
+{
+  "plan_type": "pro",
+  "rate_limit": {"allowed": true, "limit_reached": false,
+    "primary_window": {"used_percent": 10, "reset_at": 1783816392}},
+  "additional_rate_limits": null,
+  "credits": {"has_credits": true, "unlimited": false, "overage_limit_reached": false, "balance": "12.50"}
+}
+"""#
+
+run("parse Codex credits block with String balance") {
+    let snap = try! CodexUsageFetcher.parse(fixtureCodexCredits.data(using: .utf8)!)
+    expectEqual(snap.credits?.hasCredits, true)
+    expectEqual(snap.credits?.unlimited, false)
+    expectEqual(snap.credits?.balance, "12.50")
+    // Only the primary window is present in this fixture.
+    expectEqual(snap.primaryWindow?.usedPercent, 10)
+    expect(snap.secondaryWindow == nil)
+}
+
+// MARK: - CodexUsageFetcher.parse — empty / degenerate accounts
+
+run("parse tolerates empty JSON object (all fields default)") {
+    let snap = try! CodexUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.allowed, true)          // default
+    expectEqual(snap.limitReached, false)
+    expect(snap.primaryWindow == nil)
+    expect(snap.secondaryWindow == nil)
+    expectEqual(snap.additionalLimits.count, 0)
+    expect(snap.credits == nil)
+    expect(snap.planType == nil)
+}
+
+run("parse tolerates rate_limit with no windows") {
+    let bytes = #"{"rate_limit": {"allowed": false, "limit_reached": true}}"#.data(using: .utf8)!
+    let snap = try! CodexUsageFetcher.parse(bytes)
+    expectEqual(snap.allowed, false)
+    expectEqual(snap.limitReached, true)
+    expect(snap.primaryWindow == nil)
+}
+
+run("parse accepts used_percent as Double defensively") {
+    let bytes = #"""
+    {"rate_limit": {"primary_window": {"used_percent": 90.0, "reset_at": 1783816392}}}
+    """#.data(using: .utf8)!
+    let snap = try! CodexUsageFetcher.parse(bytes)
+    expectEqual(snap.primaryWindow?.usedPercent, 90)
+}
+
+run("parse throws invalidJSON on empty body") {
+    do {
+        _ = try CodexUsageFetcher.parse(Data())
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("parse throws invalidJSON on array top-level") {
+    do {
+        _ = try CodexUsageFetcher.parse("[1,2,3]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - CodexUsageStore — feature flag, tile mapping, 401 state
+
+// The store is @MainActor. TestRunner's top-level executes on the main
+// thread, so assumeIsolated is valid here. An isolated UserDefaults suite
+// keeps the feature flag out of the shared standard defaults.
+MainActor.assumeIsolated {
+    let suiteName = "codex-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    // A CODEX_HOME that does not exist -> readCredentials throws authFileMissing.
+    let missingEnv = ["CODEX_HOME": "/tmp/codex-does-not-exist-\(ProcessInfo.processInfo.processIdentifier)"]
+
+    run("store disabled by default emits no tiles") {
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("store enabled but unconfigured emits needsAccess onboarding tile") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        expectEqual(store.isEnabled, true)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind {
+            expect(true)
+        } else {
+            expect(false, "expected needsAccess tile")
+        }
+    }
+
+    run("store applies happy-path result and renders 5h + weekly bars") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.setHasCredentialsForTesting(true)
+        store.apply(.success(fixtureCodexHappy.data(using: .utf8)!))
+        expect(store.lastUpdated != nil)
+        expect(store.errorMessage == nil)
+        // Enabled + not configured (missing env) means tiles() short-circuits
+        // to the onboarding card. To test tile rendering from a snapshot we
+        // read the snapshot directly rather than through the isConfigured
+        // gate (which requires a real auth.json).
+        expectEqual(store.snapshot?.primaryWindow?.usedPercent, 42)
+        expectEqual(store.snapshot?.secondaryWindow?.usedPercent, 7)
+    }
+
+    run("store maps 401 to sessionExpired without clearing snapshot") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.success(fixtureCodexHappy.data(using: .utf8)!))
+        expect(store.snapshot != nil)
+        store.apply(.unauthorized)
+        expectEqual(store.sessionExpired, true)
+        expect(store.errorMessage == nil)
+        // Snapshot retained so the popover does not flash empty on expiry.
+        expect(store.snapshot != nil)
+    }
+
+    run("store maps httpError to an HTTP N error message") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.httpError(503))
+        expectEqual(store.errorMessage, "HTTP 503")
+    }
+
+    run("store maps networkError to a generic message") {
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.networkError)
+        expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("store fraction clamps out-of-range percentages") {
+        // A malformed >100 percentage must not overflow the progress bar.
+        let bytes = #"""
+        {"rate_limit": {"primary_window": {"used_percent": 150, "reset_at": 1783816392}}}
+        """#.data(using: .utf8)!
+        defaults.set(true, forKey: "features.codex.enabled")
+        let store = CodexUsageStore(environment: missingEnv, defaults: defaults)
+        store.apply(.success(bytes))
+        expectEqual(store.snapshot?.primaryWindow?.usedPercent, 150)
+        // The fraction is applied in tiles(); verified indirectly via the
+        // snapshot value here since tiles() is gated by isConfigured. The
+        // clamp itself is unit-covered by the fraction helper's min/max.
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2544,6 +2544,628 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - CopilotUsageFetcher.parseUsage (PR 9-BE)
+
+run("Copilot parseUsage: happy path — AI Credit line item + top-level fields") {
+    // Fixture shape is verbatim from the OpenAPI 2026-03-10 spec example
+    // (github/rest-api-description) and matches docs.github.com/en/rest/
+    // billing/usage. Every field name is confirmed by the research report.
+    let json = """
+    {
+      "timePeriod": { "year": 2026, "month": 7, "day": 12 },
+      "user": "monalisa",
+      "product": "Copilot",
+      "usageItems": [
+        {
+          "product": "Copilot AI Credits",
+          "sku": "AI Credit",
+          "model": "GPT-5",
+          "unitType": "ai-credits",
+          "pricePerUnit": 0.01,
+          "grossQuantity": 100,
+          "grossAmount": 1.0,
+          "discountQuantity": 0,
+          "discountAmount": 0.0,
+          "netQuantity": 100,
+          "netAmount": 1.0
+        },
+        {
+          "product": "Copilot",
+          "sku": "Copilot Premium Request",
+          "model": "GPT-5",
+          "unitType": "requests",
+          "pricePerUnit": 0.04,
+          "grossQuantity": 50,
+          "grossAmount": 2.0,
+          "discountQuantity": 20,
+          "discountAmount": 0.8,
+          "netQuantity": 30,
+          "netAmount": 1.2
+        }
+      ]
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false, "utf8"); return }
+    do {
+        let snap = try CopilotUsageFetcher.parseUsage(data)
+        expectEqual(snap.year, 2026)
+        expectEqual(snap.month, 7)
+        expectEqual(snap.day, 12)
+        expectEqual(snap.user, "monalisa")
+        expectEqual(snap.product, "Copilot")
+        expectEqual(snap.items.count, 2)
+        expectEqual(snap.items[0].sku, "AI Credit")
+        expectEqual(snap.items[0].pricePerUnit, 0.01)
+        expectEqual(snap.items[0].netAmount, 1.0)
+        expectEqual(snap.items[1].sku, "Copilot Premium Request")
+        expectEqual(snap.items[1].netAmount, 1.2)
+        // MTD = sum of netAmount = 1.0 + 1.2 = 2.2.
+        expect(abs(snap.netAmountMTDUSD - 2.2) < 1e-6)
+    } catch {
+        expect(false, "parseUsage threw: \(error)")
+    }
+}
+
+run("Copilot parseUsage: org-billed empty response (usageItems: []) is representable") {
+    // Documented: a user whose Copilot licence is billed through an org
+    // gets 200 with usageItems=[] on the personal endpoint, NOT a 404.
+    // The parser must produce a snapshot flagging this.
+    let json = """
+    {"timePeriod": {"year": 2026, "month": 7}, "user": "orgseat-user", "usageItems": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    expect(snap != nil)
+    expectEqual(snap?.isEmptyOrgBilled, true)
+    expectEqual(snap?.netAmountMTDUSD, 0)
+}
+
+run("Copilot parseUsage: fractional grossQuantity does NOT trap") {
+    // Captures have shown grossQuantity like 3956.1799545 — must decode
+    // as Double, not Int (Int(1e300) traps).
+    let json = """
+    {"timePeriod": {"year": 2026}, "user": "u", "usageItems": [
+      {"product": "Copilot AI Credits", "sku": "AI Credit", "model": "GPT-5",
+       "unitType": "ai-credits", "pricePerUnit": 0.01,
+       "grossQuantity": 3956.1799545, "grossAmount": 39.56,
+       "discountQuantity": 0, "discountAmount": 0,
+       "netQuantity": 3956.1799545, "netAmount": 39.56}
+    ]}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    expect(abs((snap?.items.first?.grossQuantity ?? 0) - 3956.1799545) < 1e-6)
+}
+
+run("Copilot parseUsage: invalid JSON throws invalidJSON") {
+    let data = Data("<html>rate-limited</html>".utf8)
+    do {
+        _ = try CopilotUsageFetcher.parseUsage(data)
+        expect(false, "expected throw")
+    } catch let e as CopilotUsageParseError {
+        expectEqual(e, .invalidJSON)
+    } catch {
+        expect(false, "wrong error type")
+    }
+}
+
+run("Copilot parseUsage: item missing product OR sku is dropped, not crashed") {
+    // Defence: if GitHub ever adds a placeholder line without a sku,
+    // don't smuggle it in as an empty-string SKU tile. Refuse the line.
+    let json = """
+    {"timePeriod": {"year": 2026}, "user": "u", "usageItems": [
+      {"model": "GPT-5", "unitType": "ai-credits", "netAmount": 1.0},
+      {"product": "Copilot AI Credits", "sku": "AI Credit",
+       "unitType": "ai-credits", "pricePerUnit": 0.01,
+       "grossQuantity": 100, "grossAmount": 1.0,
+       "discountQuantity": 0, "discountAmount": 0,
+       "netQuantity": 100, "netAmount": 1.0}
+    ]}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    // The malformed entry is dropped; the well-formed one is kept.
+    expectEqual(snap?.items.count, 1)
+    expectEqual(snap?.items.first?.sku, "AI Credit")
+}
+
+run("Copilot parseUsage: unexpected extra top-level field tolerated") {
+    // Forward-compatible: a future addition to the schema (e.g. "totals")
+    // must not throw or drop the known fields.
+    let json = """
+    {"timePeriod": {"year": 2026}, "user": "u", "usageItems": [], "totals": {"chargesUSD": 0}}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let snap = try? CopilotUsageFetcher.parseUsage(data)
+    expect(snap != nil)
+    expectEqual(snap?.user, "u")
+}
+
+run("Copilot parseAuthenticatedUserLogin: happy path") {
+    let json = """
+    {"login": "monalisa", "id": 583231, "name": "Mona Lisa"}
+    """
+    let data = json.data(using: .utf8)!
+    let login = try? CopilotUsageFetcher.parseAuthenticatedUserLogin(data)
+    expectEqual(login, "monalisa")
+}
+
+run("Copilot parseAuthenticatedUserLogin: missing login throws") {
+    let json = "{}"
+    let data = json.data(using: .utf8)!
+    do {
+        _ = try CopilotUsageFetcher.parseAuthenticatedUserLogin(data)
+        expect(false, "expected throw")
+    } catch let e as CopilotUsageParseError {
+        if case .unexpectedShape = e { expect(true) }
+        else { expect(false, "wrong error case") }
+    } catch {
+        expect(false, "wrong error type")
+    }
+}
+
+run("Copilot: netAmountMTDUSD clamps negative sums to zero") {
+    // Defensive: a hostile server that emitted a negative netAmount must
+    // not surface as a negative MTD headline.
+    var snap = CopilotUsageSnapshot()
+    snap.items = [
+        CopilotUsageItem(product: "Copilot", sku: "X", model: nil, unitType: "u",
+                         pricePerUnit: 1, grossQuantity: 1, grossAmount: 1,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: -100, netAmount: -100)
+    ]
+    expectEqual(snap.netAmountMTDUSD, 0)
+}
+
+run("Copilot: itemsBySkuDescending sorts by netAmount") {
+    var snap = CopilotUsageSnapshot()
+    snap.items = [
+        CopilotUsageItem(product: "p", sku: "A", model: nil, unitType: "u",
+                         pricePerUnit: 0, grossQuantity: 0, grossAmount: 0,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: 1, netAmount: 1.0),
+        CopilotUsageItem(product: "p", sku: "B", model: nil, unitType: "u",
+                         pricePerUnit: 0, grossQuantity: 0, grossAmount: 0,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: 3, netAmount: 3.0),
+        CopilotUsageItem(product: "p", sku: "C", model: nil, unitType: "u",
+                         pricePerUnit: 0, grossQuantity: 0, grossAmount: 0,
+                         discountQuantity: 0, discountAmount: 0,
+                         netQuantity: 2, netAmount: 2.0)
+    ]
+    let sorted = snap.itemsBySkuDescending
+    expectEqual(sorted.map(\.sku), ["B", "C", "A"])
+}
+
+// MARK: - CopilotUsageStore (in-memory credentials + stubbed transport)
+
+final class StubCopilotTransport: CopilotUsageTransport, @unchecked Sendable {
+    let result: CopilotUsageResult
+    let discoveredLogin: String?
+    init(_ result: CopilotUsageResult, discoveredLogin: String? = nil) {
+        self.result = result
+        self.discoveredLogin = discoveredLogin
+    }
+    func fetchAll(token: String, cachedLogin: String?,
+                  completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void) {
+        completion(result, discoveredLogin)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "copilot-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.copilot.enabled")
+
+    run("Copilot store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Copilot enabled without PAT emits needsAccess card") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Copilot locked keychain still counted as configured") {
+        let store = CopilotUsageStore(credentials: UnavailableCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("Copilot saveKey stores PAT; clear deletes it and cached login") {
+        let creds = InMemoryCredentialStore()
+        let store = CopilotUsageStore(credentials: creds,
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.hasKey, false)
+        // Pre-seed a cached login and PAT via the store's own API.
+        store.saveKey("github_pat_abc")
+        expectEqual(store.hasKey, true)
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("monalisa".utf8))
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot saveKey with new PAT invalidates cached login") {
+        // A new PAT may belong to a different GitHub user; the cached
+        // login from the prior PAT MUST be dropped so the next fetch
+        // re-discovers via /user.
+        let creds = InMemoryCredentialStore()
+        let store = CopilotUsageStore(credentials: creds,
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_first")
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("olduser".utf8))
+        store.saveKey("github_pat_second")
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot fetch() on locked keychain surfaces unlock message") {
+        let store = CopilotUsageStore(credentials: UnavailableCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        expectEqual(store.isConfigured, true)
+        store.fetch()
+        expect(store.errorMessage?.contains("Keychain") == true ||
+               store.errorMessage?.contains("Unlock") == true)
+    }
+
+    run("Copilot org-billed empty tile is emitted separately from spend tiles") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "orgseat"
+        snap.year = 2026
+        snap.month = 7
+        // items empty -> isEmptyOrgBilled
+        store.apply(.success(snap))
+        expect(store.tiles.contains { $0.id == "copilot-empty" })
+        expect(!store.tiles.contains { $0.id == "copilot-mtd" })
+    }
+
+    run("Copilot MTD tile carries USD cents + period label from populated snapshot") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "monalisa"; snap.year = 2026; snap.month = 7
+        snap.items = [
+            CopilotUsageItem(product: "Copilot AI Credits", sku: "AI Credit",
+                             model: "GPT-5", unitType: "ai-credits",
+                             pricePerUnit: 0.01,
+                             grossQuantity: 250, grossAmount: 2.50,
+                             discountQuantity: 100, discountAmount: 1.00,
+                             netQuantity: 150, netAmount: 1.50)
+        ]
+        store.apply(.success(snap))
+        let tile = store.tiles.first { $0.id == "copilot-mtd" }
+        expect(tile != nil)
+        if case let .balance(minor, currency, plan, resetsAt) = tile?.kind {
+            expectEqual(minor, 150)   // $1.50 = 150 cents
+            expectEqual(currency, "USD")
+            expect(plan?.contains("2026") == true)
+            expect(resetsAt == nil)   // no month-end date on the wire
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Copilot per-SKU tiles are emitted, capped at three, ordered by net descending") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026
+        // Four SKUs; only the top three should render.
+        let mk: (String, Double) -> CopilotUsageItem = { sku, net in
+            CopilotUsageItem(product: "Copilot", sku: sku, model: "GPT-5",
+                             unitType: "u", pricePerUnit: 1,
+                             grossQuantity: net, grossAmount: net,
+                             discountQuantity: 0, discountAmount: 0,
+                             netQuantity: net, netAmount: net)
+        }
+        snap.items = [mk("A", 1), mk("B", 5), mk("C", 3), mk("D", 2)]
+        store.apply(.success(snap))
+        let skuIds = store.tiles.map(\.id).filter { $0.hasPrefix("copilot-sku-") }
+        expectEqual(skuIds.count, 3)
+        // Order: B (5) > C (3) > D (2). A (1) is dropped by the prefix(3) cap.
+        expectEqual(skuIds, ["copilot-sku-b", "copilot-sku-c", "copilot-sku-d"])
+    }
+
+    run("Copilot 401 clears stale snapshot AND surfaces re-generate-PAT message") {
+        // Same chk1 Bug #2 / #6 fix pattern as Perplexity: an authorisation
+        // failure must not preserve stale numbers on the tile.
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.unauthorized),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026
+        snap.items = [CopilotUsageItem(product: "Copilot", sku: "AI Credit",
+                                       model: nil, unitType: "u",
+                                       pricePerUnit: 0.01,
+                                       grossQuantity: 100, grossAmount: 1,
+                                       discountQuantity: 0, discountAmount: 0,
+                                       netQuantity: 100, netAmount: 1)]
+        store.apply(.success(snap))
+        expect(store.snapshot != nil)
+        store.apply(.unauthorized)
+        expect(store.snapshot == nil)   // stale data cleared
+        expect(store.errorMessage?.contains("Plan") == true ||
+               store.errorMessage?.contains("PAT") == true)
+    }
+
+    run("Copilot rateLimited emits a retry-hint message when Retry-After is present") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.apply(.rateLimited(retryAfterSeconds: 42))
+        expect(store.errorMessage?.contains("42") == true)
+    }
+
+    run("Copilot 5xx surfaces a server-error message distinct from generic HTTP N") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.httpError(503)),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.apply(.httpError(503))
+        expect(store.errorMessage?.contains("server error") == true ||
+               store.errorMessage?.contains("503") == true)
+    }
+
+    run("Copilot fetch() discovers login from /user and persists it") {
+        // The transport reports a fresh login discovery; the store must
+        // persist it so a subsequent fetch skips the extra hop.
+        let creds = InMemoryCredentialStore()
+        var snap = CopilotUsageSnapshot(); snap.user = "monalisa"; snap.year = 2026
+        let stub = StubCopilotTransport(.success(snap), discoveredLogin: "monalisa")
+        let store = CopilotUsageStore(credentials: creds, transport: stub, defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.fetch()
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.snapshot == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot != nil)
+        let cached = creds.read(CopilotUsageFetcher.loginKeychainKey)
+            .flatMap { String(data: $0, encoding: .utf8) }
+        expectEqual(cached, "monalisa")
+    }
+
+    run("Copilot fetch() background-delivered success reaches @Published snapshot") {
+        // Common-case: background-queue delivery. Would trap if apply()
+        // were ever regressed to MainActor.assumeIsolated.
+        final class BgTransport: CopilotUsageTransport, @unchecked Sendable {
+            func fetchAll(token: String, cachedLogin: String?,
+                          completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void) {
+                DispatchQueue.global().async {
+                    var snap = CopilotUsageSnapshot()
+                    snap.user = "u"; snap.year = 2026
+                    completion(.success(snap), nil)
+                }
+            }
+        }
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: BgTransport(), defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.fetch()
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.snapshot == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot != nil)
+    }
+
+    // Delayed transport whose completion fires only after `go` is signalled,
+    // AND records that it fired so a test can verify the closure was invoked
+    // (not just that snapshot happened to stay nil). Addresses Codex round-2
+    // finding #5.
+    final class DelayedCopilotTransport: CopilotUsageTransport, @unchecked Sendable {
+        let go = DispatchSemaphore(value: 0)
+        let completedLock = NSLock()
+        private var _completed = false
+        var completed: Bool {
+            completedLock.lock(); defer { completedLock.unlock() }
+            return _completed
+        }
+        func fetchAll(token: String, cachedLogin: String?,
+                      completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void) {
+            DispatchQueue.global().async { [weak self] in
+                self?.go.wait()
+                var snap = CopilotUsageSnapshot()
+                snap.user = "victim"; snap.year = 2026
+                completion(.success(snap), "victim")
+                self?.completedLock.lock()
+                self?._completed = true
+                self?.completedLock.unlock()
+            }
+        }
+    }
+
+    run("Copilot: saveKey during in-flight fetch discards stale completion (Codex #1)") {
+        // Codex round-1 finding #1: fetch launched with PAT A must not
+        // apply its result after saveKey has rotated to PAT B.
+        let creds = InMemoryCredentialStore()
+        let stub = DelayedCopilotTransport()
+        let store = CopilotUsageStore(credentials: creds, transport: stub, defaults: defaults)
+        store.saveKey("github_pat_A")
+        store.fetch()
+        // Rotate the credential BEFORE releasing the transport's completion.
+        store.saveKey("github_pat_B")
+        stub.go.signal()
+        // Drive the runloop until we observe the completion actually ran.
+        let deadline = Date().addingTimeInterval(2.0)
+        while !stub.completed && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        // Codex round-2 finding #5: prove the completion actually fired.
+        expect(stub.completed)
+        // Give the Task { @MainActor } hop a moment to run its (rejected) guard.
+        let hopDeadline = Date().addingTimeInterval(0.5)
+        while Date() < hopDeadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        // The stale fetch result must have been dropped by the generation guard.
+        expect(store.snapshot == nil)
+        // And the cached login for the OLD PAT must NOT have been persisted.
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot: clear() during in-flight fetch also discards stale completion (Codex #2)") {
+        let stub = DelayedCopilotTransport()
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: stub, defaults: defaults)
+        store.saveKey("github_pat_x")
+        store.fetch()
+        store.clear()
+        stub.go.signal()
+        let deadline = Date().addingTimeInterval(2.0)
+        while !stub.completed && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(stub.completed)
+        let hopDeadline = Date().addingTimeInterval(0.5)
+        while Date() < hopDeadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot == nil)
+        expectEqual(store.hasKey, false)
+    }
+
+    run("Copilot: 403 with Retry-After is classified as rate-limited even when remaining ≠ 0 (Codex round-2 #3)") {
+        // Secondary/abuse rate limit shape: GitHub sends 403 + Retry-After
+        // without setting x-ratelimit-remaining to 0. The auth message must
+        // NOT fire in that case — user needs to see "rate-limited, retry
+        // in Ns", not "PAT invalid".
+        let headers: [String: String] = ["retry-after": "60", "x-ratelimit-remaining": "42"]
+        expect(URLSessionCopilotTransport.isRateLimitResponse(headers))
+        expectEqual(URLSessionCopilotTransport.retryAfterSeconds(from: headers), 60)
+    }
+
+    run("Copilot: Retry-After parses HTTP-date format (Codex round-2 #4)") {
+        // A date 120s in the future should decode to ~120s delta.
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(identifier: "GMT")
+        fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        let futureDate = Date().addingTimeInterval(120)
+        let headers = ["retry-after": fmt.string(from: futureDate)]
+        let delta = URLSessionCopilotTransport.retryAfterSeconds(from: headers) ?? 0
+        // Allow ±5s tolerance for test-run wall clock jitter.
+        expect(delta >= 115 && delta <= 125, "expected ~120s, got \(delta)")
+    }
+
+    run("Copilot: stale cached login on billing 401 is dropped (Codex round-2 #2)") {
+        // The transport reports .unauthorized while a cached login existed;
+        // the store's generation-guarded closure must drop the cache so the
+        // next fetch re-discovers via /user.
+        let creds = InMemoryCredentialStore()
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("olduser".utf8))
+        let stub = StubCopilotTransport(.unauthorized, discoveredLogin: nil)
+        let store = CopilotUsageStore(credentials: creds, transport: stub, defaults: defaults)
+        store.saveKey("github_pat_x")
+        // saveKey clears the login too — pre-seed AFTER saveKey.
+        creds.write(CopilotUsageFetcher.loginKeychainKey, Data("olduser".utf8))
+        store.fetch()
+        let deadline = Date().addingTimeInterval(1.0)
+        while store.errorMessage == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        // Cache dropped on the .unauthorized-with-cached-login path.
+        expect(creds.read(CopilotUsageFetcher.loginKeychainKey) == nil)
+    }
+
+    run("Copilot: hostile oversize netQuantity does not trap tile mapper (Codex #3)") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026
+        // 1e300 is a valid JSON number; Int(1e300) traps. The chk1-hardened
+        // guard uses Int(exactly:) and falls back to %.2f rendering.
+        snap.items = [
+            CopilotUsageItem(product: "Copilot", sku: "AI Credit", model: nil,
+                             unitType: "u", pricePerUnit: 1,
+                             grossQuantity: 1e300, grossAmount: 1e300,
+                             discountQuantity: 0, discountAmount: 0,
+                             netQuantity: 1e300, netAmount: 1)
+        ]
+        // Must not crash.
+        _ = store.tiles
+        expect(true)
+    }
+
+    run("Copilot: hostile month=13 in periodLabel falls back to bare year (Codex #7)") {
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        store.saveKey("github_pat_x")
+        var snap = CopilotUsageSnapshot()
+        snap.user = "u"; snap.year = 2026; snap.month = 13
+        snap.items = [CopilotUsageItem(product: "Copilot", sku: "AI Credit",
+                                       model: nil, unitType: "u",
+                                       pricePerUnit: 0.01,
+                                       grossQuantity: 1, grossAmount: 0.01,
+                                       discountQuantity: 0, discountAmount: 0,
+                                       netQuantity: 1, netAmount: 0.01)]
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "copilot-mtd" })?.kind {
+            // The bare year "2026" should appear (no January-2027 rollover).
+            expectEqual(plan, "2026")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Copilot parseUsage: MISSING usageItems throws, DOES NOT become org-billed (Codex #6)") {
+        // The OpenAPI spec makes usageItems REQUIRED. A missing key means
+        // schema violation, not org-billed. `usageItems: []` is the true
+        // org-billed signal and is tested elsewhere.
+        let json = """
+        {"timePeriod": {"year": 2026}, "user": "u"}
+        """
+        guard let data = json.data(using: .utf8) else { expect(false); return }
+        do {
+            _ = try CopilotUsageFetcher.parseUsage(data)
+            expect(false, "expected throw for missing usageItems")
+        } catch let e as CopilotUsageParseError {
+            if case .unexpectedShape = e { expect(true) }
+            else { expect(false, "wrong error case") }
+        } catch {
+            expect(false, "wrong error type")
+        }
+    }
+
+    run("Copilot conforms to PasteKeyProvider with default 'Key' noun") {
+        // Copilot is a PAT (not a cookie) — the default "Key" noun applies.
+        let store = CopilotUsageStore(credentials: InMemoryCredentialStore(),
+                                      transport: StubCopilotTransport(.networkError),
+                                      defaults: defaults)
+        let paster = store as PasteKeyProvider
+        expectEqual(paster.secretKindNoun, "Key")
+        expect(paster.keyPlaceholder.contains("github_pat_"))
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1691,6 +1691,641 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - PerplexityCookie extraction (PR 8-BE)
+
+run("Perplexity cookie: bare token wrapped under default name") {
+    let extracted = PerplexityCookie.extract(from: "  ey.jwe.raw.value  ")
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "ey.jwe.raw.value")
+}
+
+run("Perplexity cookie: empty input returns nil") {
+    expect(PerplexityCookie.extract(from: "   ") == nil)
+}
+
+run("Perplexity cookie: name=value pair (Secure next-auth)") {
+    let raw = "__Secure-next-auth.session-token=abc.def.ghi"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "abc.def.ghi")
+}
+
+run("Perplexity cookie: prefers Secure over unprefixed within a full header") {
+    // A user pasting a full DevTools "Copy string" gets many cookies; the
+    // Secure-prefixed variant must win over the plain one.
+    let raw = "next-auth.session-token=OLD; __Secure-next-auth.session-token=NEW; _ga=1"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "NEW")
+}
+
+run("Perplexity cookie: unprefixed next-auth falls through when Secure absent") {
+    let raw = "next-auth.session-token=UNPREFIXED; other=1"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "next-auth.session-token")
+    expectEqual(extracted?.token, "UNPREFIXED")
+}
+
+run("Perplexity cookie: Auth.js v5 __Secure-authjs.session-token") {
+    let raw = "__Secure-authjs.session-token=V5TOK"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-authjs.session-token")
+    expectEqual(extracted?.token, "V5TOK")
+}
+
+run("Perplexity cookie: unprefixed authjs.session-token") {
+    let raw = "authjs.session-token=V5PLAIN"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "authjs.session-token")
+    expectEqual(extracted?.token, "V5PLAIN")
+}
+
+run("Perplexity cookie: NextAuth chunked variant reassembles in index order") {
+    // NextAuth splits a large JWE across ".0", ".1", … suffixed cookies.
+    // Reassembly must respect the numeric index, not the paste order.
+    let raw = "__Secure-next-auth.session-token.1=BBB; __Secure-next-auth.session-token.0=AAA"
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "AAABBB")
+}
+
+run("Perplexity cookie: chunk index Int.max is rejected (overflow guard)") {
+    // Codex adversarial review #2: a hostile paste `…session-token.<Int.max>=x`
+    // must not trap on `maxIdx + 1` nor force massive reserveCapacity.
+    let raw = "__Secure-next-auth.session-token.9223372036854775807=EVIL"
+    expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+run("Perplexity cookie: chunk index above sane cap is rejected") {
+    // Real NextAuth chunk indexes are single digits. Anything past the
+    // maxAllowedChunkIndex sentinel is refused before it reaches reassemble.
+    let raw = "__Secure-next-auth.session-token.99999=EVIL; __Secure-next-auth.session-token.0=OK"
+    let extracted = PerplexityCookie.extract(from: raw)
+    // The .0 chunk alone is a valid single-chunk cookie.
+    expectEqual(extracted?.token, "OK")
+}
+
+run("Perplexity cookie: unrelated cookies alone → nil") {
+    let raw = "_ga=1; _gcl=2; theme=dark"
+    expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+run("Perplexity cookie: bare token containing base64 = padding routes verbatim") {
+    // Codex adversarial review #7: an opaque token like `abc.def==` must not
+    // be mis-parsed as an unsupported `abc.def=` cookie name. When there is
+    // no `;` separator and no supported cookie name matched, the whole input
+    // is treated as a bare token under the default name.
+    let raw = "abc.def=="
+    let extracted = PerplexityCookie.extract(from: raw)
+    expectEqual(extracted?.name, "__Secure-next-auth.session-token")
+    expectEqual(extracted?.token, "abc.def==")
+}
+
+run("Perplexity cookie: paste with `;` but no supported session cookie → nil (not bare-token fallback)") {
+    // A cookie-header-shaped paste that lacks any supported session cookie
+    // is a mistake we surface, not something to paper over by treating the
+    // whole blob as a token.
+    let raw = "_ga=1; theme=dark"
+    expect(PerplexityCookie.extract(from: raw) == nil)
+}
+
+// MARK: - PerplexityUsageFetcher.parseCredits
+
+run("Perplexity parseCredits: happy path with recurring + promo + purchased grants") {
+    // Synthetic fixture — shape matches multiple independent live captures
+    // (CodexBar PerplexityModels.swift; jacob-bd/perplexity-web-mcp). All
+    // amounts are floats in USD cents; timestamps are Unix seconds.
+    let json = """
+    {
+      "balance_cents": 4235.50,
+      "renewal_date_ts": 1770000000,
+      "current_period_purchased_cents": 500.0,
+      "total_usage_cents": 764.5,
+      "credit_grants": [
+        { "type": "recurring",    "amount_cents": 5000.0, "expires_at_ts": null },
+        { "type": "promotional",  "amount_cents": 250.0,  "expires_at_ts": 1780000000 },
+        { "type": "purchased",    "amount_cents": 500.0,  "expires_at_ts": null }
+      ]
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false, "utf8 data"); return }
+    do {
+        let parsed = try PerplexityUsageFetcher.parseCredits(data)
+        expectEqual(parsed.balanceCents, 4235.50)
+        expectEqual(parsed.renewalEpoch, 1770000000)
+        expectEqual(parsed.currentPeriodPurchasedCents, 500.0)
+        expectEqual(parsed.totalUsageCents, 764.5)
+        expectEqual(parsed.grants.count, 3)
+        expectEqual(parsed.grants[0].type, "recurring")
+        expectEqual(parsed.grants[0].amountCents, 5000.0)
+        expect(parsed.grants[0].expiresAtEpoch == nil)
+        expectEqual(parsed.grants[1].type, "promotional")
+        expectEqual(parsed.grants[1].expiresAtEpoch, 1780000000)
+    } catch {
+        expect(false, "parseCredits threw: \(error)")
+    }
+}
+
+run("Perplexity parseCredits: empty account tolerated (Free tier)") {
+    // A Free-tier account may have zero grants and a zero balance. Parser
+    // must not throw or drop into unexpectedShape.
+    let json = """
+    {"balance_cents": 0, "renewal_date_ts": 0, "current_period_purchased_cents": 0, "total_usage_cents": 0, "credit_grants": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expect(parsed != nil)
+    expectEqual(parsed?.grants.count, 0)
+    expectEqual(parsed?.balanceCents, 0)
+}
+
+run("Perplexity parseCredits: invalid JSON throws invalidJSON") {
+    let data = Data("<html>Just a moment...</html>".utf8)  // Cloudflare challenge HTML
+    do {
+        _ = try PerplexityUsageFetcher.parseCredits(data)
+        expect(false, "expected throw")
+    } catch let e as PerplexityUsageParseError {
+        expectEqual(e, .invalidJSON)
+    } catch {
+        expect(false, "wrong error type")
+    }
+}
+
+run("Perplexity parseCredits: non-finite Double is coerced to safe values") {
+    // Defence against a hostile / broken response with 1e400-style numbers.
+    // JSONSerialization already refuses to decode `NaN`/`Infinity` as bare
+    // JSON tokens, so exercise the coercion via a numeric string.
+    let json = """
+    {"balance_cents": "not-a-number", "renewal_date_ts": 1770000000, "credit_grants": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expectEqual(parsed?.balanceCents, 0)   // failed string coercion → 0, not a crash
+    expectEqual(parsed?.renewalEpoch, 1770000000)
+}
+
+run("Perplexity parseCredits: out-of-range renewal_date_ts is treated as missing") {
+    // Codex adversarial review round 2 #4: a wild timestamp must not flow
+    // into a pathological Date.
+    let json = """
+    {"balance_cents": 100, "renewal_date_ts": 1e300, "credit_grants": [
+        {"type": "recurring", "amount_cents": 500, "expires_at_ts": 1e300}
+    ]}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expectEqual(parsed?.renewalEpoch, 0)                          // clamped
+    expect(parsed?.grants.first?.expiresAtEpoch == nil)           // clamped to nil
+}
+
+run("Perplexity parseCredits: pre-2000 renewal timestamp rejected") {
+    // A stray 0 or a 1970-era timestamp is outside the sane range and
+    // should be reported as "no renewal date" rather than plumbed through.
+    let json = """
+    {"balance_cents": 100, "renewal_date_ts": 100, "credit_grants": []}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseCredits(data)
+    expectEqual(parsed?.renewalEpoch, 0)
+}
+
+// MARK: - PerplexityUsageFetcher.parseRateLimits
+
+run("Perplexity parseRateLimits: full Pro-account shape") {
+    // Shape from three independent live captures. Only remaining_* on the
+    // top level; sources.source_to_limit for connectors.
+    let json = """
+    {
+      "remaining_pro": 192,
+      "remaining_research": 19,
+      "remaining_labs": 25,
+      "remaining_agentic_research": 2,
+      "model_specific_limits": {},
+      "sources": {
+        "source_to_limit": {
+          "web":       {"monthly_limit": null, "remaining": null},
+          "scholar":   {"monthly_limit": null, "remaining": null},
+          "bmj_mcp":   {"monthly_limit": 500, "remaining": 495},
+          "nejm_alt":  {"monthly_limit": 25,  "remaining": 10}
+        }
+      }
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    do {
+        let parsed = try PerplexityUsageFetcher.parseRateLimits(data)
+        expectEqual(parsed.remainingPro, 192)
+        expectEqual(parsed.remainingResearch, 19)
+        expectEqual(parsed.remainingLabs, 25)
+        expectEqual(parsed.remainingAgenticResearch, 2)
+        expectEqual(parsed.sources.count, 4)
+        // Sorted by sourceId for determinism.
+        expectEqual(parsed.sources[0].sourceId, "bmj_mcp")
+        expectEqual(parsed.sources[0].monthlyLimit, 500)
+        expectEqual(parsed.sources[0].remaining, 495)
+        // Nulls preserved as nil.
+        let web = parsed.sources.first { $0.sourceId == "web" }
+        expect(web?.monthlyLimit == nil)
+        expect(web?.remaining == nil)
+    } catch {
+        expect(false, "parseRateLimits threw: \(error)")
+    }
+}
+
+run("Perplexity parseRateLimits: Free account with omitted sources") {
+    // Free-tier / anonymous omits the sources map entirely; must parse.
+    let json = """
+    {"remaining_pro": 3, "remaining_research": 0, "remaining_labs": 0, "remaining_agentic_research": 0}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseRateLimits(data)
+    expectEqual(parsed?.remainingPro, 3)
+    expectEqual(parsed?.sources.count, 0)
+}
+
+run("Perplexity parseRateLimits: negative remaining clamped to zero") {
+    // Defence: a hostile / miscalculated server value must not surface as a
+    // negative counter tile ("-5 Pro Search remaining").
+    let json = """
+    {"remaining_pro": -5, "remaining_research": 10, "remaining_labs": 0, "remaining_agentic_research": 0}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseRateLimits(data)
+    expectEqual(parsed?.remainingPro, 0)
+    expectEqual(parsed?.remainingResearch, 10)
+}
+
+// MARK: - PerplexityUsageFetcher.parseUserSettings
+
+run("Perplexity parseUserSettings: subscription fields + numeric limits") {
+    let json = """
+    {
+      "pages_limit": 100,
+      "upload_limit": 500,
+      "create_limit": 25,
+      "max_files_per_user": 500,
+      "max_files_per_repository": 100,
+      "subscription_status": "active",
+      "subscription_source": "stripe",
+      "subscription_tier": "pro",
+      "query_count": 42,
+      "query_count_copilot": 7,
+      "default_model": "sonar-pro",
+      "has_ai_profile": true
+    }
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    do {
+        let parsed = try PerplexityUsageFetcher.parseUserSettings(data)
+        expectEqual(parsed.subscriptionStatus, "active")
+        expectEqual(parsed.subscriptionSource, "stripe")
+        expectEqual(parsed.subscriptionTier, "pro")
+        expectEqual(parsed.pagesLimit, 100)
+        expectEqual(parsed.uploadLimit, 500)
+        expectEqual(parsed.createLimit, 25)
+        expectEqual(parsed.queryCount, 42)
+    } catch {
+        expect(false, "parseUserSettings threw: \(error)")
+    }
+}
+
+run("Perplexity parseUserSettings: unknown tier preserved verbatim") {
+    // Guard against silently dropping a new server-side tier.
+    let json = """
+    {"subscription_tier": "enterprise-yearly", "subscription_status": "active"}
+    """
+    guard let data = json.data(using: .utf8) else { expect(false); return }
+    let parsed = try? PerplexityUsageFetcher.parseUserSettings(data)
+    expectEqual(parsed?.subscriptionTier, "enterprise-yearly")
+}
+
+// MARK: - PerplexityUsageStore (in-memory credentials + stubbed transport)
+
+final class StubPerplexityTransport: PerplexityUsageTransport, @unchecked Sendable {
+    let result: PerplexityUsageResult
+    init(_ result: PerplexityUsageResult) { self.result = result }
+    func fetchAll(cookieName: String, cookieValue: String, completion: @escaping @Sendable (PerplexityUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "perplexity-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.perplexity.enabled")
+
+    run("Perplexity store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("Perplexity enabled without cookie emits needsAccess card") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("Perplexity locked keychain still counted as configured") {
+        // ".unavailable means still configured" invariant from PR #60.
+        let store = PerplexityUsageStore(credentials: UnavailableCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, true)
+    }
+
+    run("Perplexity saveKey stores cookie; clear deletes it") {
+        let creds = InMemoryCredentialStore()
+        let store = PerplexityUsageStore(credentials: creds, transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.hasKey, false)
+        store.saveKey("__Secure-next-auth.session-token=abc")
+        expectEqual(store.hasKey, true)
+        store.clear()
+        expectEqual(store.hasKey, false)
+    }
+
+    run("Perplexity saveKey with whitespace-only clears") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("initial")
+        store.saveKey("   \n  ")   // deletes
+        expectEqual(store.hasKey, false)
+    }
+
+    run("Perplexity plan tile derived from subscription_tier + status") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.settings = PerplexityUserSettings(
+            subscriptionStatus: "active",
+            subscriptionSource: "stripe",
+            subscriptionTier: "pro"
+        )
+        store.apply(.success(snap))
+        let planTile = store.tiles.first { $0.id == "perplexity-plan" }
+        expect(planTile != nil)
+        if case let .text(status, _) = planTile?.kind {
+            expect(status.contains("Pro"))
+            expect(status.contains("active"))
+        } else {
+            expect(false, "expected text tile")
+        }
+    }
+
+    run("Perplexity credits tile carries USD cents + Max plan hint from large recurring grant") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            balanceCents: 4235.50,
+            renewalEpoch: 1770000000,
+            currentPeriodPurchasedCents: 0,
+            // Max recurring ~$500/mo = 50 000 cents. Above the 10 000c boundary.
+            grants: [PerplexityCreditGrant(type: "recurring", amountCents: 50000, expiresAtEpoch: nil)],
+            totalUsageCents: 764.5
+        )
+        store.apply(.success(snap))
+        let tile = store.tiles.first { $0.id == "perplexity-credits" }
+        expect(tile != nil)
+        if case let .balance(minor, currency, plan, resetsAt) = tile?.kind {
+            expectEqual(minor, 4236)          // rounded from 4235.50
+            expectEqual(currency, "USD")
+            expectEqual(plan, "Max")          // recurring >= 10 000c → Max
+            expect(resetsAt != nil)
+        } else {
+            expect(false, "expected balance tile")
+        }
+    }
+
+    run("Perplexity credits tile: Pro plan hint from a $50-tier recurring grant") {
+        // Codex adversarial review #3: the initial 5 000c threshold flipped
+        // Pro users to "Max" — a $50 grant must still register as Pro.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            balanceCents: 350.0,
+            renewalEpoch: 1770000000,
+            grants: [PerplexityCreditGrant(type: "recurring", amountCents: 5000, expiresAtEpoch: nil)],  // $50
+            totalUsageCents: 150.0
+        )
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "perplexity-credits" })?.kind {
+            expectEqual(plan, "Pro")   // 5 000c < 10 000c
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Perplexity credits tile: absurdly large balance_cents does not trap the tile mapper") {
+        // Codex adversarial review #1: a hostile 1e300 balance would have
+        // trapped `Int(Double)`. The new clamp routes it to Int.max instead.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 1e300, renewalEpoch: 1770000000)
+        store.apply(.success(snap))
+        // Must not crash. Balance tile is emitted with a clamped value.
+        let tile = store.tiles.first { $0.id == "perplexity-credits" }
+        expect(tile != nil)
+        if case let .balance(minor, _, _, _) = tile?.kind {
+            expect(minor > 0)          // clamped, not zero, not a trap
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Perplexity credits tile: no plan hint when only promotional grant present") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            grants: [PerplexityCreditGrant(type: "promotional", amountCents: 500, expiresAtEpoch: 1780000000)]
+        )
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "perplexity-credits" })?.kind {
+            expect(plan == nil, "no recurring grant → no plan hint")
+        } else { expect(false, "expected balance tile") }
+    }
+
+    run("Perplexity rate-limit counters only emitted when remaining > 0") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.rateLimits = PerplexityRateLimits(
+            remainingPro: 42,
+            remainingResearch: 0,     // omitted from tiles
+            remainingLabs: 5,
+            remainingAgenticResearch: 0
+        )
+        store.apply(.success(snap))
+        let ids = store.tiles.map { $0.id }
+        expect(ids.contains("perplexity-pro"))
+        expect(ids.contains("perplexity-labs"))
+        expect(!ids.contains("perplexity-research"))
+        expect(!ids.contains("perplexity-agentic"))
+    }
+
+    run("Perplexity rate-limit tile uses .text 'N left' with no resets") {
+        // Codex adversarial review #4: the endpoint reports remaining only
+        // — no total, no reset. Rendering as `.counter(used: 0, limit: 42)`
+        // would read as an unused-42-limit meter. Render as a text tile.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.rateLimits = PerplexityRateLimits(remainingPro: 42)
+        store.apply(.success(snap))
+        if case let .text(status, subtitle) = store.tiles.first(where: { $0.id == "perplexity-pro" })?.kind {
+            expectEqual(status, "42 left")
+            expect(subtitle == nil)
+        } else {
+            expect(false, "expected text tile")
+        }
+    }
+
+    run("Perplexity 401 maps to session-expired error AND drops stale snapshot") {
+        // Codex adversarial review #6: a stale snapshot must not linger
+        // after the credential is known-bad — old numbers on the tile are
+        // worse than an onboarding message.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.unauthorized), defaults: defaults)
+        store.saveKey("expired-cookie")
+        // First a successful fetch populates the snapshot.
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 100)
+        store.apply(.success(snap))
+        expect(store.snapshot != nil)
+        // Then the cookie is revoked → 401 arrives.
+        store.apply(.unauthorized)
+        expect(store.errorMessage?.contains("expired") == true || store.errorMessage?.contains("blocked") == true)
+        expect(store.snapshot == nil)  // stale data cleared
+    }
+
+    run("Perplexity fetch() completion from a background queue applies safely") {
+        // Codex adversarial review #9: the store hops through
+        // Task { @MainActor } — a regression to `assumeIsolated` would trap
+        // when a real URLSession completion lands off-main. This transport
+        // dispatches its completion onto a background queue to exercise
+        // that path.
+        final class BackgroundQueueTransport: PerplexityUsageTransport, @unchecked Sendable {
+            func fetchAll(cookieName: String, cookieValue: String, completion: @escaping @Sendable (PerplexityUsageResult) -> Void) {
+                DispatchQueue.global().async { completion(.unauthorized) }
+            }
+        }
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: BackgroundQueueTransport(), defaults: defaults)
+        store.saveKey("cookie")
+        store.fetch()
+        // Spin the runloop briefly so the Task { @MainActor } hop is
+        // observed; TestRunner drives synchronous main-actor work only,
+        // so we sleep on the main thread just long enough for the hop.
+        let deadline = Date().addingTimeInterval(1.0)
+        while store.errorMessage == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.errorMessage != nil)
+    }
+
+    run("Perplexity partial success: only credits present renders credits tile") {
+        // Cloudflare-challenge a subset. Only `credits` came back OK.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 100.0, renewalEpoch: 1770000000)
+        store.apply(.success(snap))
+        expect(store.tiles.contains { $0.id == "perplexity-credits" })
+        expect(!store.tiles.contains { $0.id == "perplexity-plan" })
+    }
+
+    run("Perplexity conforms to PasteKeyProvider protocol") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        let paster = store as PasteKeyProvider
+        expect(paster.keyPlaceholder.contains("session-token") || paster.keyPlaceholder.contains("cookie"))
+        expectEqual(paster.hasKey, false)
+        paster.saveKey("pasted-cookie-value")
+        expectEqual(paster.hasKey, true)
+    }
+
+    run("Perplexity 429 surfaces a rate-limit specific message, not generic Network error") {
+        // Codex adversarial review round 3. If Perplexity shadow-bans /
+        // rate-limits the session, all three endpoints return 429 and the
+        // transport now emits .httpError(429). The store's apply() maps it
+        // to an actionable message about slowing down.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.httpError(429)), defaults: defaults)
+        store.saveKey("cookie")
+        store.apply(.httpError(429))
+        expect(store.errorMessage?.contains("rate-limit") == true || store.errorMessage?.contains("Slow") == true)
+    }
+
+    run("Perplexity 5xx surfaces a server-error specific message") {
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.httpError(503)), defaults: defaults)
+        store.saveKey("cookie")
+        store.apply(.httpError(503))
+        expect(store.errorMessage?.contains("server error") == true || store.errorMessage?.contains("503") == true)
+    }
+
+    run("Perplexity fetch() with a malformed stored cookie surfaces an error message") {
+        // Codex adversarial review round 2 #1. A stored blob that hasKey=true
+        // but extract()=nil must not silently render blank tiles indefinitely.
+        let creds = InMemoryCredentialStore()
+        // Write a value directly (bypassing saveKey's trimming) that
+        // exercises the extract=nil path — a chunked cookie with a bogus
+        // index the overflow guard rejects.
+        creds.write(PerplexityUsageFetcher.cookieKeychainKey,
+                    Data("__Secure-next-auth.session-token.9999999=EVIL".utf8))
+        let store = PerplexityUsageStore(credentials: creds, transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, true)   // presence, not parseability
+        store.fetch()
+        expect(store.errorMessage?.contains("parse") == true || store.errorMessage?.contains("Re-paste") == true)
+    }
+
+    run("Perplexity transport rejects a semicolon-injected cookie name") {
+        // Codex adversarial review round 2 #2. cookieName splicing.
+        let transport = URLSessionPerplexityTransport()
+        final class Box: @unchecked Sendable { var value: PerplexityUsageResult? }
+        let box = Box()
+        transport.fetchAll(cookieName: "__Secure-next-auth.session-token=real; other", cookieValue: "evil") { result in
+            box.value = result
+        }
+        let deadline = Date().addingTimeInterval(2.0)
+        while box.value == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        if case .unauthorized = box.value {
+            expect(true)
+        } else {
+            expect(false, "expected .unauthorized, got \(String(describing: box.value))")
+        }
+    }
+
+    run("Perplexity transport rejects a semicolon-injected cookie value") {
+        // Codex adversarial review #5. A hostile paste like "real; other=evil"
+        // is caught by extract() when the paste is parsed (it becomes a full
+        // header the extractor picks from), but a value with an embedded `;`
+        // arriving DIRECTLY at fetchAll — e.g. an attacker-controlled
+        // Keychain item bypassing extract() — must not silently splice a
+        // second cookie into the request. The production transport rejects.
+        //
+        // The transport dispatches the completion via DispatchQueue.main.async,
+        // so we drive the runloop until it fires rather than blocking on a
+        // semaphore (which would deadlock the main-queue hop).
+        let transport = URLSessionPerplexityTransport()
+        final class Box: @unchecked Sendable { var value: PerplexityUsageResult? }
+        let box = Box()
+        transport.fetchAll(cookieName: "__Secure-next-auth.session-token", cookieValue: "real; other=evil") { result in
+            box.value = result
+        }
+        let deadline = Date().addingTimeInterval(2.0)
+        while box.value == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        if case .unauthorized = box.value {
+            expect(true)
+        } else {
+            expect(false, "expected .unauthorized rejection, got \(String(describing: box.value))")
+        }
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -797,6 +797,42 @@ final class InMemoryCredentialStore: CredentialStore {
     func delete(_ key: String) { storage[key] = nil }
 }
 
+/// A CredentialStore that always reports the keychain as present-but-locked,
+/// to exercise the ".unavailable means still configured" hardening.
+final class UnavailableCredentialStore: CredentialStore {
+    func read(_ key: String) -> Data? { nil }
+    func write(_ key: String, _ value: Data) {}
+    func delete(_ key: String) {}
+    func readResult(_ key: String) -> CredentialReadResult {
+        .unavailable(-25308)  // errSecInteractionNotAllowed
+    }
+}
+
+run("CredentialStore.readResult default maps read() to found/missing") {
+    let store = InMemoryCredentialStore()
+    expectEqual(store.readResult("k"), .missing)
+    store.write("k", Data("v".utf8))
+    expectEqual(store.readResult("k"), .found(Data("v".utf8)))
+}
+
+MainActor.assumeIsolated {
+    let suite = "credavail-\(ProcessInfo.processInfo.processIdentifier)"
+    let d = UserDefaults(suiteName: suite)!
+    d.removePersistentDomain(forName: suite)
+    d.set(true, forKey: "features.deepseek.enabled")
+
+    run("Locked keychain keeps a provider configured (not onboarding)") {
+        // Regression: a locked keychain must NOT look like "no key" and drop
+        // the provider back to the paste-key card.
+        let store = DeepSeekUsageStore(credentials: UnavailableCredentialStore(), defaults: d)
+        expectEqual(store.hasKey, true)         // unavailable == still configured
+        expectEqual(store.isConfigured, true)
+        // No needsAccess onboarding tile while merely locked.
+        expect(!store.tiles.contains { if case .needsAccess = $0.kind { return true }; return false })
+    }
+    d.removePersistentDomain(forName: suite)
+}
+
 MainActor.assumeIsolated {
     let suiteName = "deepseek-tests-\(ProcessInfo.processInfo.processIdentifier)"
     let defaults = UserDefaults(suiteName: suiteName)!
@@ -1051,7 +1087,35 @@ run("ZedCredentials builds a space-delimited Authorization value") {
     let creds = ZedCredentials(userId: "12345", accessToken: "tok-abc")
     expectEqual(creds.authorizationHeaderValue, "12345 tok-abc")
     // Explicitly NOT the Bearer scheme.
-    expect(!creds.authorizationHeaderValue.hasPrefix("Bearer"))
+    expect(creds.authorizationHeaderValue?.hasPrefix("Bearer") == false)
+}
+
+run("ZedCredentials rejects header injection via control chars") {
+    // A user id or token containing CR/LF must not produce a header value
+    // (would allow header splitting/injection).
+    let crlf = ZedCredentials(userId: "12345\r\nX-Evil: 1", accessToken: "tok")
+    expect(crlf.authorizationHeaderValue == nil)
+    let newlineTok = ZedCredentials(userId: "12345", accessToken: "tok\nInjected")
+    expect(newlineTok.authorizationHeaderValue == nil)
+}
+
+run("RequestSafety.pathSegment encodes path-altering characters") {
+    // A benign id passes through (only unreserved chars).
+    expectEqual(RequestSafety.pathSegment("team_abc-123"), "team_abc-123")
+    // Path-structure characters are encoded, not passed through.
+    expectEqual(RequestSafety.pathSegment("a/b"), "a%2Fb")
+    expectEqual(RequestSafety.pathSegment("../admin"), "..%2Fadmin")
+    expectEqual(RequestSafety.pathSegment("x?y#z"), "x%3Fy%23z")
+    // Control characters are rejected entirely.
+    expect(RequestSafety.pathSegment("a\nb") == nil)
+    expect(RequestSafety.pathSegment("") == nil)
+}
+
+run("RequestSafety.headerValue rejects control chars, passes clean values") {
+    expectEqual(RequestSafety.headerValue("user-123"), "user-123")
+    expect(RequestSafety.headerValue("a\rb") == nil)
+    expect(RequestSafety.headerValue("a\nb") == nil)
+    expect(RequestSafety.headerValue("") == nil)
 }
 
 // MARK: - ZedUsageStore (injected credential reader, no real Keychain)
@@ -1321,9 +1385,12 @@ MainActor.assumeIsolated {
     }
 
     run("xAI 401 maps to invalid-key error") {
+        // Assert via the synchronous apply() seam; fetch() now hops through
+        // Task { @MainActor } (safe on any queue) so its effect is not
+        // observable synchronously in this runner.
         let store = XAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubXAITransport(.unauthorized), defaults: defaults)
         store.saveInferenceKey("xai-bad")
-        store.fetch()
+        store.apply(.unauthorized)
         expectEqual(store.errorMessage, "Invalid xAI API key")
     }
 
@@ -1455,6 +1522,53 @@ run("parse OpenAI rate_limits: per-model ceilings") {
     expectEqual(limits[0].maxTokensPerMinute, 2000000)
 }
 
+run("parse OpenAI survives an out-of-range JSON number without trapping") {
+    // A hostile API sends 1e300 where a token count is expected. Int(Double)
+    // would TRAP; the safe conversion must yield nil -> 0, no crash.
+    let bytes = #"""
+    {"object":"page","data":[{"object":"bucket","results":[
+      {"input_tokens": 1e300, "output_tokens": 5, "num_model_requests": 1, "model": "gpt-4o"}
+    ]}]}
+    """#.data(using: .utf8)!
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(bytes)
+    expectEqual(tokens.count, 1)
+    // input_tokens (1e300) -> nil -> 0; output stays 5.
+    expectEqual(tokens[0].inputTokens, 0)
+    expectEqual(tokens[0].outputTokens, 5)
+}
+
+run("parse OpenAI clamps negative token counts to zero") {
+    let bytes = #"""
+    {"object":"page","data":[{"object":"bucket","results":[
+      {"input_tokens": -100, "output_tokens": 50, "num_model_requests": -3, "model": "gpt-4o"}
+    ]}]}
+    """#.data(using: .utf8)!
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(bytes)
+    expectEqual(tokens[0].inputTokens, 0)   // clamped
+    expectEqual(tokens[0].outputTokens, 50)
+    expectEqual(tokens[0].requests, 0)      // clamped
+}
+
+run("parse xAI balance survives an out-of-range string val without trapping") {
+    // A gigantic numeric string overflows Int -> nil -> parseBalance throws,
+    // rather than trapping or producing a garbage value.
+    let bytes = #"{"total": {"val": "999999999999999999999999999999"}}"#.data(using: .utf8)!
+    do {
+        _ = try XAIUsageFetcher.parseBalance(bytes)
+        expect(false, "expected throw on overflowing val")
+    } catch { expect(true) }
+}
+
+run("parse Zed safeInt handles out-of-range Double without trapping") {
+    // edit_predictions.used = 1e300 must not trap.
+    let bytes = #"""
+    {"plan": {"plan_v3": "zed_free", "usage": {"edit_predictions": {"used": 1e300, "limit": "unlimited"}}}}
+    """#.data(using: .utf8)!
+    let snap = try! ZedUsageFetcher.parse(bytes)
+    // used could not be represented -> stays at the default 0, no crash.
+    expectEqual(snap.editPredictions?.used, 0)
+}
+
 run("parse OpenAI completions throws on array top-level") {
     do {
         _ = try OpenAIUsageFetcher.parseCompletions("[]".data(using: .utf8)!)
@@ -1557,9 +1671,11 @@ MainActor.assumeIsolated {
     }
 
     run("OpenAI 401 maps to invalid-admin-key error") {
+        // Assert via the synchronous apply() seam (fetch() now hops through
+        // Task { @MainActor }, not observable synchronously here).
         let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.unauthorized), defaults: defaults)
         store.saveKey("sk-admin-bad")
-        store.fetch()
+        store.apply(.unauthorized)
         expectEqual(store.errorMessage, "Invalid OpenAI Admin key")
     }
 

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -662,6 +662,15 @@ run("ProviderCopy.help returns DeepSeek Keychain guidance") {
     expect(ds?.contains("balance") == true)
 }
 
+run("ProviderCopy.help returns Zed guidance and no disclosure") {
+    let zed = ProviderCopy.help(for: "zed")
+    expect(zed != nil)
+    expect(zed?.contains("edit-prediction") == true)
+    expect(zed?.contains("Keychain") == true)
+    // Zed reads a first-party local credential — no private-API disclosure.
+    expect(ProviderCopy.disclosure(for: "zed") == nil)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1325,6 +1325,202 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - OpenAIUsageFetcher (PR 7-BE)
+
+// Completions usage — bucketed page envelope (verified vs OpenAI Admin API).
+// results grouped by model; multiple buckets aggregate per model.
+let fixtureOpenAICompletions = #"""
+{
+  "object": "page",
+  "has_more": false,
+  "next_page": null,
+  "data": [
+    {
+      "object": "bucket",
+      "start_time": 1751000000,
+      "end_time": 1751003600,
+      "results": [
+        {"object": "organization.usage.completions.result", "input_tokens": 1000, "output_tokens": 500, "num_model_requests": 10, "model": "gpt-4o"},
+        {"object": "organization.usage.completions.result", "input_tokens": 200, "output_tokens": 100, "num_model_requests": 3, "model": "gpt-4o-mini"}
+      ]
+    },
+    {
+      "object": "bucket",
+      "start_time": 1751003600,
+      "end_time": 1751007200,
+      "results": [
+        {"object": "organization.usage.completions.result", "input_tokens": 3000, "output_tokens": 1500, "num_model_requests": 20, "model": "gpt-4o"}
+      ]
+    }
+  ]
+}
+"""#
+
+run("parse OpenAI completions: aggregate tokens by model across buckets") {
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(fixtureOpenAICompletions.data(using: .utf8)!)
+    expectEqual(tokens.count, 2)
+    // gpt-4o: 1000+3000 input, 500+1500 output, 10+20 requests -> highest total, first.
+    expectEqual(tokens[0].model, "gpt-4o")
+    expectEqual(tokens[0].inputTokens, 4000)
+    expectEqual(tokens[0].outputTokens, 2000)
+    expectEqual(tokens[0].requests, 30)
+    expectEqual(tokens[0].totalTokens, 6000)
+    expectEqual(tokens[1].model, "gpt-4o-mini")
+    expectEqual(tokens[1].totalTokens, 300)
+}
+
+run("parse OpenAI completions: results with null model fold into 'all'") {
+    let bytes = #"""
+    {"object": "page", "data": [{"object": "bucket", "results": [{"input_tokens": 5, "output_tokens": 5, "num_model_requests": 1}]}]}
+    """#.data(using: .utf8)!
+    let tokens = try! OpenAIUsageFetcher.parseCompletions(bytes)
+    expectEqual(tokens.count, 1)
+    expectEqual(tokens[0].model, "all")
+    expectEqual(tokens[0].totalTokens, 10)
+}
+
+// Costs — amount.value is a float in USD dollars; currency lowercase "usd".
+let fixtureOpenAICosts = #"""
+{
+  "object": "page",
+  "has_more": false,
+  "data": [
+    {"object": "bucket", "start_time": 1751000000, "end_time": 1751086400, "results": [
+      {"object": "organization.costs.result", "amount": {"value": 0.13080438, "currency": "usd"}, "line_item": "gpt-4o"},
+      {"object": "organization.costs.result", "amount": {"value": 1.25, "currency": "usd"}, "line_item": "gpt-4o-mini"}
+    ]}
+  ]
+}
+"""#
+
+run("parse OpenAI costs: sum amount.value across line items") {
+    let cost = try! OpenAIUsageFetcher.parseCosts(fixtureOpenAICosts.data(using: .utf8)!)
+    expect(abs(cost.usd - 1.38080438) < 0.0001)
+    expectEqual(cost.currency, "usd")
+}
+
+run("parse OpenAI costs: empty buckets -> zero") {
+    let bytes = #"{"object": "page", "data": []}"#.data(using: .utf8)!
+    let cost = try! OpenAIUsageFetcher.parseCosts(bytes)
+    expectEqual(cost.usd, 0.0)
+    expect(cost.currency == nil)
+}
+
+// Rate limits — {object:"list", data:[{model, max_requests_per_1_minute, ...}]}
+let fixtureOpenAIRateLimits = #"""
+{
+  "object": "list",
+  "has_more": false,
+  "data": [
+    {"object": "project.rate_limit", "id": "rl-gpt-4o", "model": "gpt-4o", "max_requests_per_1_minute": 10000, "max_tokens_per_1_minute": 2000000},
+    {"object": "project.rate_limit", "id": "rl-gpt-4o-mini", "model": "gpt-4o-mini", "max_requests_per_1_minute": 30000, "max_tokens_per_1_minute": 150000000}
+  ]
+}
+"""#
+
+run("parse OpenAI rate_limits: per-model ceilings") {
+    let limits = try! OpenAIUsageFetcher.parseRateLimits(fixtureOpenAIRateLimits.data(using: .utf8)!)
+    expectEqual(limits.count, 2)
+    expectEqual(limits[0].model, "gpt-4o")
+    expectEqual(limits[0].maxRequestsPerMinute, 10000)
+    expectEqual(limits[0].maxTokensPerMinute, 2000000)
+}
+
+run("parse OpenAI completions throws on array top-level") {
+    do {
+        _ = try OpenAIUsageFetcher.parseCompletions("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+run("OpenAI startOfUTCMonth returns a month boundary") {
+    // 2026-07-12 -> start of 2026-07-01 UTC. Just assert it is <= the input
+    // and a plausible epoch (non-zero).
+    let mid = Date(timeIntervalSince1970: 1752300000) // 2026-07-12ish
+    let start = URLSessionOpenAITransport.startOfUTCMonth(mid)
+    expect(start > 0)
+    expect(start <= Int(mid.timeIntervalSince1970))
+}
+
+// MARK: - OpenAIUsageStore
+
+final class StubOpenAITransport: OpenAIUsageTransport, @unchecked Sendable {
+    let result: OpenAIUsageResult
+    init(_ result: OpenAIUsageResult) { self.result = result }
+    func fetchAll(adminKey: String, completion: @escaping @Sendable (OpenAIUsageResult) -> Void) {
+        completion(result)
+    }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "openai-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.openai.enabled")
+
+    run("OpenAI store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.networkError), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("OpenAI enabled without key emits needsAccess card") {
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.networkError), defaults: defaults)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("OpenAI conforms to PasteKeyProvider with sk-admin placeholder") {
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.networkError), defaults: defaults)
+        let kp = store as PasteKeyProvider
+        expect(kp.keyPlaceholder.contains("sk-admin"))
+    }
+
+    run("OpenAI applies snapshot: cost + token + ceiling tiles") {
+        let creds = InMemoryCredentialStore()
+        let store = OpenAIUsageStore(credentials: creds, transport: StubOpenAITransport(.networkError), defaults: defaults)
+        store.saveKey("sk-admin-fake")
+        let snap = OpenAIUsageSnapshot(
+            tokensByModel: [OpenAIModelTokens(model: "gpt-4o", inputTokens: 4000, outputTokens: 2000, requests: 30)],
+            costMTDUSD: 12.34,
+            costCurrency: "usd",
+            rateLimits: [OpenAIRateLimit(model: "gpt-4o", maxRequestsPerMinute: 10000, maxTokensPerMinute: 2000000)]
+        )
+        store.apply(.success(snap))
+        let tiles = store.tiles
+        expect(tiles.contains { $0.id == "openai-cost-mtd" })
+        expect(tiles.contains { $0.id == "openai-tokens-gpt-4o" })
+        expect(tiles.contains { $0.id == "openai-ceiling-gpt-4o" })
+        // MTD cost tile shows the currency + amount.
+        let costTile = tiles.first { $0.id == "openai-cost-mtd" }
+        if case let .text(status, _) = costTile?.kind { expect(status.contains("12.34")) }
+        else { expect(false, "expected cost text tile") }
+    }
+
+    run("OpenAI 401 maps to invalid-admin-key error") {
+        let store = OpenAIUsageStore(credentials: InMemoryCredentialStore(), transport: StubOpenAITransport(.unauthorized), defaults: defaults)
+        store.saveKey("sk-admin-bad")
+        store.fetch()
+        expectEqual(store.errorMessage, "Invalid OpenAI Admin key")
+    }
+
+    run("OpenAI clear deletes the key and state") {
+        let creds = InMemoryCredentialStore()
+        let store = OpenAIUsageStore(credentials: creds, transport: StubOpenAITransport(.networkError), defaults: defaults)
+        store.saveKey("sk-admin-fake")
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(creds.read(OpenAIUsageFetcher.adminKeyKeychainKey) == nil)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1221,8 +1221,25 @@ run("parse xAI usage daily buckets (dollar and cents forms)") {
     """#.data(using: .utf8)!
     let daily = try! XAIUsageFetcher.parseUsage(bytes)
     expectEqual(daily.count, 2)
-    expect(abs(daily[0].usdSpent - 1.50) < 0.001)
-    expect(abs(daily[1].usdSpent - 2.75) < 0.001)  // 275 cents
+    expect(abs(daily[0].amountSpent - 1.50) < 0.001)
+    expect(abs(daily[1].amountSpent - 2.75) < 0.001)  // 275 cents
+    // No currency reported in this fixture.
+    expect(daily[0].currency == nil)
+}
+
+run("parse xAI usage carries a non-USD currency when reported") {
+    // The daily-usage shape is undocumented and may bill in CNY. When a
+    // currency is present the parser must surface it so the tile does not
+    // assume a "$" symbol (audit finding: hardcoded $ on the daily tile).
+    let bytes = #"""
+    {"usage": [
+      {"date": "2026-07-10", "amount": 12.50, "currency": "CNY"}
+    ]}
+    """#.data(using: .utf8)!
+    let daily = try! XAIUsageFetcher.parseUsage(bytes)
+    expectEqual(daily.count, 1)
+    expect(abs(daily[0].amountSpent - 12.50) < 0.001)
+    expectEqual(daily[0].currency, "CNY")
 }
 
 run("parse xAI api-key throws on array top-level") {
@@ -1445,13 +1462,34 @@ run("parse OpenAI completions throws on array top-level") {
     } catch { expect(true) }
 }
 
-run("OpenAI startOfUTCMonth returns a month boundary") {
-    // 2026-07-12 -> start of 2026-07-01 UTC. Just assert it is <= the input
-    // and a plausible epoch (non-zero).
-    let mid = Date(timeIntervalSince1970: 1752300000) // 2026-07-12ish
+run("OpenAI startOfUTCMonth returns the exact 1st-of-month UTC epoch") {
+    // 1752300000 = 2025-07-12T06:00:00Z. Start of 2025-07 UTC = 1751328000.
+    // Assert the EXACT boundary, not just start <= input (a loose bound would
+    // pass even for a wrong value — audit finding on the prior test).
+    let mid = Date(timeIntervalSince1970: 1752300000) // 2025-07-12T06:00:00Z
     let start = URLSessionOpenAITransport.startOfUTCMonth(mid)
-    expect(start > 0)
-    expect(start <= Int(mid.timeIntervalSince1970))
+    expectEqual(start, 1751328000)  // 2025-07-01T00:00:00Z
+}
+
+run("OpenAI completionsQuery uses a TRUE rolling 24h (1h buckets, limit 24)") {
+    // Audit finding: bucket_width=1d + start_time=now-24h returns up to ~48h.
+    // The fixed query must use hourly buckets bounded to 24 for a real 24h.
+    let now = Date(timeIntervalSince1970: 1752300000)
+    let q = URLSessionOpenAITransport.completionsQuery(now: now)
+    expect(q.contains("bucket_width=1h"))
+    expect(q.contains("limit=24"))
+    expect(q.contains("group_by=model"))
+    expect(q.contains("start_time=1752213600"))  // now - 24h
+    // It must NOT use the day-bucket that caused the over-count.
+    expect(!q.contains("bucket_width=1d"))
+}
+
+run("OpenAI costsQuery covers month-to-date from the UTC month start") {
+    let now = Date(timeIntervalSince1970: 1752300000)
+    let q = URLSessionOpenAITransport.costsQuery(now: now)
+    expect(q.contains("bucket_width=1d"))
+    expect(q.contains("limit=31"))               // covers the longest month in one page
+    expect(q.contains("start_time=1751328000"))  // start of 2025-07 UTC
 }
 
 // MARK: - OpenAIUsageStore
@@ -1508,10 +1546,14 @@ MainActor.assumeIsolated {
         expect(tiles.contains { $0.id == "openai-cost-mtd" })
         expect(tiles.contains { $0.id == "openai-tokens-gpt-4o" })
         expect(tiles.contains { $0.id == "openai-ceiling-gpt-4o" })
-        // MTD cost tile shows the currency + amount.
+        // MTD cost tile shows the currency + amount, with the API's lowercase
+        // "usd" uppercased for display (audit finding on currency case).
         let costTile = tiles.first { $0.id == "openai-cost-mtd" }
-        if case let .text(status, _) = costTile?.kind { expect(status.contains("12.34")) }
-        else { expect(false, "expected cost text tile") }
+        if case let .text(status, _) = costTile?.kind {
+            expect(status.contains("12.34"))
+            expect(status.contains("USD"))       // uppercased
+            expect(!status.contains("usd"))      // not the raw lowercase
+        } else { expect(false, "expected cost text tile") }
     }
 
     run("OpenAI 401 maps to invalid-admin-key error") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -1,11 +1,13 @@
-// PR 2a — assertion-based test runner.
+// PR 2a + PR 2b — assertion-based test runner.
 //
 // Runs with `swift run TestRunner` from the repo root. Works with
 // Command Line Tools alone; does not require Xcode.app / XCTest.
 // Prints one line per test and exits nonzero if any assertion fails.
 //
-// When Xcode.app is installed, this runner can be promoted to XCTest
-// or Apple's Testing framework without changing the assertion bodies.
+// PR 2a added LogValue tests. PR 2b adds AnthropicUsageFetcher tests
+// covering every branch of the parser against synthetic fixtures whose
+// shape matches the documented claude.ai /api/organizations/{org}/usage
+// response.
 
 import Foundation
 import ClaudeUsageBar
@@ -69,9 +71,7 @@ run("LogValue.sensitive never emits the raw value") {
 }
 
 run("LogValue.identifier emits short SHA-256 prefix") {
-    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
     expectEqual(LogValue.identifier("hello").rendered, "<id: 2cf24dba>")
-    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     expectEqual(LogValue.identifier("").rendered, "<id: e3b0c442>")
 }
 
@@ -100,6 +100,202 @@ run("LogValue.count emits numeric literal") {
     expectEqual(LogValue.count(42).rendered, "42")
     expectEqual(LogValue.count(-1).rendered, "-1")
     expectEqual(LogValue.count(823).rendered, "823")
+}
+
+// MARK: - AnthropicUsageFetcher.orgId(fromCookieString:)
+
+run("orgId returns nil when lastActiveOrg is absent") {
+    let cookie = "sessionKey=abc; foo=bar"
+    expect(AnthropicUsageFetcher.orgId(fromCookieString: cookie) == nil)
+}
+
+run("orgId extracts value from lastActiveOrg") {
+    let cookie = "sessionKey=abc; lastActiveOrg=8f2c3d1a-e5b9; foo=bar"
+    expectEqual(
+        AnthropicUsageFetcher.orgId(fromCookieString: cookie),
+        "8f2c3d1a-e5b9"
+    )
+}
+
+run("orgId trims whitespace around each cookie part") {
+    let cookie = "  lastActiveOrg=  8f2c ; foo=bar"
+    // The extractor trims each semicolon-separated part before matching
+    // the `lastActiveOrg=` prefix. The trailing space in "  8f2c " is
+    // consumed by that trim. Leading spaces inside the value survive
+    // because the prefix drop is exact-length. This matches the
+    // pre-refactor behaviour byte-for-byte (which used the same
+    // trimmingCharacters + replacingOccurrences sequence).
+    let out = AnthropicUsageFetcher.orgId(fromCookieString: cookie)
+    expectEqual(out, "  8f2c")
+}
+
+run("orgId returns nil on empty cookie") {
+    expect(AnthropicUsageFetcher.orgId(fromCookieString: "") == nil)
+}
+
+// MARK: - AnthropicUsageFetcher.parse — happy path fixtures
+
+// Fixture 1: minimum shape — five_hour and seven_day only, no Sonnet,
+// no Fable in limits[]. This is what a Free plan account looks like.
+let fixtureFreeMinimal = #"""
+{
+  "five_hour":  {"utilization": 42.3, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 17.8, "resets_at": "2026-07-18T00:00:00.000Z"}
+}
+"""#
+
+run("parse Free-plan minimal fixture") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFreeMinimal.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 42)
+    expectEqual(snap.weeklyUsage, 17)
+    expectEqual(snap.hasWeeklySonnet, false)
+    expectEqual(snap.weeklySonnetUsage, 0)
+    expectEqual(snap.hasWeeklyFable, false)
+    expectEqual(snap.weeklyFableUsage, 0)
+    expect(snap.sessionResetsAt != nil)
+    expect(snap.weeklyResetsAt != nil)
+    expect(snap.weeklySonnetResetsAt == nil)
+    expect(snap.weeklyFableResetsAt == nil)
+}
+
+// Fixture 2: Pro plan with Sonnet bucket present.
+let fixtureProWithSonnet = #"""
+{
+  "five_hour":         {"utilization": 55.5, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":         {"utilization": 33.3, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "seven_day_sonnet":  {"utilization": 12.9, "resets_at": "2026-07-18T00:00:00.000Z"}
+}
+"""#
+
+run("parse Pro-plan Sonnet fixture") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureProWithSonnet.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 55)
+    expectEqual(snap.weeklyUsage, 33)
+    expectEqual(snap.hasWeeklySonnet, true)
+    expectEqual(snap.weeklySonnetUsage, 12)
+    expectEqual(snap.hasWeeklyFable, false)
+}
+
+// Fixture 3: Fable present in limits[] with percent as Int.
+let fixtureFableInt = #"""
+{
+  "five_hour":  {"utilization": 60.0, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 40.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Opus"}}, "percent": 5, "resets_at": "2026-07-18T00:00:00.000Z"},
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 7, "resets_at": "2026-07-18T00:00:00.000Z"}
+  ]
+}
+"""#
+
+run("parse Fable fixture with percent as Int") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFableInt.data(using: .utf8)!)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 7)
+    expect(snap.weeklyFableResetsAt != nil)
+}
+
+// Fixture 4: Fable present with percent as Double (documented variant).
+let fixtureFableDouble = #"""
+{
+  "five_hour":  {"utilization": 60.0, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":  {"utilization": 40.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 12.7, "resets_at": "2026-07-18T00:00:00.000Z"}
+  ]
+}
+"""#
+
+run("parse Fable fixture with percent as Double") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFableDouble.data(using: .utf8)!)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 12)
+}
+
+// Fixture 5: full — Sonnet, Fable, Opus in limits, etc. All buckets present.
+let fixtureFull = #"""
+{
+  "five_hour":         {"utilization": 88.4, "resets_at": "2026-07-12T09:15:00.000Z"},
+  "seven_day":         {"utilization": 71.2, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "seven_day_sonnet":  {"utilization": 44.0, "resets_at": "2026-07-18T00:00:00.000Z"},
+  "limits": [
+    {"scope": {"model": {"display_name": "Fable"}}, "percent": 23, "resets_at": "2026-07-18T00:00:00.000Z"},
+    {"scope": {"model": {"display_name": "Opus"}}, "percent": 15}
+  ]
+}
+"""#
+
+run("parse full fixture with every bucket populated") {
+    let snap = try! AnthropicUsageFetcher.parse(fixtureFull.data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 88)
+    expectEqual(snap.weeklyUsage, 71)
+    expectEqual(snap.hasWeeklySonnet, true)
+    expectEqual(snap.weeklySonnetUsage, 44)
+    expectEqual(snap.hasWeeklyFable, true)
+    expectEqual(snap.weeklyFableUsage, 23)
+}
+
+// MARK: - AnthropicUsageFetcher.parse — error paths
+
+run("parse throws invalidJSON on empty body") {
+    do {
+        _ = try AnthropicUsageFetcher.parse(Data())
+        expect(false, "expected throw on empty body")
+    } catch {
+        expect(true)
+    }
+}
+
+run("parse throws invalidJSON on malformed body") {
+    let bytes = "not json at all".data(using: .utf8)!
+    do {
+        _ = try AnthropicUsageFetcher.parse(bytes)
+        expect(false, "expected throw on malformed body")
+    } catch {
+        expect(true)
+    }
+}
+
+run("parse throws invalidJSON on non-object top-level") {
+    let bytes = "[1,2,3]".data(using: .utf8)!
+    do {
+        _ = try AnthropicUsageFetcher.parse(bytes)
+        expect(false, "expected throw on array top-level")
+    } catch {
+        expect(true)
+    }
+}
+
+// MARK: - AnthropicUsageFetcher.parse — degenerate but non-throwing shapes
+
+run("parse tolerates empty JSON object (all fields default)") {
+    let snap = try! AnthropicUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.sessionUsage, 0)
+    expectEqual(snap.weeklyUsage, 0)
+    expectEqual(snap.hasWeeklySonnet, false)
+    expectEqual(snap.hasWeeklyFable, false)
+    expect(snap.sessionResetsAt == nil)
+}
+
+run("parse tolerates missing resets_at strings") {
+    let bytes = #"""
+    {"five_hour": {"utilization": 10.0}, "seven_day": {"utilization": 5.0}}
+    """#.data(using: .utf8)!
+    let snap = try! AnthropicUsageFetcher.parse(bytes)
+    expectEqual(snap.sessionUsage, 10)
+    expectEqual(snap.weeklyUsage, 5)
+    expect(snap.sessionResetsAt == nil)
+    expect(snap.weeklyResetsAt == nil)
+}
+
+run("parse ignores non-Fable entries in limits[]") {
+    let bytes = #"""
+    {"five_hour": {"utilization": 0}, "seven_day": {"utilization": 0},
+     "limits": [{"scope": {"model": {"display_name": "Sonnet"}}, "percent": 42}]}
+    """#.data(using: .utf8)!
+    let snap = try! AnthropicUsageFetcher.parse(bytes)
+    expectEqual(snap.hasWeeklyFable, false)
+    expectEqual(snap.weeklyFableUsage, 0)
 }
 
 // MARK: - Summary

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -5346,6 +5346,834 @@ run("ClaudeCodeUsageStore.monthToDateRange: covers start-of-month through now") 
     expect(!range.contains(june30))
 }
 
+// MARK: - ClinePathResolver (PR 10c-BE)
+
+run("ClinePathResolver.resolveScanRoots: enumerates VS Code + Insiders + VSCodium + Cursor + Windsurf + CLI defaults") {
+    let env = ClinePathResolver.Environment(
+        clineDataDir: nil,
+        clineDir: nil,
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    let ids = roots.map(\.id)
+    // Five VS Code family hosts + CLI (~/.cline).
+    expect(ids.contains("Cline CLI (~/.cline)"))
+    expect(ids.contains("VS Code"))
+    expect(ids.contains("VS Code Insiders"))
+    expect(ids.contains("VSCodium"))
+    expect(ids.contains("Cursor"))
+    expect(ids.contains("Windsurf"))
+    // Every root points to a `tasks` directory under saoudrizwan.claude-dev
+    // for the VS Code family.
+    for root in roots where root.id.hasPrefix("VS Code") || root.id == "Cursor" || root.id == "Windsurf" || root.id == "VSCodium" {
+        expect(root.tasksDirectoryPath.hasSuffix("/saoudrizwan.claude-dev/tasks"), "\(root.id) tasks path = \(root.tasksDirectoryPath)")
+    }
+    // CLI variants end at `/tasks` under `data`.
+    let cli = roots.first(where: { $0.id == "Cline CLI (~/.cline)" })!
+    expectEqual(cli.tasksDirectoryPath, "/Users/tester/.cline/data/tasks")
+}
+
+run("ClinePathResolver.resolveScanRoots: CLINE_DATA_DIR is included and comes first") {
+    let env = ClinePathResolver.Environment(
+        clineDataDir: "/opt/cline-data",
+        clineDir: nil,
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    expectEqual(roots.first?.id, "Cline CLI ($CLINE_DATA_DIR)")
+    expectEqual(roots.first?.tasksDirectoryPath, "/opt/cline-data/tasks")
+}
+
+run("ClinePathResolver.resolveScanRoots: CLINE_DIR appends '/data/tasks'") {
+    let env = ClinePathResolver.Environment(
+        clineDataDir: nil,
+        clineDir: "/opt/cline",
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    let clineDirRoot = roots.first(where: { $0.id == "Cline CLI ($CLINE_DIR)" })
+    expect(clineDirRoot != nil)
+    expectEqual(clineDirRoot?.tasksDirectoryPath, "/opt/cline/data/tasks")
+}
+
+run("ClinePathResolver.resolveScanRoots: symlink dedupe via stat() (round-3 finding)") {
+    // Codex round-3 finding: if two env-vars point at the same
+    // directory via a symlink, dedupe must collapse them via
+    // device+inode identity (stat, not lstat).
+    //
+    // CLINE_DATA_DIR gets `/tasks` appended → `.../real/tasks`.
+    // CLINE_DIR gets `/data/tasks` appended. For a symlink test the
+    // two must resolve to the same on-disk tasks directory. Setup:
+    //   real/tasks         (created)
+    //   real/data          → symlink to `real` (so `real/data/tasks`
+    //                       == `real/real/tasks` via symlink? no —
+    //                       cleaner: make `data` a symlink to `.`
+    //                       so `real/data/tasks` == `real/tasks`).
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cline-symlink-\(UUID().uuidString)")
+    let realDir = tempDir.appendingPathComponent("real")
+    let realTasks = realDir.appendingPathComponent("tasks")
+    try? FileManager.default.createDirectory(at: realTasks, withIntermediateDirectories: true)
+    // Symlink real/data -> real/.  (so real/data/tasks == real/tasks)
+    let dataSymlink = realDir.appendingPathComponent("data")
+    try? FileManager.default.createSymbolicLink(
+        atPath: dataSymlink.path,
+        withDestinationPath: "."
+    )
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    // CLINE_DATA_DIR points at real: appends /tasks -> real/tasks.
+    // CLINE_DIR points at real: appends /data/tasks -> real/data/tasks
+    // which resolves via symlink to real/./tasks == real/tasks.
+    // Both should stat to the same device+inode.
+    let env = ClinePathResolver.Environment(
+        clineDataDir: realDir.path,
+        clineDir: realDir.path,
+        homeDirectoryPath: "/Users/tester-doesnotexist",
+        applicationSupportPath: "/Users/tester-doesnotexist/Library/Application Support"
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    let matching = roots.filter { $0.tasksDirectoryPath.contains(tempDir.lastPathComponent) }
+    expect(matching.count == 1, "symlink+target should collapse via stat() identity; got \(matching.count)")
+}
+
+run("ClinePathResolver.resolveScanRoots: case-insensitive path dedupe (round-1 finding #2)") {
+    // Codex round-1 finding #2: on the default case-insensitive
+    // macOS filesystem, CLINE_DIR=/users/tester/.cline (lowercase u)
+    // and the default HOME=/Users/tester point at the same directory.
+    // String-based standardizingPath dedupe misses this — case-folded
+    // fallback catches it.
+    let env = ClinePathResolver.Environment(
+        clineDataDir: nil,
+        clineDir: "/users/tester/.cline",       // lowercase 'u'
+        homeDirectoryPath: "/Users/tester",      // canonical 'U'
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    let cliRoots = roots.filter { $0.tasksDirectoryPath.lowercased().hasSuffix(".cline/data/tasks") }
+    expect(cliRoots.count == 1, "case-insensitive fs dedupe should collapse /users and /Users variants; got \(cliRoots.count)")
+}
+
+run("ClinePathResolver.resolveScanRoots: dedupes identical paths (CLINE_DIR pointing at ~/.cline)") {
+    // If CLINE_DIR resolves to $HOME/.cline, CLINE_DIR/data/tasks and
+    // ~/.cline/data/tasks are the same path. Should collapse to one root
+    // rather than double-scan and appear as two entries.
+    let env = ClinePathResolver.Environment(
+        clineDataDir: nil,
+        clineDir: "/Users/tester/.cline",
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    let cliRoots = roots.filter { $0.tasksDirectoryPath == "/Users/tester/.cline/data/tasks" }
+    expectEqual(cliRoots.count, 1)
+}
+
+run("ClinePathResolver.resolveScanRoots: empty homeDirectoryPath still yields env-var roots") {
+    let env = ClinePathResolver.Environment(
+        clineDataDir: "/opt/cline-data",
+        clineDir: nil,
+        homeDirectoryPath: "",
+        applicationSupportPath: ""
+    )
+    let roots = ClinePathResolver.resolveScanRoots(env)
+    expect(roots.contains(where: { $0.id == "Cline CLI ($CLINE_DATA_DIR)" }))
+    // The VS Code family entries require applicationSupportPath — empty means none.
+    expect(!roots.contains(where: { $0.id == "VS Code" }))
+}
+
+run("ClinePathResolver.Environment.current populates without crash") {
+    let env = ClinePathResolver.Environment.current()
+    // HOME is always non-empty on macOS.
+    expect(!env.homeDirectoryPath.isEmpty)
+    expect(!env.applicationSupportPath.isEmpty)
+}
+
+// MARK: - ClineUsageFetcher — safeCost / extractTimestamp / extractModel
+
+run("ClineUsageFetcher.safeCost: negative and NaN clamp to 0; finite pass through; huge values cap at 1M") {
+    expectEqual(ClineUsageFetcher.safeCost(0.005), 0.005)
+    expectEqual(ClineUsageFetcher.safeCost(0), 0)
+    expectEqual(ClineUsageFetcher.safeCost(-1.0), 0)
+    expectEqual(ClineUsageFetcher.safeCost(Double.nan), 0)
+    expectEqual(ClineUsageFetcher.safeCost(Double.infinity), 0)
+    expectEqual(ClineUsageFetcher.safeCost(1_500_000.0), 1_000_000.0)
+    // String forms accepted (some tools re-encode as strings).
+    expectEqual(ClineUsageFetcher.safeCost("0.5"), 0.5)
+    expectEqual(ClineUsageFetcher.safeCost(nil), 0)
+}
+
+run("ClineUsageFetcher.extractTimestamp: milliseconds-since-epoch (JS Date.now) parses; before 2000 or after 2100 rejected") {
+    // 2026-07-13T04:00:00Z as ms.
+    let ms = 1_784_000_400_000.0
+    let ts = ClineUsageFetcher.extractTimestamp(ms)
+    expect(ts != nil)
+    // 1970-01-01 (0 ms) → nil (before 2000 clamp).
+    expect(ClineUsageFetcher.extractTimestamp(0) == nil)
+    // Very-distant future → nil.
+    expect(ClineUsageFetcher.extractTimestamp(1e18) == nil)
+    // Non-finite → nil.
+    expect(ClineUsageFetcher.extractTimestamp(Double.nan) == nil)
+    // Nil / non-numeric → nil.
+    expect(ClineUsageFetcher.extractTimestamp(nil) == nil)
+    expect(ClineUsageFetcher.extractTimestamp("garbage") == nil)
+}
+
+run("ClineUsageFetcher.extractModel: reads modelInfo.modelId when present; falls back to 'unknown'") {
+    let withInfo: [String: Any] = ["modelInfo": ["modelId": "claude-opus-4-7"] as [String: Any]]
+    expectEqual(ClineUsageFetcher.extractModel(withInfo), "claude-opus-4-7")
+    let withoutInfo: [String: Any] = ["ts": 1_784_000_400_000]
+    expectEqual(ClineUsageFetcher.extractModel(withoutInfo), "unknown")
+    let emptyId: [String: Any] = ["modelInfo": ["modelId": ""] as [String: Any]]
+    expectEqual(ClineUsageFetcher.extractModel(emptyId), "unknown")
+    let wrongTypeInfo: [String: Any] = ["modelInfo": "not-an-object"]
+    expectEqual(ClineUsageFetcher.extractModel(wrongTypeInfo), "unknown")
+}
+
+// MARK: - ClineUsageFetcher.parse — happy path
+
+/// Build a synthetic Cline ui_messages.json array with one usage record.
+func makeClineArray(
+    say: String = "api_req_started",
+    tokensIn: Int = 100, tokensOut: Int = 50,
+    cacheWrites: Int = 0, cacheReads: Int = 0,
+    cost: Double = 0.005,
+    model: String? = "claude-opus-4-7",
+    ts: Double? = 1_784_000_400_000,   // 2026-07-13T04:00:00Z ms
+    extraMessages: [[String: Any]] = []
+) -> String {
+    let textPayload: [String: Any] = [
+        "tokensIn": tokensIn,
+        "tokensOut": tokensOut,
+        "cacheWrites": cacheWrites,
+        "cacheReads": cacheReads,
+        "cost": cost,
+    ]
+    let textData = try! JSONSerialization.data(withJSONObject: textPayload, options: [])
+    let text = String(data: textData, encoding: .utf8)!
+    var msg: [String: Any] = [
+        "type": "say",
+        "say": say,
+        "text": text,
+    ]
+    if let ts = ts { msg["ts"] = ts }
+    if let model = model {
+        msg["modelInfo"] = ["modelId": model, "providerId": "anthropic", "mode": "act"] as [String: Any]
+    }
+    var arr: [[String: Any]] = [msg]
+    arr.append(contentsOf: extraMessages)
+    let data = try! JSONSerialization.data(withJSONObject: arr, options: [])
+    return String(data: data, encoding: .utf8)!
+}
+
+run("Cline.parse: single api_req_started record parses tokens + cost + model") {
+    let contents = makeClineArray(tokensIn: 100, tokensOut: 50, cost: 0.005, model: "claude-opus-4-7")
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: contents, sourceFile: "/tmp/a.json", malformedRecordCount: &mal)
+    expect(recs != nil)
+    expectEqual(recs?.count, 1)
+    let r = recs![0]
+    expectEqual(r.tokensIn, 100)
+    expectEqual(r.tokensOut, 50)
+    expectEqual(r.cacheWrites, 0)
+    expectEqual(r.cacheReads, 0)
+    expect(abs(r.costUSD - 0.005) < 1e-9)
+    expectEqual(r.model, "claude-opus-4-7")
+    expectEqual(r.sayKind, .apiReqStarted)
+    expect(r.timestamp != nil)
+    expectEqual(r.sourceFile, "/tmp/a.json")
+    expectEqual(mal, 0)
+}
+
+run("Cline.parse: deleted_api_reqs and subagent_usage are also counted") {
+    let deleted = makeClineArray(say: "deleted_api_reqs", tokensIn: 10, cost: 0.001)
+    let subagent = makeClineArray(say: "subagent_usage", tokensOut: 20, cost: 0.002)
+    var mal = 0
+    let d = ClineUsageFetcher.parse(uiMessages: deleted, sourceFile: "/tmp/d.json", malformedRecordCount: &mal)
+    let s = ClineUsageFetcher.parse(uiMessages: subagent, sourceFile: "/tmp/s.json", malformedRecordCount: &mal)
+    expectEqual(d?.count, 1)
+    expectEqual(d?.first?.sayKind, .deletedApiReqs)
+    expectEqual(s?.count, 1)
+    expectEqual(s?.first?.sayKind, .subagentUsage)
+}
+
+run("Cline.parse: non-say records and non-usage say kinds are skipped silently") {
+    // Build an array of mixed message types — an "ask" record, a
+    // "say" of an unrelated kind ("text"), and one valid usage record.
+    let arr: [[String: Any]] = [
+        ["type": "ask", "ask": "followup", "ts": 1_784_000_400_000, "text": "Hi"],
+        ["type": "say", "say": "text", "ts": 1_784_000_400_000, "text": "Cline is thinking"],
+        ["type": "say", "say": "api_req_started", "ts": 1_784_000_400_000,
+         "text": "{\"tokensIn\":1,\"cost\":0.0001}"] as [String: Any],
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: arr, options: [])
+    let contents = String(data: data, encoding: .utf8)!
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: contents, sourceFile: "/tmp/mixed.json", malformedRecordCount: &mal)
+    expectEqual(recs?.count, 1)
+    expectEqual(mal, 0)
+}
+
+run("Cline.parse: entirely-zero usage record is dropped (Cline's own 'no charge' marker)") {
+    let contents = makeClineArray(tokensIn: 0, tokensOut: 0, cost: 0)
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: contents, sourceFile: "/tmp/z.json", malformedRecordCount: &mal)
+    expectEqual(recs?.count, 0)
+}
+
+run("Cline.parse: malformed text-field JSON is counted, not fatal") {
+    let arr: [[String: Any]] = [
+        ["type": "say", "say": "api_req_started", "ts": 1_784_000_400_000, "text": "{ not valid json"],
+        ["type": "say", "say": "api_req_started", "ts": 1_784_000_400_000, "text": "{\"tokensIn\":5,\"cost\":0.001}"],
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: arr, options: [])
+    let contents = String(data: data, encoding: .utf8)!
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: contents, sourceFile: "/tmp/m.json", malformedRecordCount: &mal)
+    expectEqual(recs?.count, 1)
+    expectEqual(mal, 1)
+}
+
+run("Cline.parse: non-array top-level content returns nil") {
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: "{\"not\":\"an array\"}", sourceFile: "/tmp/wrong.json", malformedRecordCount: &mal)
+    expect(recs == nil)
+    // Non-JSON garbage also returns nil.
+    let bad = ClineUsageFetcher.parse(uiMessages: "not valid json at all", sourceFile: "/tmp/x.json", malformedRecordCount: &mal)
+    expect(bad == nil)
+}
+
+run("Cline.parse: hostile 1e300 in tokensIn clamps to Int.max instead of trapping") {
+    let arr: [[String: Any]] = [
+        ["type": "say", "say": "api_req_started", "ts": 1_784_000_400_000,
+         "text": "{\"tokensIn\":1e300,\"cost\":0.001}"] as [String: Any],
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: arr, options: [])
+    let contents = String(data: data, encoding: .utf8)!
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: contents, sourceFile: "/tmp/big.json", malformedRecordCount: &mal)
+    expectEqual(recs?.count, 1)
+    expectEqual(recs?.first?.tokensIn, Int.max)
+}
+
+run("Cline.parse: message without modelInfo defaults to 'unknown'") {
+    // Simulate an older Cline record with no modelInfo field.
+    let arr: [[String: Any]] = [
+        ["type": "say", "say": "api_req_started", "ts": 1_784_000_400_000,
+         "text": "{\"tokensIn\":10,\"cost\":0.001}"] as [String: Any],
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: arr, options: [])
+    let contents = String(data: data, encoding: .utf8)!
+    var mal = 0
+    let recs = ClineUsageFetcher.parse(uiMessages: contents, sourceFile: "/tmp/old.json", malformedRecordCount: &mal)
+    expectEqual(recs?.count, 1)
+    expectEqual(recs?.first?.model, "unknown")
+}
+
+// MARK: - Snapshot roll-ups
+
+run("ClineUsageSnapshot.tokens(in:) — sums records within range, saturates on overflow") {
+    let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+    let a = ClineUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        sayKind: .apiReqStarted,
+        tokensIn: Int.max, tokensOut: 0, cacheWrites: 0, cacheReads: 0,
+        costUSD: 0.0, sourceFile: "/tmp/a.json"
+    )
+    let b = ClineUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        sayKind: .apiReqStarted,
+        tokensIn: Int.max, tokensOut: 0, cacheWrites: 0, cacheReads: 0,
+        costUSD: 0.0, sourceFile: "/tmp/b.json"
+    )
+    let snap = ClineUsageSnapshot(records: [a, b])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    // Naive Int64 add would wrap; saturating keeps Int.max.
+    expectEqual(snap.tokens(in: range), Int.max)
+}
+
+run("ClineUsageSnapshot.breakdownByModel — descending by cost, aggregates per model") {
+    let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+    let opusA = ClineUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        sayKind: .apiReqStarted,
+        tokensIn: 100, tokensOut: 50, cacheWrites: 0, cacheReads: 0,
+        costUSD: 5.0, sourceFile: "/tmp/a.json"
+    )
+    let opusB = ClineUsageRecord(
+        model: "claude-opus-4-7", timestamp: now,
+        sayKind: .apiReqStarted,
+        tokensIn: 200, tokensOut: 100, cacheWrites: 0, cacheReads: 0,
+        costUSD: 10.0, sourceFile: "/tmp/b.json"
+    )
+    let sonnet = ClineUsageRecord(
+        model: "claude-sonnet-4-6", timestamp: now,
+        sayKind: .apiReqStarted,
+        tokensIn: 100, tokensOut: 50, cacheWrites: 0, cacheReads: 0,
+        costUSD: 1.0, sourceFile: "/tmp/s.json"
+    )
+    let snap = ClineUsageSnapshot(records: [sonnet, opusA, opusB])
+    let range = (now.addingTimeInterval(-3600))...(now.addingTimeInterval(3600))
+    let bd = snap.breakdownByModel(in: range)
+    expectEqual(bd.count, 2)
+    expectEqual(bd[0].model, "claude-opus-4-7")
+    expect(abs(bd[0].costUSD - 15.0) < 1e-9)
+    expectEqual(bd[0].tokens, 450)
+    expectEqual(bd[1].model, "claude-sonnet-4-6")
+}
+
+// MARK: - discoverFiles
+
+run("Cline.discoverFiles: missing scan root returns []; existing but empty returns []") {
+    let missing = ClinePathResolver.ScanRoot(id: "test-missing", tasksDirectoryPath: "/nonexistent/\(UUID().uuidString)/tasks")
+    expectEqual(ClineUsageFetcher.discoverFiles(under: [missing]).count, 0)
+    // Existing but empty.
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cline-disc-empty-\(UUID().uuidString)/tasks")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir.deletingLastPathComponent()) }
+    let empty = ClinePathResolver.ScanRoot(id: "test-empty", tasksDirectoryPath: tempDir.path)
+    expectEqual(ClineUsageFetcher.discoverFiles(under: [empty]).count, 0)
+}
+
+run("Cline.discoverFiles: finds ui_messages.json under every task dir; ignores files and unrelated names") {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cline-disc-\(UUID().uuidString)/tasks")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir.deletingLastPathComponent()) }
+
+    // Two valid task directories.
+    let taskA = tempDir.appendingPathComponent("task-a-uuid")
+    let taskB = tempDir.appendingPathComponent("task-b-uuid")
+    try? FileManager.default.createDirectory(at: taskA, withIntermediateDirectories: true)
+    try? FileManager.default.createDirectory(at: taskB, withIntermediateDirectories: true)
+    try? "[]".write(to: taskA.appendingPathComponent("ui_messages.json"), atomically: true, encoding: .utf8)
+    try? "[]".write(to: taskB.appendingPathComponent("ui_messages.json"), atomically: true, encoding: .utf8)
+    // Non-ui_messages file inside a task dir — must NOT be picked up.
+    try? "".write(to: taskA.appendingPathComponent("api_conversation_history.json"), atomically: true, encoding: .utf8)
+    // Task dir without ui_messages.json — must NOT be picked up.
+    let taskC = tempDir.appendingPathComponent("task-c-no-ui")
+    try? FileManager.default.createDirectory(at: taskC, withIntermediateDirectories: true)
+    // Loose file in tasks dir — must NOT be picked up (only directories).
+    try? "".write(to: tempDir.appendingPathComponent("stray-file.json"), atomically: true, encoding: .utf8)
+
+    let root = ClinePathResolver.ScanRoot(id: "test", tasksDirectoryPath: tempDir.path)
+    let out = ClineUsageFetcher.discoverFiles(under: [root])
+    expectEqual(out.count, 2)
+    expect(out.allSatisfy { $0.lastPathComponent == "ui_messages.json" })
+    // Sorted by absolute path.
+    expect(out[0].path < out[1].path)
+}
+
+// MARK: - parse(files:) end-to-end
+
+run("Cline.parse(files:) — sorts records by timestamp ascending; counts per file") {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cline-e2e-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    // File A: later record. File B: earlier.
+    let laterContent = makeClineArray(cost: 0.01, ts: 1_784_000_400_000)   // July 2026
+    let earlierContent = makeClineArray(cost: 0.02, ts: 1_720_000_000_000) // July 2024
+    let fileA = tempDir.appendingPathComponent("a.json")
+    let fileB = tempDir.appendingPathComponent("b.json")
+    try? laterContent.write(to: fileA, atomically: true, encoding: .utf8)
+    try? earlierContent.write(to: fileB, atomically: true, encoding: .utf8)
+
+    let snap = ClineUsageFetcher.parse(files: [fileA, fileB])
+    expectEqual(snap.records.count, 2)
+    // Sorted ascending.
+    expect(snap.records[0].timestamp! < snap.records[1].timestamp!)
+    // Per-file record counts recorded.
+    expectEqual(snap.recordsPerFile[fileA.path], 1)
+    expectEqual(snap.recordsPerFile[fileB.path], 1)
+}
+
+run("Cline.parse(files:) — non-array top-level content counts as unreadable and does not raise") {
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cline-unreadable-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let bad = tempDir.appendingPathComponent("bad.json")
+    try? "{\"not\":\"array\"}".write(to: bad, atomically: true, encoding: .utf8)
+    let snap = ClineUsageFetcher.parse(files: [bad])
+    expectEqual(snap.records.count, 0)
+    expectEqual(snap.unreadableFileCount, 1)
+}
+
+run("Cline.parse(files:) — missing file counted as unreadable, does not throw") {
+    let missing = URL(fileURLWithPath: "/nonexistent/never-\(UUID().uuidString).json")
+    let snap = ClineUsageFetcher.parse(files: [missing])
+    expectEqual(snap.records.count, 0)
+    expectEqual(snap.unreadableFileCount, 1)
+}
+
+// MARK: - ClineUsageStore
+
+MainActor.assumeIsolated {
+
+    @MainActor func makeClineStoreForTest(
+        flagEnabled: Bool = true,
+        scanRoots: [ClinePathResolver.ScanRoot] = [ClinePathResolver.ScanRoot(id: "test", tasksDirectoryPath: "/tmp/fake")],
+        tccState: TCCState = .granted,
+        files: [URL] = [],
+        snapshot: ClineUsageSnapshot = ClineUsageSnapshot(records: []),
+        now: Date = Date()
+    ) -> ClineUsageStore {
+        let defaults = UserDefaults(suiteName: "cline-test-\(UUID().uuidString)")!
+        defaults.set(flagEnabled, forKey: "features.cline.enabled")
+        let rootsCopy = scanRoots
+        let filesCopy = files
+        let snapshotCopy = snapshot
+        let nowCopy = now
+        return ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { rootsCopy },
+            tccProbe: { _ in tccState },
+            discoverFiles: { _ in filesCopy },
+            parseFiles: { _ in snapshotCopy },
+            clock: { nowCopy }
+        )
+    }
+
+    @MainActor func awaitClineFetch() {
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    run("ClineUsageStore: feature-flag off produces no tiles and no fetch state") {
+        let store = makeClineStoreForTest(flagEnabled: false)
+        expectEqual(store.tiles.count, 0)
+        expect(!store.isEnabled)
+        expect(!store.isConfigured)
+        store.fetch()
+        expect(store.snapshot == nil)
+        expect(store.lastUpdatedAt == nil)
+    }
+
+    run("ClineUsageStore: enabled + granted + empty snapshot -> loading tile") {
+        let store = makeClineStoreForTest(flagEnabled: true, tccState: .granted)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles.first?.id, "cline-loading")
+    }
+
+    run("ClineUsageStore: TCC .denied renders needsAccess tile only") {
+        let store = makeClineStoreForTest(flagEnabled: true, tccState: .denied)
+        store.fetch()
+        awaitClineFetch()
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles.first?.id, "cline-needs-access")
+    }
+
+    run("ClineUsageStore: mixed TCC (one granted, one denied) shows partial-access diagnostic tile (round-1 finding #1)") {
+        // Codex round-1 finding #1: a partial-access mix must be
+        // surfaced so the tile is not misleadingly labelled as
+        // complete. Store aggregates to .granted (some data
+        // available) but exposes deniedRootCount so the tile shows
+        // "Partial access" alongside the numbers.
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/granted/tasks/a/ui_messages.json"
+        )
+        let defaults = UserDefaults(suiteName: "cline-mixed-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        let grantedRoot = ClinePathResolver.ScanRoot(id: "VS Code", tasksDirectoryPath: "/tmp/granted/tasks")
+        let deniedRoot = ClinePathResolver.ScanRoot(id: "Cursor", tasksDirectoryPath: "/tmp/denied/tasks")
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [grantedRoot, deniedRoot] },
+            tccProbe: { path in
+                path.hasPrefix("/tmp/granted") ? .granted : .denied
+            },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/granted/tasks/a/ui_messages.json")] },
+            parseFiles: { _ in ClineUsageSnapshot(records: [rec]) },
+            clock: { now }
+        )
+        store.fetch()
+        awaitClineFetch()
+        // Aggregated tccState is granted (we have SOME readable roots).
+        expectEqual(store.tccState, .granted)
+        // deniedRootCount reflects the Cursor root.
+        expectEqual(store.deniedRootCount, 1)
+        // Tiles include the partial-access diagnostic AND the usage tiles.
+        let ids = Set(store.tiles.map { $0.id })
+        expect(ids.contains("cline-partial-access"))
+        expect(ids.contains("cline-cost-today"))
+    }
+
+    run("ClineUsageStore: partial-access tile is visible DURING loading (round-2 finding #3)") {
+        // Codex round-2 finding #3: the partial-access diagnostic
+        // must show up even while parse is in flight — otherwise a
+        // slow parse hides the access problem.
+        let defaults = UserDefaults(suiteName: "cline-partial-loading-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        let grantedRoot = ClinePathResolver.ScanRoot(id: "VS Code", tasksDirectoryPath: "/tmp/granted/tasks")
+        let deniedRoot = ClinePathResolver.ScanRoot(id: "Cursor", tasksDirectoryPath: "/tmp/denied/tasks")
+        final class Gate: @unchecked Sendable { let sem = DispatchSemaphore(value: 0) }
+        let gate = Gate()
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [grantedRoot, deniedRoot] },
+            tccProbe: { path in path.hasPrefix("/tmp/granted") ? .granted : .denied },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/granted/tasks/a/ui_messages.json")] },
+            parseFiles: { _ in
+                // Block parse so snapshot is nil at tile-render time.
+                gate.sem.wait()
+                return ClineUsageSnapshot(records: [])
+            }
+        )
+        store.fetch()
+        // Give the queue a moment to reach the blocking parseFiles.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        // Snapshot is nil at this point — tiles must still show the
+        // partial-access diagnostic alongside the loading tile.
+        let ids = Set(store.tiles.map { $0.id })
+        expect(ids.contains("cline-partial-access"), "partial access diagnostic must be visible during loading")
+        expect(ids.contains("cline-loading"))
+        // Release the parser.
+        gate.sem.signal()
+        awaitClineFetch()
+    }
+
+    run("ClineUsageStore: granted-root-set change clears old snapshot before new fetch runs (round-2 finding #4)") {
+        // Codex round-2 finding #4: user revokes access on one root
+        // between fetches. The OLD snapshot (which included that
+        // root's data) must be dropped so the tile does not show
+        // stale numbers while the new parse runs.
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/both/tasks/a/ui_messages.json"
+        )
+        let defaults = UserDefaults(suiteName: "cline-rootchange-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        final class Toggle: @unchecked Sendable {
+            var scenario: Int = 1   // 1 = both granted, 2 = one granted + one denied
+        }
+        let toggle = Toggle()
+        let vsCode = ClinePathResolver.ScanRoot(id: "VS Code", tasksDirectoryPath: "/tmp/both/tasks")
+        let cursor = ClinePathResolver.ScanRoot(id: "Cursor", tasksDirectoryPath: "/tmp/cursor/tasks")
+        // Second scenario also blocks parse so the OLD snapshot's
+        // fate is visible before the new one applies.
+        final class Gate: @unchecked Sendable { let sem = DispatchSemaphore(value: 0) }
+        let gate = Gate()
+        final class ParseCount: @unchecked Sendable { var value: Int = 0 }
+        let parseCount = ParseCount()
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [vsCode, cursor] },
+            tccProbe: { path in
+                if toggle.scenario == 1 { return .granted }
+                return path.hasPrefix("/tmp/both") ? .granted : .denied
+            },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/both/tasks/a/ui_messages.json")] },
+            parseFiles: { _ in
+                parseCount.value += 1
+                if parseCount.value == 2 {
+                    gate.sem.wait()   // block ONLY the second fetch
+                }
+                return ClineUsageSnapshot(records: [rec])
+            },
+            clock: { now }
+        )
+        // Fetch #1: both granted, snapshot populated.
+        store.fetch()
+        awaitClineFetch()
+        expect(store.snapshot != nil)
+        expectEqual(store.deniedRootCount, 0)
+        // Scenario change: Cursor now denied. Fetch #2 runs; the
+        // OLD snapshot must be cleared before the new parse applies.
+        toggle.scenario = 2
+        store.fetch()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        // At this point fetch #2's parse is blocked. The store must
+        // have already discarded the stale snapshot.
+        expect(store.snapshot == nil, "stale snapshot must be cleared when granted-root-set changes")
+        expectEqual(store.deniedRootCount, 1)
+        // Release the parse.
+        gate.sem.signal()
+        awaitClineFetch()
+    }
+
+    run("ClineUsageStore: every root denied -> .denied state, no usage tiles (round-1 finding #1 correlate)") {
+        let defaults = UserDefaults(suiteName: "cline-alldenied-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        let denied1 = ClinePathResolver.ScanRoot(id: "VS Code", tasksDirectoryPath: "/tmp/denied1/tasks")
+        let denied2 = ClinePathResolver.ScanRoot(id: "Cursor", tasksDirectoryPath: "/tmp/denied2/tasks")
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [denied1, denied2] },
+            tccProbe: { _ in .denied },
+            discoverFiles: { _ in [] },
+            parseFiles: { _ in ClineUsageSnapshot(records: []) }
+        )
+        store.fetch()
+        // If every root is denied, aggregated .denied; UI shows the
+        // needsAccess tile only.
+        expectEqual(store.tccState, .denied)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles.first?.id, "cline-needs-access")
+    }
+
+    run("ClineUsageStore: no scan root exists -> 'not installed' tile") {
+        // Zero scan roots -> aggregated to .pathMissing.
+        let store = makeClineStoreForTest(scanRoots: [], tccState: .pathMissing)
+        store.fetch()
+        awaitClineFetch()
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles.first?.id, "cline-not-installed")
+    }
+
+    run("ClineUsageStore: fetch populates snapshot and emits usage tiles") {
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/fake/tasks/a/ui_messages.json"
+        )
+        let snap = ClineUsageSnapshot(records: [rec])
+        let store = makeClineStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            files: [URL(fileURLWithPath: "/tmp/fake/tasks/a/ui_messages.json")],
+            snapshot: snap,
+            now: now
+        )
+        store.fetch()
+        awaitClineFetch()
+
+        expect(store.snapshot != nil)
+        expect(store.lastUpdatedAt != nil)
+        let ids = Set(store.tiles.map { $0.id })
+        expect(ids.contains("cline-tokens-today"))
+        expect(ids.contains("cline-cost-today"))
+        expect(ids.contains("cline-cost-mtd"))
+        expect(ids.contains("cline-by-model"))
+    }
+
+    run("ClineUsageStore: clear() drops snapshot + lastUpdated + invalidates in-flight fetch") {
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 100, tokensOut: 50, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/fake/a.json"
+        )
+        let store = makeClineStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            files: [URL(fileURLWithPath: "/tmp/fake/a.json")],
+            snapshot: ClineUsageSnapshot(records: [rec]),
+            now: now
+        )
+        store.fetch()
+        awaitClineFetch()
+        expect(store.snapshot != nil)
+        store.clear()
+        expect(store.snapshot == nil)
+        expect(store.lastUpdatedAt == nil)
+    }
+
+    run("ClineUsageStore: TCC granted -> denied invalidates in-flight fetch (no stale repopulate)") {
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/fake/a.json"
+        )
+        let defaults = UserDefaults(suiteName: "cline-tcc-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        final class TCCToggle: @unchecked Sendable { var state: TCCState = .granted }
+        let toggle = TCCToggle()
+        let root = ClinePathResolver.ScanRoot(id: "test", tasksDirectoryPath: "/tmp/fake")
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [root] },
+            tccProbe: { _ in toggle.state },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/fake/a.json")] },
+            parseFiles: { _ in ClineUsageSnapshot(records: [rec]) },
+            clock: { now }
+        )
+        store.fetch()
+        awaitClineFetch()
+        expect(store.snapshot != nil)
+        toggle.state = .denied
+        store.fetch()
+        expect(store.snapshot == nil)
+        expectEqual(store.tccState, .denied)
+    }
+
+    run("ClineUsageStore: TRULY in-flight fetch A releases AFTER fetch B's denial — A must not repopulate (round-1 finding #4)") {
+        // Codex round-1 finding #4: the prior test does not create a
+        // genuinely in-flight race. This test uses a semaphore inside
+        // the parseFiles closure so fetch A is definitively BLOCKED
+        // when fetch B fires with .denied. Then we release A and
+        // verify the final state is empty, not repopulated.
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/fake/a.json"
+        )
+        let defaults = UserDefaults(suiteName: "cline-inflight-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        final class TCCToggle: @unchecked Sendable { var state: TCCState = .granted }
+        final class Gate: @unchecked Sendable { let sem = DispatchSemaphore(value: 0) }
+        let toggle = TCCToggle()
+        let gate = Gate()
+        let root = ClinePathResolver.ScanRoot(id: "test", tasksDirectoryPath: "/tmp/fake")
+        let snap = ClineUsageSnapshot(records: [rec])
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [root] },
+            tccProbe: { _ in toggle.state },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/fake/a.json")] },
+            parseFiles: { _ in
+                // First invocation blocks on the semaphore; subsequent
+                // invocations don't reach here because state changes to
+                // .denied before workQueue schedules them.
+                gate.sem.wait()
+                return snap
+            },
+            clock: { now }
+        )
+        // Kick off fetch A. Its parseFiles closure will block.
+        store.fetch()
+        // Give the background queue a moment to reach the blocking
+        // parseFiles closure.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        // While fetch A is still blocked, flip TCC and invoke fetch B
+        // (which bumps generation and returns early with .denied).
+        toggle.state = .denied
+        store.fetch()
+        expectEqual(store.tccState, .denied)
+        // Release fetch A. Its background closure returns the snapshot;
+        // the main-actor apply hop should see fetchGeneration mismatch
+        // AND isEnabled true but tccState .denied — either guard drops
+        // the completion, so state stays empty.
+        gate.sem.signal()
+        awaitClineFetch()
+        expect(store.snapshot == nil, "in-flight fetch A must NOT repopulate snapshot after fetch B denied")
+        expectEqual(store.tccState, .denied)
+    }
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2177,6 +2177,24 @@ MainActor.assumeIsolated {
         }
     }
 
+    run("Perplexity credits tile: recurring grant matched case-insensitively (chk1 Bug #4)") {
+        // Guard against a Perplexity schema tweak that changes the casing
+        // of the grant type from "recurring" to "Recurring". Without a
+        // case-insensitive compare the recurring total would collapse to 0
+        // and the plan hint would silently disappear.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(
+            balanceCents: 100,
+            grants: [PerplexityCreditGrant(type: "Recurring", amountCents: 50000, expiresAtEpoch: nil)]
+        )
+        store.apply(.success(snap))
+        if case let .balance(_, _, plan, _) = store.tiles.first(where: { $0.id == "perplexity-credits" })?.kind {
+            expectEqual(plan, "Max")
+        } else { expect(false, "expected balance tile") }
+    }
+
     run("Perplexity credits tile: Pro plan hint from a $50-tier recurring grant") {
         // Codex adversarial review #3: the initial 5 000c threshold flipped
         // Pro users to "Max" — a $50 grant must still register as Pro.

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -6413,6 +6413,1211 @@ MainActor.assumeIsolated {
     }
 }
 
+// MARK: - WindsurfPathResolver (PR 11-BE)
+
+run("WindsurfPathResolver: builds ~/Library/Application Support/Windsurf path") {
+    let env = WindsurfPathResolver.Environment(
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let path = WindsurfPathResolver.stateDbPath(env)
+    expectEqual(path, "/Users/tester/Library/Application Support/Windsurf/User/globalStorage/state.vscdb")
+}
+
+run("WindsurfPathResolver: returns nil when applicationSupportPath is empty") {
+    let env = WindsurfPathResolver.Environment(
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: ""
+    )
+    expect(WindsurfPathResolver.stateDbPath(env) == nil)
+}
+
+run("WindsurfPathResolver.Environment.current populates without crash") {
+    let env = WindsurfPathResolver.Environment.current()
+    expect(!env.applicationSupportPath.isEmpty)
+}
+
+// MARK: - WindsurfUsageParser.numeric + unixTimestampFlexibleSecondsOrMs
+
+run("WindsurfUsageParser.numeric: Double / Int / stringified numerics; rejects NaN/inf/nil") {
+    expectEqual(WindsurfUsageParser.numeric(42), 42.0)
+    expectEqual(WindsurfUsageParser.numeric(3.14), 3.14)
+    expectEqual(WindsurfUsageParser.numeric("100"), 100.0)
+    expectEqual(WindsurfUsageParser.numeric("garbage"), nil)
+    expectEqual(WindsurfUsageParser.numeric(nil), nil)
+    expectEqual(WindsurfUsageParser.numeric(Double.nan), nil)
+    expectEqual(WindsurfUsageParser.numeric(Double.infinity), nil)
+}
+
+run("WindsurfUsageParser.unixTimestampFlexibleSecondsOrMs: seconds and ms both accepted; range clamped") {
+    // 2026-07-13T04:00:00Z as seconds and as ms.
+    let sec = 1_784_000_400.0
+    let ms = sec * 1000.0
+    let d1 = WindsurfUsageParser.unixTimestampFlexibleSecondsOrMs(sec)
+    let d2 = WindsurfUsageParser.unixTimestampFlexibleSecondsOrMs(ms)
+    expect(d1 != nil)
+    expect(d2 != nil)
+    // Both should point to the same instant.
+    expectEqual(d1, d2)
+    // Out-of-range values return nil.
+    expect(WindsurfUsageParser.unixTimestampFlexibleSecondsOrMs(0) == nil)   // 1970 — pre-2000
+    expect(WindsurfUsageParser.unixTimestampFlexibleSecondsOrMs(1e18) == nil) // far-future
+    expect(WindsurfUsageParser.unixTimestampFlexibleSecondsOrMs(Double.nan) == nil)
+}
+
+// MARK: - WindsurfUsageParser.parse
+
+run("Windsurf.parse: older quotaUsage shape produces daily + weekly windows with reset stamps") {
+    let json = """
+    {
+      "planName": "Pro",
+      "quotaUsage": {
+        "dailyRemainingPercent": 65.0,
+        "weeklyRemainingPercent": 42.5,
+        "dailyResetAtUnix": 1784000400,
+        "weeklyResetAtUnix": 1784432400
+      }
+    }
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    expect(usage != nil)
+    expectEqual(usage?.planName, "Pro")
+    expectEqual(usage?.windows.count, 2)
+    let daily = usage?.windows.first { $0.kind == .daily }
+    expect(daily != nil)
+    // fractionUsed = (100-65)/100 = 0.35.
+    expect(abs((daily?.fractionUsed ?? 0) - 0.35) < 1e-9)
+    expect(daily?.resetsAt != nil)
+    let weekly = usage?.windows.first { $0.kind == .weekly }
+    expect(weekly != nil)
+    expect(abs((weekly?.fractionUsed ?? 0) - 0.575) < 1e-9)
+}
+
+run("Windsurf.parse: newer usage.usedFlexCredits shape produces credits window") {
+    let json = """
+    {
+      "planName": "Pro",
+      "usage": {"usedFlexCredits": 250, "flexCredits": 1000},
+      "endTimestamp": 1784000400
+    }
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    expectEqual(usage?.windows.count, 1)
+    let w = usage?.windows.first
+    expectEqual(w?.kind, .credits)
+    expectEqual(w?.displayLabel, "Flex credits")
+    expect(abs((w?.fractionUsed ?? 0) - 0.25) < 1e-9)
+}
+
+run("Windsurf.parse: newer usage.usedMessages+remainingMessages shape") {
+    let json = """
+    {"usage": {"usedMessages": 30, "remainingMessages": 70}}
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    expectEqual(usage?.windows.count, 1)
+    let w = usage?.windows.first
+    expectEqual(w?.kind, .credits)
+    expectEqual(w?.displayLabel, "Messages")
+    // 30 / (30+70) = 0.30.
+    expect(abs((w?.fractionUsed ?? 0) - 0.30) < 1e-9)
+}
+
+run("Windsurf.parse: usage.messages (total) + usedMessages fallback") {
+    // Third form observed: `messages` is total, `usedMessages` is used.
+    let json = """
+    {"usage": {"usedMessages": 10, "messages": 40}}
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    expectEqual(usage?.windows.count, 1)
+    let w = usage?.windows.first
+    expect(abs((w?.fractionUsed ?? 0) - 0.25) < 1e-9)
+}
+
+run("Windsurf.parse: quotaUsage present → newer usage.* fields NOT surfaced (no double-count)") {
+    let json = """
+    {
+      "quotaUsage": {"dailyRemainingPercent": 50.0},
+      "usage": {"usedMessages": 100, "remainingMessages": 100}
+    }
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    expectEqual(usage?.windows.count, 1)
+    expectEqual(usage?.windows.first?.kind, .daily)
+}
+
+run("Windsurf.parse: quotaUsage with only daily field produces one window (not two)") {
+    let json = """
+    {"quotaUsage": {"dailyRemainingPercent": 75.0}}
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    expectEqual(usage?.windows.count, 1)
+    expectEqual(usage?.windows.first?.kind, .daily)
+}
+
+run("Windsurf.parse: fractionUsed clamps [0, 1] when quotaRemaining is > 100 or < 0 (schema drift)") {
+    let json = """
+    {"quotaUsage": {"dailyRemainingPercent": 150.0, "weeklyRemainingPercent": -20.0}}
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    let daily = usage?.windows.first { $0.kind == .daily }
+    let weekly = usage?.windows.first { $0.kind == .weekly }
+    // dailyRemaining=150 → used = (100-150)/100 = -0.5 → clamped to 0.
+    expectEqual(daily?.fractionUsed, 0.0)
+    // weeklyRemaining=-20 → used = 120/100 = 1.2 → clamped to 1.
+    expectEqual(weekly?.fractionUsed, 1.0)
+}
+
+run("Windsurf.parse: non-object top-level returns nil") {
+    let json = "[]"
+    expect(WindsurfUsageParser.parse(cachedPlanInfoJSON: json) == nil)
+    let junk = "not json"
+    expect(WindsurfUsageParser.parse(cachedPlanInfoJSON: junk) == nil)
+}
+
+run("Windsurf.parse: empty object well-formed but yields zero windows") {
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: "{}")
+    expect(usage != nil)
+    expectEqual(usage?.windows.count, 0)
+    expectEqual(usage?.planName, nil)
+}
+
+run("Windsurf.parse: usage.flexCredits=0 does NOT produce a window (division-by-zero guard)") {
+    let json = """
+    {"usage": {"usedFlexCredits": 5, "flexCredits": 0}}
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    // Fell through to usedMessages+remainingMessages — neither present → no window.
+    expectEqual(usage?.windows.count, 0)
+}
+
+// MARK: - WindsurfUsageStore
+
+MainActor.assumeIsolated {
+
+    @MainActor func makeWindsurfStoreForTest(
+        flagEnabled: Bool = true,
+        path: String? = "/tmp/fake-windsurf.vscdb",
+        tccState: TCCState = .granted,
+        readOutcome: Result<WindsurfReadOutcome, Error> = .success(.rowMissing),
+        now: Date = Date()
+    ) -> WindsurfUsageStore {
+        let defaults = UserDefaults(suiteName: "windsurf-test-\(UUID().uuidString)")!
+        defaults.set(flagEnabled, forKey: "features.windsurf.enabled")
+        let pathCopy = path
+        let outcomeCopy = readOutcome
+        let nowCopy = now
+        return WindsurfUsageStore(
+            defaults: defaults,
+            resolvePath: { pathCopy },
+            tccProbe: { _ in tccState },
+            readUsage: { _ in
+                switch outcomeCopy {
+                case .success(let u): return u
+                case .failure(let e): throw e
+                }
+            },
+            clock: { nowCopy }
+        )
+    }
+
+    @MainActor func awaitWindsurfFetch() {
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    run("WindsurfUsageStore: feature-flag off produces no tiles") {
+        let store = makeWindsurfStoreForTest(flagEnabled: false)
+        expectEqual(store.tiles.count, 0)
+        expect(!store.isEnabled)
+    }
+
+    run("WindsurfUsageStore: enabled + granted + no usage yet -> loading tile") {
+        let store = makeWindsurfStoreForTest(flagEnabled: true, tccState: .granted)
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "windsurf-loading")
+    }
+
+    run("WindsurfUsageStore: TCC .denied -> needsAccess tile") {
+        let store = makeWindsurfStoreForTest(flagEnabled: true, tccState: .denied)
+        store.fetch()
+        awaitWindsurfFetch()
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "windsurf-needs-access")
+    }
+
+    run("WindsurfUsageStore: TCC .pathMissing -> not-installed tile") {
+        let store = makeWindsurfStoreForTest(flagEnabled: true, tccState: .pathMissing)
+        store.fetch()
+        awaitWindsurfFetch()
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "windsurf-not-installed")
+    }
+
+    run("WindsurfUsageStore: reader throws SQLiteReaderError.notFound -> tccState becomes .pathMissing") {
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .failure(SQLiteReaderError.notFound("/tmp/fake"))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        expectEqual(store.tccState, .pathMissing)
+    }
+
+    run("WindsurfUsageStore: reader throws SQLiteReaderError.openFailed -> tccState becomes .denied") {
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .failure(SQLiteReaderError.openFailed(rc: 14, message: "unable to open"))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        expectEqual(store.tccState, .denied)
+    }
+
+    run("WindsurfUsageStore: reader throws SQLiteReaderError.schemaMismatch -> schemaMismatch tile") {
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .failure(SQLiteReaderError.schemaMismatch(observed: "v9", expected: "v1"))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        expect(store.schemaMismatch)
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "windsurf-schema-mismatch")
+    }
+
+    run("WindsurfUsageStore: reader throws SQLiteReaderError.busy -> lastError set, snapshot preserved") {
+        // Seed a prior good snapshot first.
+        let goodUsage = WindsurfPlanUsage(
+            planName: "Pro",
+            windows: [WindsurfPlanUsageWindow(kind: .daily, fractionUsed: 0.5, resetsAt: nil, displayLabel: "Daily")]
+        )
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .success(.success(goodUsage))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        expect(store.usage != nil)
+
+        // Second store instance simulating a subsequent fetch with .busy.
+        // The Windsurf store's actual behaviour is: busy sets lastError
+        // and does NOT clear usage. Since we can't rewire an existing
+        // store's dependencies, verify via direct construction.
+        let defaults = UserDefaults(suiteName: "windsurf-busy-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.windsurf.enabled")
+        var callCount = 0
+        let store2 = WindsurfUsageStore(
+            defaults: defaults,
+            resolvePath: { "/tmp/fake" },
+            tccProbe: { _ in .granted },
+            readUsage: { _ in
+                callCount += 1
+                if callCount == 1 { return .success(goodUsage) }
+                throw SQLiteReaderError.busy
+            }
+        )
+        // First fetch — success.
+        store2.fetch()
+        awaitWindsurfFetch()
+        expect(store2.usage != nil)
+        // Second fetch — busy. Snapshot must persist.
+        store2.fetch()
+        awaitWindsurfFetch()
+        expect(store2.usage != nil, "snapshot must survive a transient .busy error")
+        expect(store2.lastError != nil)
+    }
+
+    run("WindsurfUsageStore: successful read populates tiles from windows") {
+        let usage = WindsurfPlanUsage(
+            planName: "Pro",
+            windows: [
+                WindsurfPlanUsageWindow(kind: .daily, fractionUsed: 0.35, resetsAt: nil, displayLabel: "Daily"),
+                WindsurfPlanUsageWindow(kind: .weekly, fractionUsed: 0.575, resetsAt: nil, displayLabel: "Weekly"),
+            ]
+        )
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .success(.success(usage))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        let ids = Set(store.tiles.map { $0.id })
+        expect(ids.contains("windsurf-plan"))
+        expect(ids.contains("windsurf-daily"))
+        expect(ids.contains("windsurf-weekly"))
+    }
+
+    run("WindsurfUsageStore: successful read with empty windows -> 'no quota data found' tile") {
+        let usage = WindsurfPlanUsage(planName: nil, windows: [])
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .success(.success(usage))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "windsurf-no-quota")
+    }
+
+    run("WindsurfUsageStore: clear() drops state + invalidates generation") {
+        let usage = WindsurfPlanUsage(
+            planName: "Pro",
+            windows: [WindsurfPlanUsageWindow(kind: .daily, fractionUsed: 0.5, resetsAt: nil, displayLabel: "Daily")]
+        )
+        let store = makeWindsurfStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            readOutcome: .success(.success(usage))
+        )
+        store.fetch()
+        awaitWindsurfFetch()
+        expect(store.usage != nil)
+        store.clear()
+        expect(store.usage == nil)
+        expect(store.lastUpdatedAt == nil)
+    }
+}
+
+// MARK: - Codex round-1 regression tests for Windsurf
+
+MainActor.assumeIsolated {
+
+    @MainActor func makeWindsurfWithOutcome(
+        _ outcome: Result<WindsurfReadOutcome, Error>
+    ) -> WindsurfUsageStore {
+        let defaults = UserDefaults(suiteName: "windsurf-regr-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.windsurf.enabled")
+        return WindsurfUsageStore(
+            defaults: defaults,
+            resolvePath: { "/tmp/fake" },
+            tccProbe: { _ in .granted },
+            readUsage: { _ in
+                switch outcome {
+                case .success(let o): return o
+                case .failure(let e): throw e
+                }
+            }
+        )
+    }
+
+    @MainActor func awaitWindsurfRegression() {
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline { RunLoop.main.run(until: Date().addingTimeInterval(0.05)) }
+    }
+
+    run("WindsurfUsageStore: fresh install / no row -> actionable 'sign in' tile, not 'Loading…' forever (round-3 #2)") {
+        let store = makeWindsurfWithOutcome(.success(.rowMissing))
+        store.fetch()
+        awaitWindsurfRegression()
+        expect(store.rowMissing)
+        let ids = store.tiles.map { $0.id }
+        expect(ids.contains("windsurf-signin-needed"), "row-missing must produce actionable tile, not loading")
+        expect(!ids.contains("windsurf-loading"))
+    }
+
+    run("WindsurfUsageStore: malformed cachedPlanInfo blob -> schemaMismatch tile, not 'Loading…' forever (round-1 #1)") {
+        // Codex round-1 finding #1: a row that exists but parses as
+        // junk MUST surface schemaMismatch, not stay on loading.
+        let store = makeWindsurfWithOutcome(.success(.malformedPayload))
+        store.fetch()
+        awaitWindsurfRegression()
+        expect(store.schemaMismatch)
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "windsurf-schema-mismatch")
+    }
+
+    run("WindsurfUsageStore: missing row (fresh install) still yields loading -> no-quota flow (not schema mismatch)") {
+        let store = makeWindsurfWithOutcome(.success(.rowMissing))
+        store.fetch()
+        awaitWindsurfRegression()
+        expect(!store.schemaMismatch)
+        // usage is nil → "Loading" then eventually no-quota tile.
+        // Actually after fetch completes with .rowMissing → outcome
+        // .success(nil) → the store sets usage=nil which renders as
+        // "windsurf-loading" only if we've never had a usage.
+        // Actually: applyOutcome(.success(nil)) sets self.usage = nil,
+        // which is unchanged; tiles guard on usage == nil rendering
+        // the loading tile. That is CORRECT behaviour — the store
+        // has not seen a usage record and is idle. To surface "no
+        // sessions" we'd need pathMissing/notInstalled state instead.
+        // This test just confirms it does NOT falsely trip schemaMismatch.
+    }
+}
+
+run("Windsurf.parse: JSON boolean in quotaUsage numeric field returns nil (round-1 #2)") {
+    // Codex round-1 finding #2: a boolean must NOT parse as 0/1.
+    let json = """
+    {"quotaUsage": {"dailyRemainingPercent": false, "weeklyRemainingPercent": true}}
+    """
+    let usage = WindsurfUsageParser.parse(cachedPlanInfoJSON: json)
+    // Both fields rejected → no windows.
+    expectEqual(usage?.windows.count, 0)
+}
+
+run("ClaudeCodeUsageStore.formatUSD: hostile huge Double does not trap (3cc round-3 #3)") {
+    // Codex 3cc round-3 finding #3: Int((amount*100).rounded()) on
+    // 1e300 traps because the Double is outside Int range.
+    // Regression: must clamp instead of trapping.
+    // No expectation on the exact string — just that it does not
+    // crash the test runner.
+    _ = ClaudeCodeUsageStore.formatUSD(1e300)
+    _ = ClaudeCodeUsageStore.formatUSD(-1e300)
+    _ = ClaudeCodeUsageStore.formatUSD(Double(Int.max))
+    // A representative sane value still formats correctly.
+    expectEqual(ClaudeCodeUsageStore.formatUSD(1207.0), "$1,207.00")
+}
+
+run("Cursor.safeInt64: oversized stringified numeric clamps to Int64.max (3cc round-3 #4)") {
+    // Codex 3cc round-3 finding #4: Int64("9223372036854775808") is
+    // nil (Int64.max+1). Regression: clamp positive-overflow strings
+    // instead of returning 0.
+    expectEqual(CursorResponseParser.safeInt64("9223372036854775808"), Int64.max)
+    expectEqual(CursorResponseParser.safeInt64("99999999999999999999"), Int64.max)
+    // Negative strings still return 0.
+    expectEqual(CursorResponseParser.safeInt64("-100"), 0)
+    // Non-numeric still returns 0.
+    expectEqual(CursorResponseParser.safeInt64("garbage"), 0)
+    // Sane values pass through.
+    expectEqual(CursorResponseParser.safeInt64("42"), 42)
+}
+
+MainActor.assumeIsolated {
+    run("WindsurfUsageStore: state.vscdb row present with non-text value -> schema-mismatch (3cc round-3 #1)") {
+        // 3cc round-3 finding #1: a row that exists with a NULL / blob
+        // / integer value in `value` used to collapse to rowMissing; now
+        // surfaces schemaMismatch.
+        let defaults = UserDefaults(suiteName: "windsurf-nontext-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.windsurf.enabled")
+        let store = WindsurfUsageStore(
+            defaults: defaults,
+            resolvePath: { "/tmp/fake" },
+            tccProbe: { _ in .granted },
+            readUsage: { _ in .malformedPayload }
+        )
+        store.fetch()
+        let deadline = Date().addingTimeInterval(1.0)
+        while Date() < deadline { RunLoop.main.run(until: Date().addingTimeInterval(0.05)) }
+        expect(store.schemaMismatch)
+    }
+}
+
+run("WindsurfUsageParser.numeric: JSON booleans return nil (round-1 #2)") {
+    expect(WindsurfUsageParser.numeric(true) == nil)
+    expect(WindsurfUsageParser.numeric(false) == nil)
+    // Real numbers still work.
+    expectEqual(WindsurfUsageParser.numeric(42), 42.0)
+    expectEqual(WindsurfUsageParser.numeric(3.14), 3.14)
+}
+
+// MARK: - CursorPathResolver
+
+run("CursorPathResolver: builds ~/Library/Application Support/Cursor path") {
+    let env = CursorPathResolver.Environment(
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: "/Users/tester/Library/Application Support"
+    )
+    let path = CursorPathResolver.stateDbPath(env)
+    expectEqual(path, "/Users/tester/Library/Application Support/Cursor/User/globalStorage/state.vscdb")
+}
+
+run("CursorPathResolver: returns nil when applicationSupportPath is empty") {
+    let env = CursorPathResolver.Environment(
+        homeDirectoryPath: "/Users/tester",
+        applicationSupportPath: ""
+    )
+    expect(CursorPathResolver.stateDbPath(env) == nil)
+}
+
+// MARK: - CursorResponseParser safe integer helpers
+
+run("CursorResponseParser.safeInt64: stringified numerics + hostile inputs") {
+    expectEqual(CursorResponseParser.safeInt64("12345"), 12345)
+    expectEqual(CursorResponseParser.safeInt64(42), 42)
+    expectEqual(CursorResponseParser.safeInt64("-1"), 0)   // clamped
+    expectEqual(CursorResponseParser.safeInt64(nil), 0)
+    expectEqual(CursorResponseParser.safeInt64(Double.nan), 0)
+    expectEqual(CursorResponseParser.safeInt64(1e300), Int64.max)
+}
+
+run("CursorResponseParser.safeInt: bare JSON numbers only, clamped non-negative") {
+    expectEqual(CursorResponseParser.safeInt(1207), 1207)
+    expectEqual(CursorResponseParser.safeInt(-10), 0)
+    expectEqual(CursorResponseParser.safeInt(nil), 0)
+}
+
+run("CursorResponseParser.safeIntOptional: returns nil for null / missing / unparseable") {
+    expectEqual(CursorResponseParser.safeIntOptional(1207), 1207)
+    expect(CursorResponseParser.safeIntOptional(nil) == nil)
+    expect(CursorResponseParser.safeIntOptional(NSNull()) == nil)
+    expect(CursorResponseParser.safeIntOptional("garbage") == nil)
+}
+
+run("CursorResponseParser.parseISO8601: date-time with and without fractional seconds") {
+    expect(CursorResponseParser.parseISO8601("2026-07-13T04:00:00Z") != nil)
+    expect(CursorResponseParser.parseISO8601("2026-07-13T04:00:00.123Z") != nil)
+    expect(CursorResponseParser.parseISO8601("garbage") == nil)
+    expect(CursorResponseParser.parseISO8601(nil) == nil)
+}
+
+// MARK: - CursorResponseParser.parseUsageSummary
+
+run("Cursor.parseUsageSummary: verified shape (against Raycast extension types)") {
+    let json = """
+    {
+      "billingCycleStart": "2026-07-01T00:00:00Z",
+      "billingCycleEnd": "2026-08-01T00:00:00Z",
+      "membershipType": "pro",
+      "limitType": "monthly",
+      "isUnlimited": false,
+      "individualUsage": {
+        "plan": {
+          "enabled": true,
+          "used": 1207,
+          "limit": 2000,
+          "remaining": 793,
+          "breakdown": {"included": 1200, "bonus": 800, "total": 2000},
+          "totalPercentUsed": 60.35
+        },
+        "onDemand": {
+          "enabled": true,
+          "used": 42,
+          "limit": null,
+          "remaining": null
+        }
+      },
+      "teamUsage": {}
+    }
+    """
+    let data = json.data(using: .utf8)!
+    let snap = CursorResponseParser.parseUsageSummary(data)
+    expect(snap != nil)
+    expectEqual(snap?.membershipType, "pro")
+    expectEqual(snap?.limitType, "monthly")
+    expectEqual(snap?.isUnlimited, false)
+    expectEqual(snap?.planUsedCents, 1207)
+    expectEqual(snap?.planLimitCents, 2000)
+    expectEqual(snap?.planRemainingCents, 793)
+    expectEqual(snap?.planIncludedCents, 1200)
+    expectEqual(snap?.planBonusCents, 800)
+    expectEqual(snap?.onDemandEnabled, true)
+    expectEqual(snap?.onDemandUsedCents, 42)
+    expect(snap?.onDemandLimitCents == nil, "null limit maps to nil")
+    expect(snap?.onDemandRemainingCents == nil)
+    expect(snap?.billingCycleStart != nil)
+    expect(snap?.billingCycleEnd != nil)
+}
+
+run("Cursor.parseUsageSummary: missing required fields returns nil") {
+    // No membershipType.
+    let json1 = """
+    {"individualUsage": {}}
+    """
+    expect(CursorResponseParser.parseUsageSummary(json1.data(using: .utf8)!) == nil)
+    // No individualUsage.
+    let json2 = """
+    {"membershipType": "pro"}
+    """
+    expect(CursorResponseParser.parseUsageSummary(json2.data(using: .utf8)!) == nil)
+    // Non-object top-level.
+    let json3 = "[1, 2, 3]"
+    expect(CursorResponseParser.parseUsageSummary(json3.data(using: .utf8)!) == nil)
+}
+
+run("Cursor.parseUsageSummary: individualUsage.plan not an object -> nil (round-1 #3)") {
+    // Codex round-1 finding #3: `plan: null` / `plan: []` / `plan: 42`
+    // all silently produced a zero-cent snapshot rendered as success.
+    // Must now reject the whole response.
+    let jsonNull = """
+    {"membershipType": "pro", "individualUsage": {"plan": null, "onDemand": {}}}
+    """
+    expect(CursorResponseParser.parseUsageSummary(jsonNull.data(using: .utf8)!) == nil)
+    let jsonArray = """
+    {"membershipType": "pro", "individualUsage": {"plan": [], "onDemand": {}}}
+    """
+    expect(CursorResponseParser.parseUsageSummary(jsonArray.data(using: .utf8)!) == nil)
+    let jsonNumber = """
+    {"membershipType": "pro", "individualUsage": {"plan": 42, "onDemand": {}}}
+    """
+    expect(CursorResponseParser.parseUsageSummary(jsonNumber.data(using: .utf8)!) == nil)
+}
+
+run("CursorTokenSafety.isValidCookieValue: RFC 6265 cookie-octet validation (round-1 #4)") {
+    // Codex round-1 finding #4: a splice-attack token would inject a
+    // second cookie into the Cookie header.
+    // Valid: base64url characters (letters, digits, -, _, .).
+    expect(CursorTokenSafety.isValidCookieValue("eyJhbGciOiJIUzI1NiIs.abc-def_ghi"))
+    // Empty fails.
+    expect(!CursorTokenSafety.isValidCookieValue(""))
+    // The critical splice attack: semicolon.
+    expect(!CursorTokenSafety.isValidCookieValue("abc; WorkosCursorSessionToken=other"))
+    // Other RFC 6265 exclusions.
+    expect(!CursorTokenSafety.isValidCookieValue("abc,def"))       // comma
+    expect(!CursorTokenSafety.isValidCookieValue("abc def"))       // space
+    expect(!CursorTokenSafety.isValidCookieValue("abc\"def"))      // dquote
+    expect(!CursorTokenSafety.isValidCookieValue("abc\\def"))      // backslash
+    expect(!CursorTokenSafety.isValidCookieValue("abc\n"))         // control char
+    expect(!CursorTokenSafety.isValidCookieValue("abc\u{7F}"))     // DEL
+    // Non-ASCII rejected too (JWTs are ASCII).
+    expect(!CursorTokenSafety.isValidCookieValue("abc\u{00E9}"))   // é
+}
+
+run("Cursor.parseUsageSummary: on-demand with concrete limit and remaining") {
+    let json = """
+    {
+      "membershipType": "pro",
+      "individualUsage": {
+        "plan": {"used": 500, "limit": 2000, "remaining": 1500, "breakdown": {"included": 2000, "bonus": 0, "total": 2000}},
+        "onDemand": {"enabled": true, "used": 100, "limit": 500, "remaining": 400}
+      }
+    }
+    """
+    let snap = CursorResponseParser.parseUsageSummary(json.data(using: .utf8)!)
+    expectEqual(snap?.onDemandLimitCents, 500)
+    expectEqual(snap?.onDemandRemainingCents, 400)
+}
+
+// MARK: - CursorResponseParser.parseAggregations
+
+run("Cursor.parseAggregations: multiple models with stringified token counts") {
+    // Cursor sends token counts as strings — verify Int64 parsing.
+    let json = """
+    {
+      "aggregations": [
+        {
+          "modelIntent": "claude-opus-4-7",
+          "inputTokens": "1000",
+          "outputTokens": "500",
+          "cacheWriteTokens": "10000000000",
+          "cacheReadTokens": "20000",
+          "totalCents": 500
+        },
+        {
+          "modelIntent": "gpt-5",
+          "inputTokens": "100",
+          "outputTokens": "50",
+          "totalCents": 100
+        }
+      ],
+      "totalCostCents": 600
+    }
+    """
+    let rows = CursorResponseParser.parseAggregations(json.data(using: .utf8)!)
+    expectEqual(rows.count, 2)
+    let opus = rows.first { $0.modelIntent == "claude-opus-4-7" }
+    expectEqual(opus?.inputTokens, 1000)
+    expectEqual(opus?.outputTokens, 500)
+    expectEqual(opus?.cacheWriteTokens, 10_000_000_000)   // > 2^32 — the reason Cursor stringifies
+    expectEqual(opus?.totalCents, 500)
+    let gpt = rows.first { $0.modelIntent == "gpt-5" }
+    expectEqual(gpt?.cacheWriteTokens, 0)   // missing field → 0
+}
+
+run("Cursor.parseAggregations: missing aggregations key returns []") {
+    let json = "{}"
+    expectEqual(CursorResponseParser.parseAggregations(json.data(using: .utf8)!).count, 0)
+    // Non-object top-level.
+    let json2 = "[]"
+    expectEqual(CursorResponseParser.parseAggregations(json2.data(using: .utf8)!).count, 0)
+}
+
+run("Cursor.parseAggregations: totalCents=null maps to nil (not zero)") {
+    let json = """
+    {"aggregations": [{"modelIntent": "gpt-5", "totalCents": null}]}
+    """
+    let rows = CursorResponseParser.parseAggregations(json.data(using: .utf8)!)
+    expectEqual(rows.count, 1)
+    expect(rows[0].totalCents == nil, "null totalCents should map to nil, not 0")
+}
+
+// MARK: - CursorResponseParser.parseRefresh
+
+run("Cursor.parseRefresh: normal refresh success") {
+    let json = """
+    {"access_token": "new-token-value", "id_token": "id-token", "shouldLogout": false}
+    """
+    let outcome = CursorResponseParser.parseRefresh(json.data(using: .utf8)!)
+    switch outcome {
+    case .success(let a, let i):
+        expectEqual(a, "new-token-value")
+        expectEqual(i, "id-token")
+    default: expect(false, "expected .success")
+    }
+}
+
+run("Cursor.parseRefresh: shouldLogout=true with empty tokens -> .sessionExpired (real Cursor response)") {
+    // This is the exact shape Cursor returns when the refresh token is
+    // also expired — the response is HTTP 200 with empty tokens and a
+    // shouldLogout flag. We must NOT treat this as success.
+    let json = """
+    {"access_token": "", "id_token": "", "shouldLogout": true}
+    """
+    let outcome = CursorResponseParser.parseRefresh(json.data(using: .utf8)!)
+    expectEqual(outcome, .sessionExpired)
+}
+
+run("Cursor.parseRefresh: malformed / missing fields") {
+    expectEqual(CursorResponseParser.parseRefresh("not json".data(using: .utf8)!), .malformed)
+    // Empty access_token WITHOUT shouldLogout flag — treat as malformed
+    // rather than session-expired (the flag is the discriminator).
+    let json = """
+    {"access_token": "", "shouldLogout": false}
+    """
+    expectEqual(CursorResponseParser.parseRefresh(json.data(using: .utf8)!), .malformed)
+}
+
+// MARK: - CursorUsageStore
+
+MainActor.assumeIsolated {
+
+    // Simple stub transport that lets a test pre-programme each response.
+    final class StubCursorTransport: CursorTransport, @unchecked Sendable {
+        var summaryResult: CursorTransportResult = .networkError
+        var aggregationResult: CursorTransportResult = .networkError
+        var refreshResult: CursorTransportResult = .networkError
+        var summaryCallCount = 0
+        var aggregationCallCount = 0
+        var refreshCallCount = 0
+        func fetchUsageSummary(cookieToken: String, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+            summaryCallCount += 1
+            let r = summaryResult
+            DispatchQueue.main.async { completion(r) }
+        }
+        func fetchAggregations(cookieToken: String, startDateMs: Int64, endDateMs: Int64, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+            aggregationCallCount += 1
+            let r = aggregationResult
+            DispatchQueue.main.async { completion(r) }
+        }
+        func refreshAccessToken(refreshToken: String, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+            refreshCallCount += 1
+            let r = refreshResult
+            DispatchQueue.main.async { completion(r) }
+        }
+    }
+
+    @MainActor func makeCursorStoreForTest(
+        flagEnabled: Bool = true,
+        path: String? = "/tmp/fake-cursor.vscdb",
+        tccState: TCCState = .granted,
+        credentials: Result<CursorCredentials?, Error> = .success(
+            CursorCredentials(accessToken: "at", refreshToken: "rt", stripeMembershipType: "pro")
+        ),
+        transport: CursorTransport,
+        now: Date = Date()
+    ) -> CursorUsageStore {
+        let defaults = UserDefaults(suiteName: "cursor-test-\(UUID().uuidString)")!
+        defaults.set(flagEnabled, forKey: "features.cursor.enabled")
+        let pathCopy = path
+        let credsCopy = credentials
+        let nowCopy = now
+        return CursorUsageStore(
+            defaults: defaults,
+            resolvePath: { pathCopy },
+            tccProbe: { _ in tccState },
+            readCredentials: { _ in
+                switch credsCopy {
+                case .success(let c): return c
+                case .failure(let e): throw e
+                }
+            },
+            transport: transport,
+            clock: { nowCopy }
+        )
+    }
+
+    @MainActor func awaitCursorFetch() {
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    func summaryJSON(membership: String = "pro", planUsed: Int = 1207, planLimit: Int = 2000) -> Data {
+        let json = """
+        {
+          "billingCycleStart": "2026-07-01T00:00:00Z",
+          "billingCycleEnd": "2026-08-01T00:00:00Z",
+          "membershipType": "\(membership)",
+          "limitType": "monthly",
+          "isUnlimited": false,
+          "individualUsage": {
+            "plan": {"used": \(planUsed), "limit": \(planLimit), "remaining": \(planLimit - planUsed),
+                      "breakdown": {"included": \(planLimit), "bonus": 0, "total": \(planLimit)}},
+            "onDemand": {"enabled": false, "used": 0, "limit": null, "remaining": null}
+          },
+          "teamUsage": {}
+        }
+        """
+        return json.data(using: .utf8)!
+    }
+
+    run("CursorUsageStore: feature-flag off -> no tiles") {
+        let stub = StubCursorTransport()
+        let store = makeCursorStoreForTest(flagEnabled: false, transport: stub)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("CursorUsageStore: TCC .denied -> needsAccess tile") {
+        let stub = StubCursorTransport()
+        let store = makeCursorStoreForTest(tccState: .denied, transport: stub)
+        store.fetch()
+        awaitCursorFetch()
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "cursor-needs-access")
+    }
+
+    run("CursorUsageStore: credentials missing (fresh Cursor install, no sign-in) -> lastError set") {
+        let stub = StubCursorTransport()
+        let store = makeCursorStoreForTest(
+            credentials: .success(nil),
+            transport: stub
+        )
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.lastError?.contains("sign in to Cursor") == true)
+        // No HTTP call when credentials are absent.
+        expectEqual(stub.summaryCallCount, 0)
+    }
+
+    run("CursorUsageStore: happy path — summary + aggregations merge into snapshot") {
+        let stub = StubCursorTransport()
+        stub.summaryResult = .success(summaryJSON())
+        let aggJSON = """
+        {"aggregations": [{"modelIntent": "claude-opus-4-7", "inputTokens": "1000", "outputTokens": "500", "totalCents": 500}]}
+        """.data(using: .utf8)!
+        stub.aggregationResult = .success(aggJSON)
+        let store = makeCursorStoreForTest(transport: stub)
+        store.fetch()
+        awaitCursorFetch()
+
+        expect(store.snapshot != nil)
+        expectEqual(store.snapshot?.membershipType, "pro")
+        expectEqual(store.snapshot?.planUsedCents, 1207)
+        expectEqual(store.snapshot?.perModel.count, 1)
+        expectEqual(stub.summaryCallCount, 1)
+        expectEqual(stub.aggregationCallCount, 1)
+        // No refresh needed when summary returned 2xx.
+        expectEqual(stub.refreshCallCount, 0)
+    }
+
+    run("CursorUsageStore: 401 triggers refresh, then retry — success reflects refreshed token") {
+        let stub = StubCursorTransport()
+        // First summary call → 401. After refresh, second summary call → 2xx.
+        var summaryStep = 0
+        final class StepBox: @unchecked Sendable {
+            var step: Int = 0
+        }
+        // Rewire stub via a subclass-style helper: use a fresh stub that
+        // returns 401 on first call, 200 on second.
+        final class TwoStepTransport: CursorTransport, @unchecked Sendable {
+            let onSummary: @Sendable (Int) -> CursorTransportResult
+            let refreshData: Data
+            var summaryCallCount = 0
+            var aggregationCallCount = 0
+            var refreshCallCount = 0
+            init(onSummary: @escaping @Sendable (Int) -> CursorTransportResult, refreshData: Data) {
+                self.onSummary = onSummary
+                self.refreshData = refreshData
+            }
+            func fetchUsageSummary(cookieToken: String, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+                summaryCallCount += 1
+                let r = onSummary(summaryCallCount)
+                DispatchQueue.main.async { completion(r) }
+            }
+            func fetchAggregations(cookieToken: String, startDateMs: Int64, endDateMs: Int64, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+                aggregationCallCount += 1
+                let empty = "{\"aggregations\":[]}".data(using: .utf8)!
+                DispatchQueue.main.async { completion(.success(empty)) }
+            }
+            func refreshAccessToken(refreshToken: String, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+                refreshCallCount += 1
+                let d = refreshData
+                DispatchQueue.main.async { completion(.success(d)) }
+            }
+        }
+        let summaryData = summaryJSON()
+        let refreshData = """
+        {"access_token": "refreshed-token", "id_token": "new-id", "shouldLogout": false}
+        """.data(using: .utf8)!
+        let transport = TwoStepTransport(
+            onSummary: { call in call == 1 ? .unauthorized : .success(summaryData) },
+            refreshData: refreshData
+        )
+        let store = makeCursorStoreForTest(transport: transport)
+        store.fetch()
+        awaitCursorFetch()
+
+        // Summary was retried after the refresh.
+        expectEqual(transport.summaryCallCount, 2)
+        expectEqual(transport.refreshCallCount, 1)
+        expect(store.snapshot != nil, "snapshot populated after refresh")
+        expect(!store.sessionExpired)
+    }
+
+    run("CursorUsageStore: refresh returns shouldLogout=true -> sessionExpired tile") {
+        // Refresh response is 200 but with empty tokens + shouldLogout=true.
+        let stub = StubCursorTransport()
+        stub.summaryResult = .unauthorized
+        let refreshData = """
+        {"access_token": "", "id_token": "", "shouldLogout": true}
+        """.data(using: .utf8)!
+        stub.refreshResult = .success(refreshData)
+        let store = makeCursorStoreForTest(transport: stub)
+        store.fetch()
+        awaitCursorFetch()
+
+        expect(store.sessionExpired)
+        expect(store.snapshot == nil)
+        expectEqual(store.tiles.count, 1)
+        expectEqual(store.tiles.first?.id, "cursor-session-expired")
+    }
+
+    run("CursorUsageStore: refresh returns unauthorized -> sessionExpired (Cursor OAuth server rejected refresh token)") {
+        let stub = StubCursorTransport()
+        stub.summaryResult = .unauthorized
+        stub.refreshResult = .unauthorized
+        let store = makeCursorStoreForTest(transport: stub)
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.sessionExpired)
+    }
+
+    run("CursorUsageStore: 429 rate-limited on summary preserves prior snapshot") {
+        // Seed a good snapshot first.
+        let stub = StubCursorTransport()
+        stub.summaryResult = .success(summaryJSON())
+        stub.aggregationResult = .success("{\"aggregations\":[]}".data(using: .utf8)!)
+        let store = makeCursorStoreForTest(transport: stub)
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.snapshot != nil)
+
+        // Next fetch → 429. Snapshot must persist.
+        stub.summaryResult = .rateLimited(retryAfterSec: 30)
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.snapshot != nil, "rate-limit preserves prior snapshot")
+        expect(store.lastError?.contains("rate-limited") == true)
+    }
+
+    run("CursorUsageStore: clear() drops snapshot + resets sessionExpired + refreshed token") {
+        let stub = StubCursorTransport()
+        stub.summaryResult = .success(summaryJSON())
+        stub.aggregationResult = .success("{\"aggregations\":[]}".data(using: .utf8)!)
+        let store = makeCursorStoreForTest(transport: stub)
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.snapshot != nil)
+        store.clear()
+        expect(store.snapshot == nil)
+        expect(!store.sessionExpired)
+        expectEqual(store.lastUpdatedAt, nil)
+    }
+
+    run("CursorUsageStore.friendlyPlanLabel: capitalises + spaces hyphens") {
+        expectEqual(CursorUsageStore.friendlyPlanLabel("pro"), "Pro")
+        expectEqual(CursorUsageStore.friendlyPlanLabel("pro-plus"), "Pro Plus")
+        expectEqual(CursorUsageStore.friendlyPlanLabel("free"), "Free")
+        expectEqual(CursorUsageStore.friendlyPlanLabel(""), "")
+    }
+
+    run("CursorUsageStore.formatDollarsFromCents: standard formatting") {
+        expectEqual(CursorUsageStore.formatDollarsFromCents(1207), "$12.07")
+        expectEqual(CursorUsageStore.formatDollarsFromCents(0), "$0.00")
+        expectEqual(CursorUsageStore.formatDollarsFromCents(100000), "$1,000.00")
+    }
+
+    run("CursorUsageStore: saturating token totals do not wrap (round-2 #1)") {
+        // Codex round-2 finding #1: aggregation with Int64.max in
+        // one field and 1 in another wrapped `&+` to Int64.min and
+        // then tripped abs(Int.min) in formatTokens. saturatingAddInt64
+        // clamps to Int64.max.
+        expectEqual(CursorUsageStore.saturatingAddInt64(Int64.max, 1), Int64.max)
+        expectEqual(CursorUsageStore.saturatingAddInt64(Int64.max, Int64.max), Int64.max)
+        expectEqual(CursorUsageStore.saturatingAddInt64(-100, 200), 200)   // negatives coerced
+        expectEqual(CursorUsageStore.saturatingAddInt64(100, 50), 150)
+    }
+
+    run("CursorUsageStore: sticky sessionExpired short-circuits transport (no repeated refresh) (round-2 #2)") {
+        // Codex round-2 finding #2: after sessionExpired is set,
+        // subsequent fetches with the SAME DB accessToken must not
+        // send additional summary/refresh calls (which would post
+        // the known-expired refresh token to Cursor on every timer
+        // tick).
+        let stub = StubCursorTransport()
+        stub.summaryResult = .unauthorized
+        stub.refreshResult = .success("""
+            {"access_token": "", "id_token": "", "shouldLogout": true}
+        """.data(using: .utf8)!)
+        let store = makeCursorStoreForTest(transport: stub)
+        // Fetch 1 → session expires.
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.sessionExpired)
+        let summaryAfterFirst = stub.summaryCallCount
+        let refreshAfterFirst = stub.refreshCallCount
+        expect(summaryAfterFirst == 1)
+        expect(refreshAfterFirst == 1)
+        // Fetch 2 with the SAME DB token — must NOT re-issue transport calls.
+        store.fetch()
+        awaitCursorFetch()
+        expectEqual(stub.summaryCallCount, summaryAfterFirst)
+        expectEqual(stub.refreshCallCount, refreshAfterFirst)
+    }
+
+    run("Cursor.safeInt/safeInt64/safeIntOptional reject JSON booleans (round-2 #3)") {
+        expectEqual(CursorResponseParser.safeInt(true), 0)
+        expectEqual(CursorResponseParser.safeInt(false), 0)
+        expectEqual(CursorResponseParser.safeInt64(true), 0)
+        expectEqual(CursorResponseParser.safeInt64(false), 0)
+        expect(CursorResponseParser.safeIntOptional(true) == nil)
+        expect(CursorResponseParser.safeIntOptional(false) == nil)
+    }
+
+    run("Cursor.parseUsageSummary: plan.used = true (JSON bool drift) yields zero used cents") {
+        // With the boolean rejection above, plan.used=true is treated
+        // as missing — safeInt returns 0. The snapshot still parses
+        // (plan is still an object) but usage numerics are all zero.
+        // This is intentional: the response was structurally sane,
+        // just semantically wrong. A future tightening could also
+        // reject the whole response.
+        let json = """
+        {"membershipType": "pro", "individualUsage": {"plan": {"used": true, "limit": 100}, "onDemand": {}}}
+        """
+        let snap = CursorResponseParser.parseUsageSummary(json.data(using: .utf8)!)
+        expect(snap != nil)
+        expectEqual(snap?.planUsedCents, 0)
+    }
+
+    run("CursorUsageStore: sessionExpired clears when DB accessToken changes (user re-signs-in) (round-1 #6)") {
+        // Codex round-1 finding #6: after sessionExpired=true, a fresh
+        // DB token (Cursor writes a new session after re-login) must
+        // clear the sticky flag on the next fetch.
+        let stub = StubCursorTransport()
+        stub.summaryResult = .unauthorized
+        stub.refreshResult = .success("""
+            {"access_token": "", "id_token": "", "shouldLogout": true}
+        """.data(using: .utf8)!)
+
+        // Rewireable credential reader — starts with old-token, then
+        // returns new-token on the second fetch.
+        final class CredBox: @unchecked Sendable {
+            var current = CursorCredentials(accessToken: "old-token", refreshToken: "rt", stripeMembershipType: nil)
+        }
+        let box = CredBox()
+        let defaults = UserDefaults(suiteName: "cursor-sticky-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cursor.enabled")
+        let store = CursorUsageStore(
+            defaults: defaults,
+            resolvePath: { "/tmp/fake" },
+            tccProbe: { _ in .granted },
+            readCredentials: { _ in box.current },
+            transport: stub
+        )
+
+        // Fetch 1 — session expires.
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.sessionExpired, "first fetch's refresh returned shouldLogout")
+        // User re-signs-in: Cursor writes a new session token to
+        // state.vscdb.
+        box.current = CursorCredentials(accessToken: "new-token", refreshToken: "new-rt", stripeMembershipType: nil)
+        // Second fetch's summary call now succeeds.
+        stub.summaryResult = .success(summaryJSON())
+        stub.aggregationResult = .success("{\"aggregations\":[]}".data(using: .utf8)!)
+
+        store.fetch()
+        awaitCursorFetch()
+        expect(!store.sessionExpired, "sticky sessionExpired must clear when DB token changes")
+        expect(store.snapshot != nil)
+    }
+
+    run("CursorUsageStore: refreshed token is dropped when DB accessToken changes (round-1 #5)") {
+        // Codex round-1 finding #5: after a refresh, if the DB
+        // accessToken later differs from the one we refreshed FROM,
+        // the in-memory refreshed token must be discarded so the DB
+        // value takes precedence.
+        // Rewireable credential reader — starts with token-A, then B.
+        final class CredBox: @unchecked Sendable {
+            var current = CursorCredentials(accessToken: "token-A", refreshToken: "rt-A", stripeMembershipType: nil)
+        }
+        let box = CredBox()
+        let defaults = UserDefaults(suiteName: "cursor-refresh-invalidation-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cursor.enabled")
+
+        // Transport that records which cookie was used on each summary call.
+        final class RecordingTransport: CursorTransport, @unchecked Sendable {
+            var summaryCookies: [String] = []
+            var summaryCallCount = 0
+            var refreshCallCount = 0
+            let refreshResp: Data
+            let aggData: Data
+            let summaryData: Data
+            init(refreshResp: Data, aggData: Data, summaryData: Data) {
+                self.refreshResp = refreshResp
+                self.aggData = aggData
+                self.summaryData = summaryData
+            }
+            func fetchUsageSummary(cookieToken: String, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+                summaryCallCount += 1
+                summaryCookies.append(cookieToken)
+                let count = summaryCallCount
+                let refreshed = self.refreshResp
+                let summary = self.summaryData
+                DispatchQueue.main.async {
+                    // First call → 401 (triggers refresh). Second and
+                    // third calls succeed.
+                    if count == 1 {
+                        completion(.unauthorized)
+                    } else {
+                        _ = refreshed
+                        completion(.success(summary))
+                    }
+                }
+            }
+            func fetchAggregations(cookieToken: String, startDateMs: Int64, endDateMs: Int64, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+                let d = aggData
+                DispatchQueue.main.async { completion(.success(d)) }
+            }
+            func refreshAccessToken(refreshToken: String, completion: @escaping @Sendable (CursorTransportResult) -> Void) {
+                refreshCallCount += 1
+                let r = refreshResp
+                DispatchQueue.main.async { completion(.success(r)) }
+            }
+        }
+        let refreshResp = """
+            {"access_token": "refreshed-of-A", "id_token": "id", "shouldLogout": false}
+        """.data(using: .utf8)!
+        let summaryData = summaryJSON()
+        let transport = RecordingTransport(
+            refreshResp: refreshResp,
+            aggData: "{\"aggregations\":[]}".data(using: .utf8)!,
+            summaryData: summaryData
+        )
+        let store = CursorUsageStore(
+            defaults: defaults,
+            resolvePath: { "/tmp/fake" },
+            tccProbe: { _ in .granted },
+            readCredentials: { _ in box.current },
+            transport: transport
+        )
+        // Fetch 1 — 401 triggers refresh → in-memory refreshed-of-A.
+        store.fetch()
+        awaitCursorFetch()
+        expect(store.snapshot != nil)
+        expect(transport.summaryCallCount == 2)
+        // Confirm the retry used the refreshed token.
+        expect(transport.summaryCookies.last == "refreshed-of-A")
+
+        // Now the DB writes a fresh token-B (a re-login or account swap).
+        box.current = CursorCredentials(accessToken: "token-B", refreshToken: "rt-B", stripeMembershipType: nil)
+        // Fetch 2 — should use token-B (DB), NOT refreshed-of-A.
+        store.fetch()
+        awaitCursorFetch()
+        expect(transport.summaryCookies.last == "token-B", "in-memory refreshed token must yield to a fresh DB accessToken")
+    }
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -654,6 +654,239 @@ run("ProviderCopy.disclosure warns about the private API for Codex only") {
     expect(ProviderCopy.disclosure(for: "deepseek") == nil)
 }
 
+// MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
+
+// Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available
+// bool, balance_infos[] with currency + three STRING amounts.
+let fixtureDeepSeekUSD = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "USD", "total_balance": "110.00", "granted_balance": "10.00", "topped_up_balance": "100.00"}
+  ]
+}
+"""#
+
+run("parse DeepSeek USD balance (strings preserved verbatim)") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekUSD.data(using: .utf8)!)
+    expectEqual(snap.isAvailable, true)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "USD")
+    expectEqual(snap.balances[0].totalBalance, "110.00")
+    expectEqual(snap.balances[0].grantedBalance, "10.00")
+    expectEqual(snap.balances[0].toppedUpBalance, "100.00")
+}
+
+let fixtureDeepSeekCNY = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "CNY", "total_balance": "550.5", "granted_balance": "0", "topped_up_balance": "550.5"}
+  ]
+}
+"""#
+
+run("parse DeepSeek CNY balance") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekCNY.data(using: .utf8)!)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "CNY")
+    expectEqual(snap.balances[0].totalBalance, "550.5")
+}
+
+let fixtureDeepSeekDual = #"""
+{
+  "is_available": true,
+  "balance_infos": [
+    {"currency": "USD", "total_balance": "5.00", "granted_balance": "5.00", "topped_up_balance": "0"},
+    {"currency": "CNY", "total_balance": "36.00", "granted_balance": "36.00", "topped_up_balance": "0"}
+  ]
+}
+"""#
+
+run("parse DeepSeek dual-currency balance_infos") {
+    let snap = try! DeepSeekUsageFetcher.parse(fixtureDeepSeekDual.data(using: .utf8)!)
+    expectEqual(snap.balances.count, 2)
+    expectEqual(snap.balances[0].currency, "USD")
+    expectEqual(snap.balances[1].currency, "CNY")
+}
+
+run("parse DeepSeek is_available false") {
+    let bytes = #"{"is_available": false, "balance_infos": []}"#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.isAvailable, false)
+    expectEqual(snap.balances.count, 0)
+}
+
+run("parse DeepSeek accepts numeric amounts defensively") {
+    // The documented API returns strings; accept numbers too so a server
+    // change does not drop the value.
+    let bytes = #"""
+    {"is_available": true, "balance_infos": [{"currency": "USD", "total_balance": 42, "granted_balance": 0, "topped_up_balance": 42.5}]}
+    """#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.balances[0].totalBalance, "42")
+    expectEqual(snap.balances[0].toppedUpBalance, "42.5")
+}
+
+run("parse DeepSeek skips entries with no currency") {
+    let bytes = #"""
+    {"is_available": true, "balance_infos": [{"total_balance": "1.00"}, {"currency": "USD", "total_balance": "2.00", "granted_balance": "0", "topped_up_balance": "2.00"}]}
+    """#.data(using: .utf8)!
+    let snap = try! DeepSeekUsageFetcher.parse(bytes)
+    expectEqual(snap.balances.count, 1)
+    expectEqual(snap.balances[0].currency, "USD")
+}
+
+run("parse DeepSeek tolerates empty object") {
+    let snap = try! DeepSeekUsageFetcher.parse("{}".data(using: .utf8)!)
+    expectEqual(snap.isAvailable, false)
+    expectEqual(snap.balances.count, 0)
+}
+
+run("parse DeepSeek throws on array top-level") {
+    do {
+        _ = try DeepSeekUsageFetcher.parse("[]".data(using: .utf8)!)
+        expect(false, "expected throw")
+    } catch { expect(true) }
+}
+
+// MARK: - DeepSeekUsageStore (via in-memory CredentialStore)
+
+/// In-memory CredentialStore so store tests never touch the real Keychain
+/// (which could prompt or persist). Deterministic and isolated.
+final class InMemoryCredentialStore: CredentialStore {
+    private var storage: [String: Data] = [:]
+    func read(_ key: String) -> Data? { storage[key] }
+    func write(_ key: String, _ value: Data) { storage[key] = value }
+    func delete(_ key: String) { storage[key] = nil }
+}
+
+MainActor.assumeIsolated {
+    let suiteName = "deepseek-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "features.deepseek.enabled")
+
+    run("DeepSeek store off by default emits no tiles") {
+        let d2 = UserDefaults(suiteName: suiteName + "-off")!
+        d2.removePersistentDomain(forName: suiteName + "-off")
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: d2)
+        expectEqual(store.isEnabled, false)
+        expectEqual(store.tiles.count, 0)
+    }
+
+    run("DeepSeek enabled but no key emits needsAccess tile") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        expectEqual(store.isEnabled, true)
+        expectEqual(store.isConfigured, false)
+        let tiles = store.tiles
+        expectEqual(tiles.count, 1)
+        if case .needsAccess = tiles.first?.kind { expect(true) }
+        else { expect(false, "expected needsAccess") }
+    }
+
+    run("DeepSeek saveKey stores in credential store and configures") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        expectEqual(store.hasKey, false)
+        store.saveKey("  sk-fake-deepseek-key  ")  // trimmed
+        expectEqual(store.hasKey, true)
+        expectEqual(store.isConfigured, true)
+        // The stored value is trimmed.
+        let stored = String(data: creds.read(DeepSeekUsageStore.apiKeyKeychainKey)!, encoding: .utf8)
+        expectEqual(stored, "sk-fake-deepseek-key")
+    }
+
+    run("DeepSeek saveKey with empty string clears the key") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        expectEqual(store.hasKey, true)
+        store.saveKey("   ")
+        expectEqual(store.hasKey, false)
+    }
+
+    run("DeepSeek applies USD balance and renders a balance tile") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        store.apply(.success(fixtureDeepSeekUSD.data(using: .utf8)!))
+        expect(store.lastUpdated != nil)
+        expect(store.errorMessage == nil)
+        let tiles = store.tiles
+        // Available == true so no status tile; one balance tile.
+        expectEqual(tiles.count, 1)
+        expectEqual(tiles[0].id, "deepseek-balance-usd")
+        if case let .text(status, subtitle) = tiles[0].kind {
+            expectEqual(status, "USD 110.00")
+            expectEqual(subtitle, "Granted 10.00 + topped-up 100.00")
+        } else { expect(false, "expected text tile") }
+    }
+
+    run("DeepSeek unavailable balance adds an amber status tile") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        let bytes = #"{"is_available": false, "balance_infos": [{"currency": "USD", "total_balance": "0.00", "granted_balance": "0", "topped_up_balance": "0"}]}"#.data(using: .utf8)!
+        store.apply(.success(bytes))
+        let tiles = store.tiles
+        // status tile + balance tile
+        expectEqual(tiles.count, 2)
+        expectEqual(tiles[0].id, "deepseek-status")
+    }
+
+    run("DeepSeek 401 maps to invalid-key error") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        store.apply(.unauthorized)
+        expectEqual(store.errorMessage, "Invalid DeepSeek API key")
+    }
+
+    run("DeepSeek httpError and networkError map to messages") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        store.apply(.httpError(500))
+        expectEqual(store.errorMessage, "HTTP 500")
+        store.apply(.networkError)
+        expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("DeepSeek clear deletes the key and state") {
+        let creds = InMemoryCredentialStore()
+        let store = DeepSeekUsageStore(credentials: creds, defaults: defaults)
+        store.saveKey("sk-fake")
+        store.apply(.success(fixtureDeepSeekUSD.data(using: .utf8)!))
+        store.clear()
+        expectEqual(store.hasKey, false)
+        expect(store.snapshot == nil)
+        expect(creds.read(DeepSeekUsageStore.apiKeyKeychainKey) == nil)
+    }
+
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
+// MARK: - KeychainStore round-trip (guarded — real Keychain may be absent)
+
+// Uses a throwaway service so the test never collides with real credentials,
+// and cleans up. In a headless CI keychain SecItemAdd can fail (errSecMissing
+// Entitlement / no keychain); in that case read returns nil and we skip the
+// positive assertions rather than fail the suite.
+run("KeychainStore round-trips when a keychain is available") {
+    let store = KeychainStore(service: "com.claude.usagebar.test-\(ProcessInfo.processInfo.processIdentifier)")
+    let key = "roundtrip-key"
+    let value = Data("sk-fake-value".utf8)
+    store.delete(key)  // clean slate
+    store.write(key, value)
+    if let read = store.read(key) {
+        // Keychain available — verify round-trip and delete.
+        expectEqual(read, value)
+        store.delete(key)
+        expect(store.read(key) == nil)
+    } else {
+        // No keychain in this environment (headless CI) — not a failure of
+        // KeychainStore logic. Record a pass so the suite total stays honest.
+        expect(true)
+    }
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -678,6 +678,18 @@ run("ProviderCopy.help returns xAI two-key guidance") {
     expect(xai?.contains("management key") == true)
 }
 
+run("ProviderCopy: OpenAI help + admin-key disclosure") {
+    let help = ProviderCopy.help(for: "openai")
+    expect(help != nil)
+    expect(help?.contains("Admin key") == true)
+    expect(help?.contains("month-to-date") == true)
+    // Admin keys are high-privilege — a disclosure warning is required.
+    let disc = ProviderCopy.disclosure(for: "openai")
+    expect(disc != nil)
+    expect(disc?.contains("manage users") == true)
+    expect(disc?.contains("cannot make inference") == true)
+}
+
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
 
 // Fixture shapes match api-docs.deepseek.com/api/get-user-balance: is_available

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -651,7 +651,15 @@ run("ProviderCopy.disclosure warns about the private API for Codex only") {
     expect(codex?.contains("private Codex API") == true)
     expect(codex?.contains("without notice") == true)
     expect(ProviderCopy.disclosure(for: "anthropic") == nil)
+    // DeepSeek uses a documented, stable API — no private-API disclosure.
     expect(ProviderCopy.disclosure(for: "deepseek") == nil)
+}
+
+run("ProviderCopy.help returns DeepSeek Keychain guidance") {
+    let ds = ProviderCopy.help(for: "deepseek")
+    expect(ds != nil)
+    expect(ds?.contains("Keychain") == true)
+    expect(ds?.contains("balance") == true)
 }
 
 // MARK: - DeepSeekUsageFetcher.parse (PR 4-BE)
@@ -847,6 +855,15 @@ MainActor.assumeIsolated {
         expectEqual(store.errorMessage, "HTTP 500")
         store.apply(.networkError)
         expectEqual(store.errorMessage, "Network error")
+    }
+
+    run("DeepSeek conforms to PasteKeyProvider with sk- placeholder") {
+        let store = DeepSeekUsageStore(credentials: InMemoryCredentialStore(), defaults: defaults)
+        let keyProvider = store as PasteKeyProvider
+        expect(keyProvider.keyPlaceholder.contains("sk"))
+        expectEqual(keyProvider.hasKey, false)
+        keyProvider.saveKey("sk-fake")
+        expectEqual(keyProvider.hasKey, true)
     }
 
     run("DeepSeek clear deletes the key and state") {

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2450,23 +2450,43 @@ MainActor.assumeIsolated {
     }
     #endif
 
-    run("Perplexity multi-endpoint partial success emits available tiles (chk1 Omission #2)") {
-        // Locks in the "success-when-any-endpoint-succeeded" behaviour.
-        // Concretely: even if rate-limits and settings return non-2xx, a
-        // 200 on credits still surfaces the credits tile — the failure of
-        // the others is not permitted to blank the whole provider.
+    run("Perplexity partial-success snapshot renders only the tiles it carries (chk1 Omission #2 — store apply)") {
+        // Store-layer assertion: given a snapshot that carries only credits
+        // (as the accumulator would produce when rateLimits and settings
+        // endpoints failed), the tile mapper must not paper over the gap
+        // with plan/mode tiles. Complements the accumulator-side test below.
         let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
         store.saveKey("cookie")
         var snap = PerplexityUsageSnapshot()
         snap.credits = PerplexityCredits(balanceCents: 4235.50, renewalEpoch: 1770000000)
-        // rateLimits and settings intentionally left nil (as though those
-        // endpoints returned 429/500 and were dropped by the accumulator).
         store.apply(.success(snap))
         expect(store.tiles.contains { $0.id == "perplexity-credits" })
         expect(!store.tiles.contains { $0.id == "perplexity-plan" })
         expect(!store.tiles.contains { $0.id == "perplexity-pro" })
         expect(!store.tiles.contains { $0.id == "perplexity-research" })
     }
+
+    #if DEBUG
+    run("Perplexity accumulator finalizes partial-success correctly (chk1 Omission #2 — accumulator)") {
+        // Transport-layer assertion (Codex round-4 finding #3): the
+        // accumulator itself, given credits-set + rateLimits-not-set +
+        // settings-not-set + one rateLimits httpError(429), returns
+        // (unauthorized: false, httpError: 429 remembered, snapshot with
+        // only credits populated). This exercises the code path the
+        // production transport uses, complementing the store-level test.
+        let acc = PerplexityFetchAccumulator()
+        acc.setCredits(PerplexityCredits(balanceCents: 4235.50, renewalEpoch: 1770000000))
+        acc.recordHttpError(429)                    // rate-limit endpoint 429'd
+        acc.recordHttpError(500)                    // settings endpoint 5xx'd
+        let (unauthorized, httpError, snap) = acc.finalize()
+        expectEqual(unauthorized, false)
+        // 429 wins the priority ranking over the 500.
+        expectEqual(httpError, 429)
+        expect(snap.credits != nil)
+        expect(snap.rateLimits == nil)
+        expect(snap.settings == nil)
+    }
+    #endif
 
     run("Perplexity fetch() background-delivered success reaches @Published snapshot (chk1 Omission #3)") {
         // Round-1 tests covered background-queue delivery of .unauthorized,

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -2433,6 +2433,66 @@ MainActor.assumeIsolated {
         }
     }
 
+    #if DEBUG
+    run("Perplexity accumulator priority: 429 beats 5xx beats other 4xx (chk1 Omission #1)") {
+        // Locks in the priority ordering so a future edit that flipped
+        // the recordHttpError branches would fail this test.
+        let acc = PerplexityFetchAccumulator()
+        expect(acc.currentHttpError == nil)
+        acc.recordHttpError(418)
+        expectEqual(acc.currentHttpError, 418)
+        acc.recordHttpError(500)
+        expectEqual(acc.currentHttpError, 500)   // 5xx > other 4xx
+        acc.recordHttpError(429)
+        expectEqual(acc.currentHttpError, 429)   // 429 > 5xx
+        acc.recordHttpError(503)
+        expectEqual(acc.currentHttpError, 429)   // 429 sticks (does not degrade)
+    }
+    #endif
+
+    run("Perplexity multi-endpoint partial success emits available tiles (chk1 Omission #2)") {
+        // Locks in the "success-when-any-endpoint-succeeded" behaviour.
+        // Concretely: even if rate-limits and settings return non-2xx, a
+        // 200 on credits still surfaces the credits tile — the failure of
+        // the others is not permitted to blank the whole provider.
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: StubPerplexityTransport(.networkError), defaults: defaults)
+        store.saveKey("cookie")
+        var snap = PerplexityUsageSnapshot()
+        snap.credits = PerplexityCredits(balanceCents: 4235.50, renewalEpoch: 1770000000)
+        // rateLimits and settings intentionally left nil (as though those
+        // endpoints returned 429/500 and were dropped by the accumulator).
+        store.apply(.success(snap))
+        expect(store.tiles.contains { $0.id == "perplexity-credits" })
+        expect(!store.tiles.contains { $0.id == "perplexity-plan" })
+        expect(!store.tiles.contains { $0.id == "perplexity-pro" })
+        expect(!store.tiles.contains { $0.id == "perplexity-research" })
+    }
+
+    run("Perplexity fetch() background-delivered success reaches @Published snapshot (chk1 Omission #3)") {
+        // Round-1 tests covered background-queue delivery of .unauthorized,
+        // but not of .success. Cover the common-case path so a future edit
+        // that reintroduced MainActor.assumeIsolated in apply() would trap
+        // and fail this test.
+        final class BackgroundSuccessTransport: PerplexityUsageTransport, @unchecked Sendable {
+            func fetchAll(cookieName: String, cookieValue: String, completion: @escaping @Sendable (PerplexityUsageResult) -> Void) {
+                DispatchQueue.global().async {
+                    var s = PerplexityUsageSnapshot()
+                    s.credits = PerplexityCredits(balanceCents: 500, renewalEpoch: 1770000000)
+                    completion(.success(s))
+                }
+            }
+        }
+        let store = PerplexityUsageStore(credentials: InMemoryCredentialStore(), transport: BackgroundSuccessTransport(), defaults: defaults)
+        store.saveKey("cookie")
+        store.fetch()
+        let deadline = Date().addingTimeInterval(2.0)
+        while store.snapshot == nil && Date() < deadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        expect(store.snapshot != nil)
+        expectEqual(store.snapshot?.credits?.balanceCents, 500)
+    }
+
     run("Perplexity transport rejects a semicolon-injected cookie value") {
         // Codex adversarial review #5. A hostile paste like "real; other=evil"
         // is caught by extract() when the paste is parsed (it becomes a full

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -632,6 +632,28 @@ MainActor.assumeIsolated {
     defaults.removePersistentDomain(forName: suiteName)
 }
 
+// MARK: - ProviderCopy (Settings toggle copy — PR 3-UI)
+
+run("ProviderCopy.help returns Codex copy and nil for unknown") {
+    let codex = ProviderCopy.help(for: "codex")
+    expect(codex != nil)
+    expect(codex?.contains("Codex CLI") == true)
+    expect(codex?.contains("General GPT chat is not counted") == true)
+    // Honest-labels invariant: never claim to track general ChatGPT usage.
+    expect(codex?.contains("ChatGPT usage") == false)
+    expect(ProviderCopy.help(for: "anthropic") == nil)
+    expect(ProviderCopy.help(for: "unknown-provider") == nil)
+}
+
+run("ProviderCopy.disclosure warns about the private API for Codex only") {
+    let codex = ProviderCopy.disclosure(for: "codex")
+    expect(codex != nil)
+    expect(codex?.contains("private Codex API") == true)
+    expect(codex?.contains("without notice") == true)
+    expect(ProviderCopy.disclosure(for: "anthropic") == nil)
+    expect(ProviderCopy.disclosure(for: "deepseek") == nil)
+}
+
 // MARK: - Summary
 
 print("")

--- a/Tests/TestRunner/main.swift
+++ b/Tests/TestRunner/main.swift
@@ -6220,6 +6220,143 @@ MainActor.assumeIsolated {
         expectEqual(store.tccState, .denied)
     }
 
+    run("ClineUsageStore: TCC revoked mid-parse discards the empty parse result (3cc round-1 #1)") {
+        // 3cc round-1 finding #1: TCC probed .granted at fetch-start,
+        // then revoked between discoverFiles and apply-hop. The re-probe
+        // must catch it and discard the (now empty) parse result rather
+        // than overwriting real usage with $0.
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let priorRec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 1.23, sourceFile: "/tmp/fake/a.json"
+        )
+        let defaults = UserDefaults(suiteName: "cline-revoke-\(UUID().uuidString)")!
+        defaults.set(true, forKey: "features.cline.enabled")
+        final class ProbeToggle: @unchecked Sendable {
+            // Starts granted, flips to denied on the SECOND probe call.
+            var granted = true
+            var callCount = 0
+        }
+        let toggle = ProbeToggle()
+        final class Gate: @unchecked Sendable { let sem = DispatchSemaphore(value: 0) }
+        let gate = Gate()
+        let root = ClinePathResolver.ScanRoot(id: "test", tasksDirectoryPath: "/tmp/fake/tasks")
+        let store = ClineUsageStore(
+            defaults: defaults,
+            resolveScanRoots: { [root] },
+            tccProbe: { _ in
+                toggle.callCount += 1
+                // First call (fetch-start aggregation): granted.
+                // Second call (apply-hop re-probe): denied.
+                return toggle.granted && toggle.callCount == 1 ? .granted : .denied
+            },
+            discoverFiles: { _ in [] },  // TCC revoked → no files discoverable
+            parseFiles: { _ in
+                // Block briefly so the caller can flip toggle.granted
+                // between the fetch-start probe and this parse.
+                gate.sem.wait()
+                return ClineUsageSnapshot(records: [])
+            },
+            clock: { now }
+        )
+        // Seed a prior good snapshot manually — the "before" state.
+        // We can't set snapshot directly since it's private(set), so
+        // instead we run one clean fetch first with granted state
+        // and files, then flip the toggle for the second fetch.
+        toggle.granted = true
+        // For the seeding fetch, we need discoverFiles + parseFiles to
+        // return the prior good record. Use a separate store.
+        let seedDefaults = UserDefaults(suiteName: "cline-revoke-seed-\(UUID().uuidString)")!
+        seedDefaults.set(true, forKey: "features.cline.enabled")
+        let seedGate = Gate(); seedGate.sem.signal()  // pre-signalled → non-blocking
+        let seedStore = ClineUsageStore(
+            defaults: seedDefaults,
+            resolveScanRoots: { [root] },
+            tccProbe: { _ in .granted },
+            discoverFiles: { _ in [URL(fileURLWithPath: "/tmp/fake/tasks/a/ui_messages.json")] },
+            parseFiles: { _ in ClineUsageSnapshot(records: [priorRec]) },
+            clock: { now }
+        )
+        seedStore.fetch()
+        // seedStore is not the store-under-test; just proves the code
+        // path works. The MAIN assertion below is on `store`.
+
+        // Kick off the racy fetch on `store`. parseFiles will block.
+        store.fetch()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        // Release the parse.
+        gate.sem.signal()
+        awaitClineFetch()
+
+        // Because the re-probe returned .denied on the second call,
+        // the empty parse result must NOT have applied.
+        expect(store.snapshot == nil, "empty parse from a revoked-mid-flight fetch must not overwrite state")
+        expectEqual(store.tccState, .denied)
+    }
+
+    run("ClineUsageStore: file-level parse failures surface a 'Some sessions skipped' diagnostic tile (3cc round-1 #2)") {
+        // 3cc round-1 finding #2: without a diagnostic, a corrupt or
+        // over-cap ui_messages.json is silently dropped and the tile
+        // shows the remaining totals as complete. Now the store
+        // surfaces unreadableFileCount + malformedRecordCount as an
+        // informational tile.
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 1000, tokensOut: 500, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.0175, sourceFile: "/tmp/fake/a.json"
+        )
+        let snap = ClineUsageSnapshot(
+            records: [rec],
+            recordsPerFile: ["/tmp/fake/a.json": 1],
+            malformedRecordCount: 2,
+            unreadableFileCount: 1
+        )
+        let store = makeClineStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            files: [URL(fileURLWithPath: "/tmp/fake/a.json")],
+            snapshot: snap,
+            now: now
+        )
+        store.fetch()
+        awaitClineFetch()
+
+        let ids = Set(store.tiles.map { $0.id })
+        expect(ids.contains("cline-diagnostics"))
+        // Regular tiles still present alongside the diagnostic.
+        expect(ids.contains("cline-cost-today"))
+    }
+
+    run("ClineUsageStore: no diagnostic tile when unreadable + malformed counts are both zero") {
+        let now = ClaudeCodeUsageFetcher.parseTimestamp("2026-07-13T04:00:00Z")!
+        let rec = ClineUsageRecord(
+            model: "claude-opus-4-7", timestamp: now,
+            sayKind: .apiReqStarted,
+            tokensIn: 100, tokensOut: 50, cacheWrites: 0, cacheReads: 0,
+            costUSD: 0.005, sourceFile: "/tmp/fake/a.json"
+        )
+        let snap = ClineUsageSnapshot(
+            records: [rec],
+            recordsPerFile: ["/tmp/fake/a.json": 1],
+            malformedRecordCount: 0,
+            unreadableFileCount: 0
+        )
+        let store = makeClineStoreForTest(
+            flagEnabled: true, tccState: .granted,
+            files: [URL(fileURLWithPath: "/tmp/fake/a.json")],
+            snapshot: snap,
+            now: now
+        )
+        store.fetch()
+        awaitClineFetch()
+
+        let ids = Set(store.tiles.map { $0.id })
+        expect(!ids.contains("cline-diagnostics"))
+    }
+
     run("ClineUsageStore: TRULY in-flight fetch A releases AFTER fetch B's denial — A must not repopulate (round-1 finding #4)") {
         // Codex round-1 finding #4: the prior test does not create a
         // genuinely in-flight race. This test uses a semaphore inside

--- a/app/AnthropicUsageFetcher.swift
+++ b/app/AnthropicUsageFetcher.swift
@@ -1,0 +1,153 @@
+// PR 2b — Anthropic usage fetcher.
+//
+// Extracted from UsageManager. Sendable value type. No observable state,
+// no delegates, no side effects. Takes raw response bytes, returns a
+// parsed AnthropicUsageSnapshot. All HTTP concerns are handled by
+// AnthropicUsageFetcher.fetch(cookie:); the caller decides how to apply
+// the snapshot on the main actor.
+//
+// This split keeps the fetcher testable without depending on UI, timers,
+// AppKit, or the delegate. The unit tests in Tests/TestRunner feed known
+// JSON bytes and lock in the exact parsed output.
+
+import Foundation
+
+/// A parsed snapshot of the claude.ai `/api/organizations/{org}/usage`
+/// response. Every field is optional in the same shape the endpoint
+/// itself returns — a Free-plan account has no `seven_day_sonnet`,
+/// a non-Fable account has no Fable entry in `limits[]`.
+public struct AnthropicUsageSnapshot: Equatable, Sendable {
+    public var sessionUsage: Int
+    public var sessionResetsAt: Date?
+
+    public var weeklyUsage: Int
+    public var weeklyResetsAt: Date?
+
+    public var hasWeeklySonnet: Bool
+    public var weeklySonnetUsage: Int
+    public var weeklySonnetResetsAt: Date?
+
+    public var hasWeeklyFable: Bool
+    public var weeklyFableUsage: Int
+    public var weeklyFableResetsAt: Date?
+
+    public init(
+        sessionUsage: Int = 0,
+        sessionResetsAt: Date? = nil,
+        weeklyUsage: Int = 0,
+        weeklyResetsAt: Date? = nil,
+        hasWeeklySonnet: Bool = false,
+        weeklySonnetUsage: Int = 0,
+        weeklySonnetResetsAt: Date? = nil,
+        hasWeeklyFable: Bool = false,
+        weeklyFableUsage: Int = 0,
+        weeklyFableResetsAt: Date? = nil
+    ) {
+        self.sessionUsage = sessionUsage
+        self.sessionResetsAt = sessionResetsAt
+        self.weeklyUsage = weeklyUsage
+        self.weeklyResetsAt = weeklyResetsAt
+        self.hasWeeklySonnet = hasWeeklySonnet
+        self.weeklySonnetUsage = weeklySonnetUsage
+        self.weeklySonnetResetsAt = weeklySonnetResetsAt
+        self.hasWeeklyFable = hasWeeklyFable
+        self.weeklyFableUsage = weeklyFableUsage
+        self.weeklyFableResetsAt = weeklyFableResetsAt
+    }
+}
+
+public enum AnthropicUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+/// Pure parser and HTTP client for claude.ai's usage endpoint. Value type
+/// with no observable state — all callers receive a snapshot and apply it
+/// themselves.
+public struct AnthropicUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: - Pure parsing (this is what the tests hit)
+
+    /// Parse the JSON body of a `/api/organizations/{org}/usage` response.
+    /// Preserves the historical behaviour of UsageManager.parseUsageData
+    /// exactly — every branch (missing five_hour, Sonnet absent, Fable in
+    /// limits[], Fable percent as Int vs Double) is a fixture in the test
+    /// suite so future refactors cannot silently regress.
+    public static func parse(_ data: Data) throws -> AnthropicUsageSnapshot {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AnthropicUsageParseError.invalidJSON
+        }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var snap = AnthropicUsageSnapshot()
+
+        if let fiveHour = json["five_hour"] as? [String: Any] {
+            if let util = fiveHour["utilization"] as? Double {
+                snap.sessionUsage = Int(util)
+            }
+            if let s = fiveHour["resets_at"] as? String {
+                snap.sessionResetsAt = iso.date(from: s)
+            }
+        }
+
+        if let sevenDay = json["seven_day"] as? [String: Any] {
+            if let util = sevenDay["utilization"] as? Double {
+                snap.weeklyUsage = Int(util)
+            }
+            if let s = sevenDay["resets_at"] as? String {
+                snap.weeklyResetsAt = iso.date(from: s)
+            }
+        }
+
+        if let sonnet = json["seven_day_sonnet"] as? [String: Any] {
+            snap.hasWeeklySonnet = true
+            if let util = sonnet["utilization"] as? Double {
+                snap.weeklySonnetUsage = Int(util)
+            }
+            if let s = sonnet["resets_at"] as? String {
+                snap.weeklySonnetResetsAt = iso.date(from: s)
+            }
+        }
+
+        // Fable lives inside limits[] where scope.model.display_name == "Fable".
+        // Not surfaced by UI until usage >= 1% — that decision is in the view
+        // layer, not here. `percent` may decode as Int or Double.
+        if let limits = json["limits"] as? [[String: Any]] {
+            if let fable = limits.first(where: { entry in
+                let scope = entry["scope"] as? [String: Any]
+                let model = scope?["model"] as? [String: Any]
+                return (model?["display_name"] as? String) == "Fable"
+            }) {
+                snap.hasWeeklyFable = true
+                if let p = fable["percent"] as? Int {
+                    snap.weeklyFableUsage = p
+                } else if let p = fable["percent"] as? Double {
+                    snap.weeklyFableUsage = Int(p)
+                }
+                if let s = fable["resets_at"] as? String {
+                    snap.weeklyFableResetsAt = iso.date(from: s)
+                }
+            }
+        }
+
+        return snap
+    }
+
+    // MARK: - Org-id discovery
+
+    /// Extract the org id from the `lastActiveOrg=...` cookie value, if
+    /// present. Returns nil when the cookie does not carry it.
+    public static func orgId(fromCookieString raw: String) -> String? {
+        for part in raw.components(separatedBy: ";") {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("lastActiveOrg=") {
+                return String(trimmed.dropFirst("lastActiveOrg=".count))
+            }
+        }
+        return nil
+    }
+}

--- a/app/AnthropicUsageStore.swift
+++ b/app/AnthropicUsageStore.swift
@@ -1,0 +1,145 @@
+// PR 2c — first UsageProvider conformer.
+//
+// AnthropicUsageStore wraps the existing UsageManager (which retains all
+// existing behaviour) and adapts it to the UsageProvider protocol. Nothing
+// in UsageManager changes; this store forwards to it.
+//
+// This deliberate two-layer arrangement — Fetcher (Sendable value type,
+// PR 2b), Store (ObservableObject, this PR), and legacy UsageManager
+// (still the driver, unchanged) — lets us introduce the protocol
+// without disturbing behaviour. A follow-up PR can eventually replace
+// UsageManager with a direct Store implementation once the protocol
+// surface has been exercised by multiple providers.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// AnthropicUsageStore is `final` (not public) because its `init` takes a
+// UsageManager, which is internal to the app module. This is intentional:
+// the store is an app-level integration, not a library-level primitive.
+// Library-level primitives live in Log.swift, AnthropicUsageFetcher.swift,
+// and UsageProvider.swift.
+// @preconcurrency defers strict actor-isolation checking against
+// UsageProvider until PR 16 migrates the protocol itself to @MainActor.
+// Under Swift 5 mode (current) this is a no-op; under Swift 6 it lets us
+// stage the migration one provider at a time.
+@MainActor
+final class AnthropicUsageStore: @preconcurrency UsageProvider {
+
+    let id: String = "anthropic"
+    let displayName: String = "Claude (Anthropic)"
+    let featureFlagKey: String = "features.anthropic.enabled"
+
+    /// The underlying manager holds all state. AnthropicUsageStore just
+    /// exposes it via the protocol. Its @Published properties drive the
+    /// view; ProviderBox forwards their notifications.
+    private let manager: UsageManager
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(manager: UsageManager) {
+        self.manager = manager
+        // Re-broadcast the manager's changes as our own so ProviderBox
+        // sees a single upstream. Combine subscription forwards them.
+        manager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Feature flag (Anthropic is on by default for existing users)
+
+    /// Anthropic is unlike every other provider — it is on by default so
+    /// existing v1.3.1 users see zero change on upgrade. Every subsequent
+    /// provider defaults false and requires an explicit Settings toggle.
+    var isEnabled: Bool {
+        // If the key has never been written, default to true (compat with
+        // pre-feature-flag builds). Writing false explicitly turns
+        // Anthropic off, which is a supported state.
+        if UserDefaults.standard.object(forKey: featureFlagKey) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: featureFlagKey)
+    }
+
+    var isConfigured: Bool {
+        manager.hasFetchedData || UserDefaults.standard.string(forKey: "claude_session_cookie") != nil
+    }
+
+    var lastUpdated: Date? {
+        manager.hasFetchedData ? manager.lastUpdated : nil
+    }
+
+    var errorMessage: String? {
+        manager.errorMessage
+    }
+
+    // MARK: - Tiles
+
+    var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+        guard manager.hasFetchedData else { return [] }
+
+        var out: [UsageTile] = []
+
+        out.append(UsageTile(
+            id: "anthropic-5h",
+            title: "Session (5 hour)",
+            kind: .bar(
+                fraction: manager.sessionPercentage,
+                resetsAt: manager.sessionResetsAt,
+                badge: nil
+            )
+        ))
+
+        out.append(UsageTile(
+            id: "anthropic-weekly",
+            title: "Weekly (7 day)",
+            kind: .bar(
+                fraction: manager.weeklyPercentage,
+                resetsAt: manager.weeklyResetsAt,
+                badge: nil
+            )
+        ))
+
+        if manager.hasWeeklySonnet {
+            out.append(UsageTile(
+                id: "anthropic-weekly-sonnet",
+                title: "Weekly Sonnet (7 day)",
+                kind: .bar(
+                    fraction: manager.weeklySonnetPercentage,
+                    resetsAt: manager.weeklySonnetResetsAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        // Fable surfaced only above 1% — same rule as the existing view.
+        if manager.hasWeeklyFable && manager.weeklyFableUsage >= 1 {
+            out.append(UsageTile(
+                id: "anthropic-weekly-fable",
+                title: "Weekly Fable (7 day)",
+                kind: .bar(
+                    fraction: manager.weeklyFablePercentage,
+                    resetsAt: manager.weeklyFableResetsAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Actions
+
+    func fetch() {
+        guard isEnabled else { return }
+        manager.fetchUsage()
+    }
+
+    func clear() {
+        manager.clearSessionCookie()
+    }
+}

--- a/app/ClaudeCodePricing.swift
+++ b/app/ClaudeCodePricing.swift
@@ -1,0 +1,396 @@
+// PR 10b-BE — Claude model pricing snapshot for local cost computation.
+//
+// Snapshot of LiteLLM's `model_prices_and_context_window.json`, filtered
+// to Anthropic-direct Claude models (no Bedrock, no Vertex — Claude Code
+// hits api.anthropic.com). Snapshot date: 13 Jul 2026.
+//
+// Source: https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+//
+// Rate structure per model
+// ------------------------
+//   input_cost_per_token          — regular input tokens, USD per token
+//   output_cost_per_token         — output tokens, USD per token
+//   cache_creation_input_token_cost           — ephemeral_5m tier
+//   cache_creation_input_token_cost_above_1hr — ephemeral_1h tier
+//                                               (may be absent — older
+//                                                models pre-dating the
+//                                                1h tier fall back to
+//                                                the 5m rate)
+//   cache_read_input_token_cost               — cache-read tokens
+//
+// Sonnet-4 family adds "_above_200k_tokens" variants: once the input
+// context in a single request exceeds 200 000 tokens, every input
+// category shifts to the tiered rate. `_above_1hr_above_200k_tokens`
+// crosses both dimensions for models that expose it. Threshold is
+// computed from `inputTokens + cache*Tokens` on the SAME record — this
+// matches Anthropic's per-request billing model, not a session-cumulative
+// sum.
+//
+// Refresh discipline
+// ------------------
+// Bundled as a Swift literal so the app has no runtime GitHub-raw fetch
+// dependency. A monthly background refresh from the upstream LiteLLM
+// table is possible (out of scope for PR 10b-BE; the store surfaces
+// `unknownModelRecordCount` on the snapshot so a future PR can prompt
+// for an update). Users on a build older than a Claude release get
+// TOKEN counts but $0 cost for the new model — never a wrong number.
+
+import Foundation
+
+/// Pricing snapshot with per-model rate rows. `default` bundles the
+/// embedded LiteLLM extract; tests inject `ClaudeCodePricing(rates:)`
+/// with synthetic values.
+public struct ClaudeCodePricing: Sendable {
+
+    /// Per-model rate dictionary. Keys are LiteLLM field names verbatim
+    /// so the mapping to the source is auditable.
+    public let rates: [String: [String: Double]]
+
+    public init(rates: [String: [String: Double]]) {
+        self.rates = rates
+    }
+
+    /// Compute USD cost for one record. Returns `(cost, isUnknownModel)`
+    /// — the second bool signals "no pricing row for this model" so the
+    /// caller can count unknown-model records for the pricing-refresh
+    /// prompt.
+    ///
+    /// Threshold logic: if `inputTokens + cache*Tokens > 200_000` we
+    /// switch to the tiered rate for models that have it. Sonnet-4-5
+    /// and Sonnet-4-family expose the tier; every other model returns
+    /// the base rate regardless (there is no tier to apply).
+    public func cost(
+        model: String,
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheCreation5mTokens: Int,
+        cacheCreation1hTokens: Int,
+        cacheReadTokens: Int
+    ) -> (costUSD: Double, isUnknownModel: Bool) {
+        guard let row = rates[model] else {
+            return (0.0, true)
+        }
+
+        // Codex round-2 finding #2: use saturating addition for the
+        // threshold check. `Int64 &+` wraps to negative, so a hostile
+        // clamped-to-Int.max input could make aboveTier false and
+        // silently under-price a legitimate long-context Sonnet request.
+        // Short-circuit as soon as we know we're above the threshold.
+        let threshold = 200_000
+        var runningInput = min(threshold + 1, max(0, inputTokens))
+        if runningInput <= threshold {
+            runningInput = ClaudeCodeUsageRecord
+                .saturatingAdd(runningInput, cacheCreation5mTokens)
+        }
+        if runningInput <= threshold {
+            runningInput = ClaudeCodeUsageRecord
+                .saturatingAdd(runningInput, cacheCreation1hTokens)
+        }
+        if runningInput <= threshold {
+            runningInput = ClaudeCodeUsageRecord
+                .saturatingAdd(runningInput, cacheReadTokens)
+        }
+        let aboveTier = runningInput > threshold
+
+        // Rate helpers — pick the tiered rate when available and the
+        // request crosses the threshold; otherwise the base rate. Never
+        // fall through to a wrong rate — a missing base rate means the
+        // model row is malformed and we treat that category as $0.
+        func rate(base: String, tier: String) -> Double {
+            if aboveTier, let tiered = row[tier] { return tiered }
+            return row[base] ?? 0.0
+        }
+        // Cache-creation-1hr uses the base rate when the tier-1hr field
+        // is missing (older models pre-dating the 1h tier). Codex
+        // round-2 finding #3: when the request crosses BOTH dimensions
+        // and the exact double-cross rate is missing, use MAX of the
+        // two single-dimension rates rather than one arbitrarily — the
+        // 1h premium and the >200k premium are independent, so
+        // charging only one dimension undercharges the customer
+        // consistently. `max()` preserves the correct sign of the
+        // pricing correction (never undercharges) even if the LiteLLM
+        // table is missing a row.
+        func cacheCreation1hRate() -> Double {
+            let base = row["cache_creation_input_token_cost"] ?? 0.0
+            let above1hr = row["cache_creation_input_token_cost_above_1hr"]
+            let above200k = row["cache_creation_input_token_cost_above_200k_tokens"]
+            let doubleCross = row["cache_creation_input_token_cost_above_1hr_above_200k_tokens"]
+
+            if aboveTier {
+                if let r = doubleCross { return r }
+                // At least one of these should apply — pick the higher
+                // (worst-case) rate if both are present.
+                switch (above1hr, above200k) {
+                case let (a?, b?): return max(a, b)
+                case let (a?, nil): return a
+                case let (nil, b?): return b
+                case (nil, nil):    return base
+                }
+            }
+            return above1hr ?? base
+        }
+
+        let inputRate = rate(
+            base: "input_cost_per_token",
+            tier: "input_cost_per_token_above_200k_tokens"
+        )
+        let outputRate = rate(
+            base: "output_cost_per_token",
+            tier: "output_cost_per_token_above_200k_tokens"
+        )
+        let cacheCreation5mRate = rate(
+            base: "cache_creation_input_token_cost",
+            tier: "cache_creation_input_token_cost_above_200k_tokens"
+        )
+        let cacheReadRate = rate(
+            base: "cache_read_input_token_cost",
+            tier: "cache_read_input_token_cost_above_200k_tokens"
+        )
+
+        let total = Double(inputTokens) * inputRate
+            + Double(outputTokens) * outputRate
+            + Double(cacheCreation5mTokens) * cacheCreation5mRate
+            + Double(cacheCreation1hTokens) * cacheCreation1hRate()
+            + Double(cacheReadTokens) * cacheReadRate
+
+        return (total, false)
+    }
+
+    /// True when the pricing table contains a row for `model`.
+    public func hasModel(_ model: String) -> Bool {
+        rates[model] != nil
+    }
+
+    /// The default snapshot, bundled into the binary. Access this
+    /// through `.default` rather than referencing `embeddedRates`
+    /// directly — future refresh paths will overlay a downloaded file
+    /// on top of the embedded default.
+    public static let `default` = ClaudeCodePricing(rates: embeddedRates)
+
+    // MARK: - Snapshot content
+    //
+    // Do NOT edit these numbers by hand. Regenerate from the LiteLLM
+    // source by running the script in scripts/regenerate-pricing.py
+    // (added under PR 10b-BE). Snapshot date lives in the header
+    // comment above so a future contributor can measure staleness.
+    public static let snapshotDate: String = "2026-07-13"
+
+    // NOTE for reviewers: the field names below are LiteLLM's, not
+    // Anthropic's. LiteLLM's `cache_creation_input_token_cost_above_1hr`
+    // is what Anthropic documents as the 1h ephemeral-cache creation
+    // rate (a distinct rate, NOT a 2× multiplier — an earlier draft of
+    // the EXPANSION_PLAN suggested a 2× multiplier and this snapshot
+    // supersedes that plan text).
+    /// Backing snapshot dictionary. Public so tests can iterate every
+    /// row for invariant checks (1h rate >= 5m rate, tiered rate >= base,
+    /// etc.). Not intended for runtime use — read `.default.rates`.
+    public static let embeddedRates: [String: [String: Double]] = [
+        // Codex round-4 finding #1: LiteLLM does NOT have Anthropic-direct
+        // rows for Claude 3.5 Sonnet or 3.5 Haiku (they only exist under
+        // bedrock.* keys), but Claude Code emits the bare
+        // "claude-3-5-sonnet-20241022" / "claude-3-5-haiku-20241022"
+        // model ids for direct-API sessions. Historical sessions would
+        // otherwise price at $0. Rates below are the Anthropic-direct
+        // published rates as of the snapshot date (mirroring the bedrock
+        // us-east-1 pricing that LiteLLM does have).
+        "claude-3-5-sonnet-20241022": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+        ],
+        "claude-3-5-sonnet-20240620": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+        ],
+        "claude-3-5-haiku-20241022": [
+            "cache_creation_input_token_cost": 1e-06,
+            "cache_read_input_token_cost": 8e-08,
+            "input_cost_per_token": 8e-07,
+            "output_cost_per_token": 4e-06,
+        ],
+        "claude-3-7-sonnet-20250219": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_creation_input_token_cost_above_1hr": 6e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+        ],
+        "claude-3-haiku-20240307": [
+            "cache_creation_input_token_cost": 3e-07,
+            // Codex round-2 finding #4: LiteLLM's
+            // `cache_creation_input_token_cost_above_1hr = 6e-06` for
+            // Claude 3 Haiku is inconsistent — it's higher than the 5m
+            // rate but far above the Anthropic-documented "2× input"
+            // pattern (2× 2.5e-07 = 5e-07). The LiteLLM row appears to
+            // have been mis-copied from a Sonnet row. We omit the
+            // wrong `_above_1hr` field so cache-creation-1h falls back
+            // to the base 5m rate (defensive: never OVER-charge based
+            // on a wrong upstream value; a small under-charge on this
+            // legacy model is preferable to a 20× over-charge).
+            "cache_read_input_token_cost": 3e-08,
+            "input_cost_per_token": 2.5e-07,
+            "output_cost_per_token": 1.25e-06,
+        ],
+        "claude-3-opus-20240229": [
+            "cache_creation_input_token_cost": 1.875e-05,
+            // Same LiteLLM data bug as Haiku 3: the copied
+            // `_above_1hr = 6e-06` is LOWER than the base 5m rate
+            // (1.875e-05). Removed so fallback uses the 5m rate.
+            "cache_read_input_token_cost": 1.5e-06,
+            "input_cost_per_token": 1.5e-05,
+            "output_cost_per_token": 7.5e-05,
+        ],
+        "claude-4-opus-20250514": [
+            "cache_creation_input_token_cost": 1.875e-05,
+            "cache_read_input_token_cost": 1.5e-06,
+            "input_cost_per_token": 1.5e-05,
+            "output_cost_per_token": 7.5e-05,
+        ],
+        "claude-4-sonnet-20250514": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+            "input_cost_per_token": 3e-06,
+            "input_cost_per_token_above_200k_tokens": 6e-06,
+            "output_cost_per_token": 1.5e-05,
+            "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        ],
+        "claude-haiku-4-5": [
+            "cache_creation_input_token_cost": 1.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 2e-06,
+            "cache_read_input_token_cost": 1e-07,
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+        ],
+        "claude-haiku-4-5-20251001": [
+            "cache_creation_input_token_cost": 1.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 2e-06,
+            "cache_read_input_token_cost": 1e-07,
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+        ],
+        "claude-opus-4-1": [
+            "cache_creation_input_token_cost": 1.875e-05,
+            "cache_creation_input_token_cost_above_1hr": 3e-05,
+            "cache_read_input_token_cost": 1.5e-06,
+            "input_cost_per_token": 1.5e-05,
+            "output_cost_per_token": 7.5e-05,
+        ],
+        "claude-opus-4-1-20250805": [
+            "cache_creation_input_token_cost": 1.875e-05,
+            "cache_creation_input_token_cost_above_1hr": 3e-05,
+            "cache_read_input_token_cost": 1.5e-06,
+            "input_cost_per_token": 1.5e-05,
+            "output_cost_per_token": 7.5e-05,
+        ],
+        "claude-opus-4-20250514": [
+            "cache_creation_input_token_cost": 1.875e-05,
+            "cache_creation_input_token_cost_above_1hr": 3e-05,
+            "cache_read_input_token_cost": 1.5e-06,
+            "input_cost_per_token": 1.5e-05,
+            "output_cost_per_token": 7.5e-05,
+        ],
+        "claude-opus-4-5": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-opus-4-5-20251101": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-opus-4-6": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-opus-4-6-20260205": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-opus-4-7": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-opus-4-7-20260416": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-opus-4-8": [
+            "cache_creation_input_token_cost": 6.25e-06,
+            "cache_creation_input_token_cost_above_1hr": 1e-05,
+            "cache_read_input_token_cost": 5e-07,
+            "input_cost_per_token": 5e-06,
+            "output_cost_per_token": 2.5e-05,
+        ],
+        "claude-sonnet-4-20250514": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_creation_input_token_cost_above_1hr": 6e-06,
+            "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+            "input_cost_per_token": 3e-06,
+            "input_cost_per_token_above_200k_tokens": 6e-06,
+            "output_cost_per_token": 1.5e-05,
+            "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        ],
+        "claude-sonnet-4-5": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_creation_input_token_cost_above_1hr": 6e-06,
+            "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
+            "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+            "input_cost_per_token": 3e-06,
+            "input_cost_per_token_above_200k_tokens": 6e-06,
+            "output_cost_per_token": 1.5e-05,
+            "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        ],
+        "claude-sonnet-4-5-20250929": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_creation_input_token_cost_above_1hr": 6e-06,
+            "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
+            "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+            "input_cost_per_token": 3e-06,
+            "input_cost_per_token_above_200k_tokens": 6e-06,
+            "output_cost_per_token": 1.5e-05,
+            "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        ],
+        "claude-sonnet-4-6": [
+            "cache_creation_input_token_cost": 3.75e-06,
+            "cache_creation_input_token_cost_above_1hr": 6e-06,
+            "cache_read_input_token_cost": 3e-07,
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+        ],
+        "claude-sonnet-5": [
+            "cache_creation_input_token_cost": 2.5e-06,
+            "cache_creation_input_token_cost_above_1hr": 4e-06,
+            "cache_read_input_token_cost": 2e-07,
+            "input_cost_per_token": 2e-06,
+            "output_cost_per_token": 1e-05,
+        ],
+    ]
+}

--- a/app/ClaudeCodeUsageFetcher.swift
+++ b/app/ClaudeCodeUsageFetcher.swift
@@ -1,0 +1,786 @@
+// PR 10b-BE — Claude Code local JSONL fetcher (feature-flag off).
+//
+// First provider in the "local-file readers" family (Milestone 6). Reads
+// Claude Code's own on-disk session logs and produces a token-and-cost
+// rollup. Nothing leaves the machine.
+//
+// Data source
+// -----------
+// Claude Code writes one JSONL file per session under
+// `~/.claude/projects/{cwd-slug}/{sessionId}.jsonl`. Each line is a
+// standalone JSON record. Records of `type == "assistant"` carry the
+// `message.usage` block we care about; user/tool/system records are
+// ignored.
+//
+// Path resolution (in order — first hit wins):
+//
+//   1. `$CLAUDE_CONFIG_DIR` (Claude Code's official override).
+//      When set, treat as the config root and look under `projects/`.
+//   2. `$XDG_CONFIG_HOME` (freedesktop convention that some
+//      cross-platform tooling honours). Root is `$XDG_CONFIG_HOME/claude`,
+//      then `projects/`.
+//   3. `~/.claude` (default).
+//
+// The value of `1` and `2` MUST resolve to a directory that either exists
+// or is missing-but-creatable — no shell expansion, no `~` expansion. The
+// env-var contract is documented at
+// https://docs.claude.com/en/docs/claude-code/settings.
+//
+// Dedupe (mandatory)
+// ------------------
+// Long sessions produce duplicate `(message.id, requestId)` records — the
+// same assistant response can be replayed when the CLI is resumed, and
+// `isSidechain: true` records represent parallel worker replays whose
+// usage was already accounted for on the main branch. Not deduping
+// approximately DOUBLES the reported spend on any session that runs for
+// more than a few turns (see ccusage issue #888 for the reference
+// discussion).
+//
+// Rules:
+//   - Primary key: `(message.id, requestId)`. Both non-nil.
+//   - Secondary key: `(message.id, nil)` for records where `requestId`
+//     was omitted (older CLI versions or `isSidechain: true` replays).
+//   - When a record matches EITHER key already seen, drop it.
+//   - `message.id` alone (no request id) is still a valid dedupe seed —
+//     an id that surfaces once with a request id and again without still
+//     dedupes on the second key.
+//
+// Cost computation
+// ----------------
+// Prices are loaded from `ClaudeCodePricing.embeddedJSON`, a snapshot of
+// LiteLLM's `model_prices_and_context_window.json` filtered to Anthropic-
+// direct Claude models. See that file for the snapshot date. Fields:
+//
+//   input_cost_per_token          — regular input tokens
+//   output_cost_per_token         — output tokens
+//   cache_creation_input_token_cost           — ephemeral_5m cache-creation
+//   cache_creation_input_token_cost_above_1hr — ephemeral_1h cache-creation
+//   cache_read_input_token_cost               — cache-read tokens
+//
+// Some Sonnet-4 family models also expose `_above_200k_tokens` variants
+// used once cumulative context on a request exceeds 200 000 tokens. We
+// apply the tiered rate only when the record itself exceeds the
+// threshold — Anthropic bills per-request against the request's own
+// context length, not against a session-cumulative sum.
+//
+// Unknown model — a `message.model` value not in the pricing table —
+// produces a zero-cost line rather than throwing. This lets a brand-new
+// Claude release still get counted for TOKENS while cost silently trails
+// until the next pricing refresh.
+//
+// Feature posture
+// ---------------
+// `features.claudeCode.enabled` defaults false. Nothing registers a
+// `ClaudeCodeUsageStore` into the live registry yet (that lands in PR
+// 10b-UI). This file compiles and unit-tests but is inert at runtime
+// until enabled.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// One dedupe-and-cost roll-up entry for a single (message.id, requestId)
+/// pair. Held per-record so the store can bucket by day, model, or file
+/// without having to re-parse.
+public struct ClaudeCodeUsageRecord: Equatable, Sendable {
+    /// Model identifier as reported by Claude Code (e.g. "claude-opus-4-7").
+    public var model: String
+    /// Wall-clock timestamp of the record. Nil if the JSONL line omitted
+    /// or malformed `timestamp`. Used to bucket by day/MTD.
+    public var timestamp: Date?
+    /// Anthropic message id (`message.id` — e.g. "msg_018riz53..."). Nil
+    /// if the JSONL line omitted it (rare in practice). Retained so
+    /// cross-file dedupe uses the true billing key rather than a
+    /// content-based heuristic. Codex round-5 finding.
+    public var messageId: String?
+    /// Claude Code request id (top-level `requestId` — e.g. "req_011..."). Nil
+    /// for older CLI versions or sidechain replays. Same rationale as
+    /// `messageId`.
+    public var requestId: String?
+    /// Regular input tokens (excluding cache).
+    public var inputTokens: Int
+    /// Cache-creation tokens for the ephemeral_5m tier. Priced at
+    /// `cache_creation_input_token_cost`.
+    public var cacheCreation5mTokens: Int
+    /// Cache-creation tokens for the ephemeral_1h tier. Priced at
+    /// `cache_creation_input_token_cost_above_1hr`.
+    public var cacheCreation1hTokens: Int
+    /// Cache-read tokens.
+    public var cacheReadTokens: Int
+    /// Output tokens.
+    public var outputTokens: Int
+    /// Web-search server tool invocations. Not billed as tokens; captured
+    /// so a future PR can surface them separately.
+    public var webSearchRequests: Int
+    /// Web-fetch server tool invocations. Same rationale as above.
+    public var webFetchRequests: Int
+    /// True when the record was flagged `isSidechain: true`. Kept for
+    /// diagnostic tiles but excluded from token/cost totals when
+    /// deduping.
+    public var isSidechain: Bool
+    /// Cost in USD computed by `ClaudeCodePricing.cost(for:record:)`.
+    /// Zero when the model is not in the pricing table.
+    public var costUSD: Double
+
+    public init(
+        model: String,
+        timestamp: Date?,
+        messageId: String? = nil,
+        requestId: String? = nil,
+        inputTokens: Int,
+        cacheCreation5mTokens: Int,
+        cacheCreation1hTokens: Int,
+        cacheReadTokens: Int,
+        outputTokens: Int,
+        webSearchRequests: Int,
+        webFetchRequests: Int,
+        isSidechain: Bool,
+        costUSD: Double
+    ) {
+        self.model = model
+        self.timestamp = timestamp
+        self.messageId = messageId
+        self.requestId = requestId
+        self.inputTokens = inputTokens
+        self.cacheCreation5mTokens = cacheCreation5mTokens
+        self.cacheCreation1hTokens = cacheCreation1hTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.outputTokens = outputTokens
+        self.webSearchRequests = webSearchRequests
+        self.webFetchRequests = webFetchRequests
+        self.isSidechain = isSidechain
+        self.costUSD = costUSD
+    }
+
+    /// Sum of every token category. Used for the "tokens today" tile.
+    /// Codex round-1 finding #4: `&+=` wraps silently on overflow — a
+    /// pathological Int.max + Int.max = -2 could escape as a negative
+    /// token count. `saturatingAdd` (below) clamps to Int.max instead.
+    public var totalTokens: Int {
+        var s: Int = 0
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, inputTokens)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, cacheCreation5mTokens)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, cacheCreation1hTokens)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, cacheReadTokens)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, outputTokens)
+        return s
+    }
+
+    /// Non-wrapping non-negative addition. Returns `Int.max` on overflow
+    /// rather than the wrapped negative value. Both inputs are expected
+    /// to be non-negative (parse() clamps every field to `[0, Int.max]`).
+    /// A negative input is defensively coerced to 0. Public so tests
+    /// exercise the clamp against Int.max + Int.max directly.
+    public static func saturatingAdd(_ a: Int, _ b: Int) -> Int {
+        let a_ = max(0, a)
+        let b_ = max(0, b)
+        let (sum, overflow) = a_.addingReportingOverflow(b_)
+        return overflow ? Int.max : sum
+    }
+}
+
+/// Aggregate roll-up produced by `ClaudeCodeUsageFetcher.parse` from a
+/// full JSONL corpus. Buckets by day, model, and per-file so the store
+/// can render several tiles without re-walking the records.
+public struct ClaudeCodeUsageSnapshot: Equatable, Sendable {
+    /// All records seen after dedupe, sorted by timestamp ascending.
+    public var records: [ClaudeCodeUsageRecord]
+    /// Path-relative file counts (absolute paths → record count). Nil in
+    /// tests that build a snapshot from records directly.
+    public var recordsPerFile: [String: Int]
+    /// Number of duplicate records dropped during parse. Surfaced for
+    /// diagnostics; a healthy corpus has a small but non-zero count.
+    public var dedupedRecordCount: Int
+    /// Number of records that could not be JSON-parsed. Non-zero here is
+    /// benign — a partial write mid-tick is normal — but a hot climb
+    /// suggests a schema break.
+    public var malformedRecordCount: Int
+    /// Number of records whose `message.model` was not in the pricing
+    /// table. Tokens for these are counted; cost is zero. A non-zero
+    /// value is the trigger to refresh the pricing snapshot.
+    public var unknownModelRecordCount: Int
+
+    public init(
+        records: [ClaudeCodeUsageRecord],
+        recordsPerFile: [String: Int] = [:],
+        dedupedRecordCount: Int = 0,
+        malformedRecordCount: Int = 0,
+        unknownModelRecordCount: Int = 0
+    ) {
+        self.records = records
+        self.recordsPerFile = recordsPerFile
+        self.dedupedRecordCount = dedupedRecordCount
+        self.malformedRecordCount = malformedRecordCount
+        self.unknownModelRecordCount = unknownModelRecordCount
+    }
+
+    /// Sum of tokens over records whose `timestamp` falls within `range`.
+    /// Sidechain records are excluded — they were already accounted for
+    /// on the main branch. Uses saturating addition (Codex round-1
+    /// finding #3): `&+=` on Int64 wraps to a negative value at
+    /// `Int64.max + 1` and `Int(clamping:)` on a wrapped negative value
+    /// clamps to `0`, not `Int.max` — the tile would show `0 tokens`
+    /// after billions of legitimate tokens.
+    public func tokens(in range: ClosedRange<Date>) -> Int {
+        var s: Int = 0
+        for r in records where !r.isSidechain {
+            guard let ts = r.timestamp, range.contains(ts) else { continue }
+            s = ClaudeCodeUsageRecord.saturatingAdd(s, r.totalTokens)
+        }
+        return s
+    }
+
+    /// Sum of cost over records whose `timestamp` falls within `range`.
+    public func cost(in range: ClosedRange<Date>) -> Double {
+        var s = 0.0
+        for r in records where !r.isSidechain {
+            guard let ts = r.timestamp, range.contains(ts) else { continue }
+            s += r.costUSD
+        }
+        return s
+    }
+
+    /// Per-model breakdown for the `.cost` MTD range. Returns entries
+    /// sorted by descending cost so the tile can show top-N.
+    public struct ModelBreakdown: Equatable, Sendable {
+        public var model: String
+        public var costUSD: Double
+        public var tokens: Int
+        public init(model: String, costUSD: Double, tokens: Int) {
+            self.model = model
+            self.costUSD = costUSD
+            self.tokens = tokens
+        }
+    }
+    public func breakdownByModel(in range: ClosedRange<Date>) -> [ModelBreakdown] {
+        var byModel: [String: (cost: Double, tokens: Int)] = [:]
+        for r in records where !r.isSidechain {
+            guard let ts = r.timestamp, range.contains(ts) else { continue }
+            var entry = byModel[r.model] ?? (0.0, 0)
+            entry.cost += r.costUSD
+            entry.tokens = ClaudeCodeUsageRecord.saturatingAdd(entry.tokens, r.totalTokens)
+            byModel[r.model] = entry
+        }
+        return byModel
+            .map { ModelBreakdown(model: $0.key, costUSD: $0.value.cost, tokens: $0.value.tokens) }
+            .sorted { $0.costUSD > $1.costUSD }
+    }
+}
+
+// MARK: - Path resolution
+
+/// Resolves the JSONL scan root against Claude Code's documented env-var
+/// precedence. Static and pure — takes a Process-info snapshot so tests
+/// can inject synthetic env-vars without mutating the running process.
+public enum ClaudeCodePathResolver {
+
+    /// Environment snapshot passed to `resolveScanRoot`. `homeDirectoryPath`
+    /// is Foundation's `NSHomeDirectory()` in production; tests pass a
+    /// temp directory.
+    public struct Environment: Sendable {
+        public var claudeConfigDir: String?
+        public var xdgConfigHome: String?
+        public var homeDirectoryPath: String
+        public init(claudeConfigDir: String?, xdgConfigHome: String?, homeDirectoryPath: String) {
+            self.claudeConfigDir = claudeConfigDir
+            self.xdgConfigHome = xdgConfigHome
+            self.homeDirectoryPath = homeDirectoryPath
+        }
+
+        /// Snapshot the current process env-vars and home dir. Not called
+        /// from tests — they build an `Environment` explicitly.
+        public static func current() -> Environment {
+            let env = ProcessInfo.processInfo.environment
+            return Environment(
+                claudeConfigDir: env["CLAUDE_CONFIG_DIR"].flatMap { $0.isEmpty ? nil : $0 },
+                xdgConfigHome: env["XDG_CONFIG_HOME"].flatMap { $0.isEmpty ? nil : $0 },
+                homeDirectoryPath: NSHomeDirectory()
+            )
+        }
+    }
+
+    /// Resolve the absolute directory that contains the per-project
+    /// `*/*.jsonl` trees. Never returns an empty string; returns nil only
+    /// if every candidate produced an empty path (all env-vars unset AND
+    /// `homeDirectoryPath` was empty, which does not happen on macOS).
+    public static func resolveScanRoot(_ env: Environment) -> String? {
+        // 1. $CLAUDE_CONFIG_DIR/projects
+        if let dir = env.claudeConfigDir, !dir.isEmpty {
+            return joinProjects(dir)
+        }
+        // 2. $XDG_CONFIG_HOME/claude/projects
+        if let dir = env.xdgConfigHome, !dir.isEmpty {
+            let claudeRoot = (dir as NSString).appendingPathComponent("claude")
+            return joinProjects(claudeRoot)
+        }
+        // 3. $HOME/.claude/projects
+        guard !env.homeDirectoryPath.isEmpty else { return nil }
+        let claudeRoot = (env.homeDirectoryPath as NSString).appendingPathComponent(".claude")
+        return joinProjects(claudeRoot)
+    }
+
+    private static func joinProjects(_ base: String) -> String {
+        (base as NSString).appendingPathComponent("projects")
+    }
+}
+
+// MARK: - JSONL parsing
+
+/// Sendable value-type fetcher. All parsing is pure — I/O (directory
+/// enumeration, file reads) is optional and can be supplied by the store
+/// or by tests via `parse(jsonl:)` on synthetic strings.
+public struct ClaudeCodeUsageFetcher: Sendable {
+
+    /// Parse a single `.jsonl` file's contents. `contents` is the raw
+    /// text of the file. Returns the records that survived dedupe and
+    /// the count of duplicates dropped. Malformed lines are skipped and
+    /// counted (a partial write near end-of-file is normal — Claude
+    /// Code flushes line-by-line but the last line can be truncated).
+    ///
+    /// Records with `isSidechain: true` are RETAINED in the output but
+    /// flagged; snapshot roll-ups exclude them from token/cost sums but
+    /// keep them for diagnostics.
+    ///
+    /// This function is dedupe-aware WITHIN a single file. Cross-file
+    /// dedupe (a message.id that appears in two files) happens in
+    /// `parse(files:)` below. Both use the same primary/secondary key
+    /// rules.
+    public static func parse(
+        jsonl contents: String,
+        pricing: ClaudeCodePricing = .default,
+        seenPrimary: inout Set<PrimaryKey>,
+        seenSecondary: inout Set<SecondaryKey>,
+        malformedRecordCount: inout Int,
+        dedupedRecordCount: inout Int,
+        unknownModelRecordCount: inout Int
+    ) -> [ClaudeCodeUsageRecord] {
+        var out: [ClaudeCodeUsageRecord] = []
+        // `components(separatedBy:)` returns `[String]` so `.trimmingCharacters`
+        // (a String method) resolves. `split(separator:)` on String returns
+        // ArraySlice<Character> in ambiguous overload contexts; components()
+        // is unambiguous. Empty lines are filtered explicitly below.
+        contents.components(separatedBy: "\n").forEach { rawLine in
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return }
+
+            guard let data = trimmed.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data),
+                  let dict = obj as? [String: Any] else {
+                malformedRecordCount += 1
+                return
+            }
+
+            // Only `type == "assistant"` records carry usage. Skip
+            // everything else silently (they include user prompts, tool
+            // results, system pings — a lot of records per session).
+            guard let type = dict["type"] as? String, type == "assistant" else { return }
+            guard let message = dict["message"] as? [String: Any] else { return }
+            guard let usage = message["usage"] as? [String: Any] else { return }
+
+            let messageId = message["id"] as? String
+            let requestId = dict["requestId"] as? String
+            let isSidechain = (dict["isSidechain"] as? Bool) ?? false
+
+            // Dedupe rules per module header.
+            //
+            // Codex round-1 finding #1: check secondary FIRST so
+            // (msg_1, req_a) then (msg_1, req_b) — the ccusage #888
+            // resume case — dedupes to one record.
+            //
+            // Codex round-2 finding #1: sidechain records MUST NOT
+            // seed the secondary set. Otherwise a sidechain replay
+            // arriving before the canonical main record wins the
+            // "first seen" position, and the main record is dropped —
+            // rollups then filter the sidechain out, so tokens/cost
+            // both collapse to zero. Sidechain records are still
+            // retained in the output for diagnostics; they simply do
+            // not participate in dedupe seeding.
+            if let mid = messageId, !isSidechain {
+                let secondary = SecondaryKey(messageId: mid)
+                if seenSecondary.contains(secondary) {
+                    dedupedRecordCount += 1
+                    return
+                }
+                if let rid = requestId {
+                    let primary = PrimaryKey(messageId: mid, requestId: rid)
+                    if seenPrimary.contains(primary) {
+                        dedupedRecordCount += 1
+                        return
+                    }
+                    seenPrimary.insert(primary)
+                }
+                seenSecondary.insert(secondary)
+            } else if let mid = messageId, isSidechain {
+                // A sidechain record whose main record has already been
+                // seen is a true replay — drop it. (Retention only
+                // applies to sidechain records that arrive BEFORE the
+                // canonical main, which is exotic but possible.)
+                let secondary = SecondaryKey(messageId: mid)
+                if seenSecondary.contains(secondary) {
+                    dedupedRecordCount += 1
+                    return
+                }
+            }
+            // Records missing `message.id` entirely can't be deduped; we
+            // count them as-is (rare in practice — Claude Code has always
+            // written the id).
+
+            let model = (message["model"] as? String) ?? "unknown"
+            let timestamp = (dict["timestamp"] as? String).flatMap(parseTimestamp(_:))
+
+            let inputTokens = safeInt(usage["input_tokens"])
+            let outputTokens = safeInt(usage["output_tokens"])
+            let cacheReadTokens = safeInt(usage["cache_read_input_tokens"])
+            // `cache_creation_input_tokens` is the flat total across
+            // 5m and 1h tiers; the `cache_creation` sub-object breaks
+            // it out. When the sub-object is present we trust it and
+            // ignore the flat total (they must match — but if they
+            // don't, the sub-object is authoritative). When absent,
+            // treat the flat total as if it were entirely 5m — the
+            // safer default (5m rate < 1h rate → won't over-charge).
+            let cacheFlat = safeInt(usage["cache_creation_input_tokens"])
+            let cc = usage["cache_creation"] as? [String: Any]
+            let cache1h = cc.map { safeInt($0["ephemeral_1h_input_tokens"]) } ?? 0
+            let cache5m = cc.map { safeInt($0["ephemeral_5m_input_tokens"]) } ?? cacheFlat
+
+            let stu = usage["server_tool_use"] as? [String: Any]
+            let webSearch = stu.map { safeInt($0["web_search_requests"]) } ?? 0
+            let webFetch = stu.map { safeInt($0["web_fetch_requests"]) } ?? 0
+
+            let (costUSD, isUnknownModel) = pricing.cost(
+                model: model,
+                inputTokens: inputTokens,
+                outputTokens: outputTokens,
+                cacheCreation5mTokens: cache5m,
+                cacheCreation1hTokens: cache1h,
+                cacheReadTokens: cacheReadTokens
+            )
+            if isUnknownModel {
+                unknownModelRecordCount += 1
+            }
+
+            out.append(ClaudeCodeUsageRecord(
+                model: model,
+                timestamp: timestamp,
+                messageId: messageId,
+                requestId: requestId,
+                inputTokens: inputTokens,
+                cacheCreation5mTokens: cache5m,
+                cacheCreation1hTokens: cache1h,
+                cacheReadTokens: cacheReadTokens,
+                outputTokens: outputTokens,
+                webSearchRequests: webSearch,
+                webFetchRequests: webFetch,
+                isSidechain: isSidechain,
+                costUSD: costUSD
+            ))
+        }
+        return out
+    }
+
+    /// Parse a set of JSONL file URLs into a full snapshot.
+    ///
+    /// Codex round-3 finding #2: cross-file dedupe is TIMESTAMP-ordered,
+    /// not input-order. Otherwise, if the same `message.id` appears in
+    /// file A (July, lexically earlier) and file B (June, lexically
+    /// later), the July replay wins dedupe and the June original is
+    /// dropped — MTD bucketing then bills June's tokens to July. The
+    /// two-pass structure below parses candidate records without
+    /// dedupe, sorts them so earlier timestamps and non-sidechain
+    /// records win, then applies dedupe.
+    ///
+    /// I/O errors on individual files are tolerated: a file that
+    /// disappeared mid-scan or is unreadable is silently skipped. The
+    /// snapshot's `recordsPerFile` shows which files contributed.
+    public static func parse(
+        files: [URL],
+        pricing: ClaudeCodePricing = .default
+    ) -> ClaudeCodeUsageSnapshot {
+        // Pass 1: parse candidate records from every file with dedupe
+        // sets held per-file (so a duplicate WITHIN one file is caught
+        // immediately, but cross-file duplicates are caught in pass 2).
+        // Codex round-6 finding #1 (accepted as documented behaviour):
+        // within-file dedupe keeps first-seen, not first-by-timestamp.
+        // In real logs Claude Code appends chronologically so the two
+        // coincide; the finding's out-of-order case only affects the
+        // bucketing of the RETAINED record by at most one calendar
+        // day — an acceptable tail behaviour vs the complexity of
+        // running dedupe over a merged, sorted stream.
+        var candidateRecords: [ClaudeCodeUsageRecord] = []
+        var perFile: [String: Int] = [:]
+        var malformed = 0
+        var withinFileDeduped = 0
+        var unknownModel = 0
+
+        for url in files {
+            guard let lines = readJsonlLines(from: url) else { continue }
+            let text = lines.joined(separator: "\n")
+            var seenPrimary: Set<PrimaryKey> = []
+            var seenSecondary: Set<SecondaryKey> = []
+            let recs = parse(
+                jsonl: text,
+                pricing: pricing,
+                seenPrimary: &seenPrimary,
+                seenSecondary: &seenSecondary,
+                malformedRecordCount: &malformed,
+                dedupedRecordCount: &withinFileDeduped,
+                unknownModelRecordCount: &unknownModel
+            )
+            perFile[url.path] = recs.count
+            candidateRecords.append(contentsOf: recs)
+        }
+
+        // Sort:
+        //   1. Records WITHOUT a timestamp sink to the end (they cannot
+        //      participate in day/MTD bucketing anyway; keeping them
+        //      last means dedupe prefers dated records).
+        //   2. Non-sidechain records before sidechain (so the canonical
+        //      main record wins on any (msg_id) tie).
+        //   3. Timestamp ascending (so the FIRST-in-time record wins
+        //      dedupe, which is the correct one to bill).
+        candidateRecords.sort { lhs, rhs in
+            switch (lhs.timestamp, rhs.timestamp) {
+            case (nil, _?): return false
+            case (_?, nil): return true
+            case (nil, nil): return false
+            case let (l?, r?):
+                if l != r { return l < r }
+                // Same timestamp — non-sidechain first.
+                if lhs.isSidechain != rhs.isSidechain {
+                    return !lhs.isSidechain
+                }
+                return false
+            }
+        }
+
+        // Pass 2: cross-file dedupe over the sorted candidates using
+        // the SAME primary/secondary key rules as within-file dedupe.
+        // Codex round-5 finding: because the record now carries the
+        // raw messageId + requestId, we can re-apply the true billing
+        // key across files rather than the content-based heuristic
+        // that the round-3 iteration used. Sort order (earlier
+        // timestamp, non-sidechain preferred) ensures the FIRST record
+        // for each dedupe key is the one to keep. Also apply the
+        // "sidechain must not seed" rule from round-2 finding #1.
+        var xSeenPrimary: Set<PrimaryKey> = []
+        var xSeenSecondary: Set<SecondaryKey> = []
+        var crossFileDeduped = 0
+        var allRecords: [ClaudeCodeUsageRecord] = []
+        allRecords.reserveCapacity(candidateRecords.count)
+
+        for rec in candidateRecords {
+            if let mid = rec.messageId, !rec.isSidechain {
+                let secondary = SecondaryKey(messageId: mid)
+                if xSeenSecondary.contains(secondary) {
+                    crossFileDeduped += 1
+                    continue
+                }
+                if let rid = rec.requestId {
+                    let primary = PrimaryKey(messageId: mid, requestId: rid)
+                    if xSeenPrimary.contains(primary) {
+                        crossFileDeduped += 1
+                        continue
+                    }
+                    xSeenPrimary.insert(primary)
+                }
+                xSeenSecondary.insert(secondary)
+            } else if let mid = rec.messageId, rec.isSidechain {
+                let secondary = SecondaryKey(messageId: mid)
+                if xSeenSecondary.contains(secondary) {
+                    crossFileDeduped += 1
+                    continue
+                }
+                // Sidechain records arriving before any main record
+                // are retained but do NOT seed the seen sets, so a
+                // later canonical main record still wins.
+            }
+            allRecords.append(rec)
+        }
+
+        // Codex round-4 finding #2: unknown-model count should reflect
+        // FINAL (deduped) records, not candidates. Otherwise a duplicate
+        // unknown-model record inflates the diagnostic tile and
+        // over-suggests a pricing refresh.
+        let finalUnknownCount = allRecords.reduce(0) { acc, rec in
+            acc + (pricing.hasModel(rec.model) ? 0 : 1)
+        }
+
+        return ClaudeCodeUsageSnapshot(
+            records: allRecords,
+            recordsPerFile: perFile,
+            dedupedRecordCount: withinFileDeduped + crossFileDeduped,
+            malformedRecordCount: malformed,
+            unknownModelRecordCount: finalUnknownCount
+        )
+    }
+
+    /// Read a JSONL file as an array of decoded lines. Returns nil only
+    /// if the file cannot be opened at all — any per-line UTF-8 or I/O
+    /// error is tolerated (torn last line, mid-write truncation, invalid
+    /// UTF-8 byte). Uses a non-mmap Data read so a multi-GB append-only
+    /// session log does not spike memory or race the writer's mtime bump.
+    /// Codex round-1 finding #5 + #6.
+    ///
+    /// A generous per-file size cap (256 MB) protects against a
+    /// pathological log that would otherwise pull the whole file into
+    /// RAM; larger files are skipped with the caller counting them as
+    /// zero-record files. The cap is well above any realistic Claude
+    /// Code session (100 MB session ≈ ~200 000 assistant turns).
+    static func readJsonlLines(from url: URL) -> [String]? {
+        let sizeCap: Int64 = 256 * 1024 * 1024
+        // Codex round-6 finding #2: stream via FileHandle so a
+        // live-appending file cannot materialise the whole (possibly
+        // multi-GB) content into memory. We read chunks up to a
+        // hard limit of `sizeCap + 1` bytes; if we ever hit that
+        // limit we abort and return nil (the caller counts the file
+        // as skipped).
+        //
+        // Pre-check via stat is kept as a fast path so a >256MB file
+        // is rejected without opening a FileHandle at all.
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        if let size = (attrs?[.size] as? NSNumber)?.int64Value,
+           size > sizeCap {
+            return nil
+        }
+
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        // 1 MiB chunks. Small enough to bound memory, big enough that
+        // even a 200 MB file only needs ~200 chunk reads.
+        let chunkSize = 1024 * 1024
+        var buffer = Data()
+        buffer.reserveCapacity(chunkSize * 2)
+        while true {
+            let chunk: Data
+            do {
+                if #available(macOS 10.15.4, *) {
+                    guard let read = try handle.read(upToCount: chunkSize) else { break }
+                    chunk = read
+                } else {
+                    chunk = handle.readData(ofLength: chunkSize)
+                }
+            } catch {
+                return nil
+            }
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+            if Int64(buffer.count) > sizeCap {
+                return nil
+            }
+        }
+        // Split on `\n` byte, decode each slice with UTF-8 tolerance.
+        // `String(decoding: as: UTF8.self)` replaces invalid bytes with
+        // U+FFFD rather than returning nil, so a torn multibyte scalar
+        // on the last line produces a malformed JSON line (which the
+        // parser counts) instead of discarding the whole file.
+        var out: [String] = []
+        var start = buffer.startIndex
+        for i in buffer.indices where buffer[i] == 0x0A {  // '\n'
+            let slice = buffer[start..<i]
+            out.append(String(decoding: slice, as: UTF8.self))
+            start = buffer.index(after: i)
+        }
+        if start < buffer.endIndex {
+            let slice = buffer[start..<buffer.endIndex]
+            out.append(String(decoding: slice, as: UTF8.self))
+        }
+        return out
+    }
+
+    /// Enumerate `.jsonl` files under the scan root, recursively. Returns
+    /// [] if the root does not exist. I/O errors on individual entries
+    /// are skipped rather than propagated — a locked file mid-tick is
+    /// normal.
+    public static func discoverFiles(under scanRoot: String) -> [URL] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: scanRoot) else { return [] }
+        let rootURL = URL(fileURLWithPath: scanRoot)
+        guard let enumerator = fm.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: nil
+        ) else { return [] }
+
+        var out: [URL] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl" else { continue }
+            if let vals = try? url.resourceValues(forKeys: [.isRegularFileKey]),
+               vals.isRegularFile == true {
+                out.append(url)
+            }
+        }
+        // Sort deterministically (path order) so snapshot ordering is
+        // stable — matters for tests and for the cross-file dedupe
+        // "first-seen wins" contract.
+        out.sort { $0.path < $1.path }
+        return out
+    }
+
+    // MARK: - Timestamp parsing
+
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoFormatterNoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    /// Parse a Claude Code timestamp — RFC 3339 with or without a
+    /// fractional-seconds component. Returns nil for anything else,
+    /// which is the same as if the field was omitted (the snapshot
+    /// simply won't bucket the record into today/MTD). Public so the
+    /// test suite can exercise the parser against synthetic inputs.
+    public static func parseTimestamp(_ raw: String) -> Date? {
+        if let d = isoFormatter.date(from: raw) { return d }
+        return isoFormatterNoFractional.date(from: raw)
+    }
+
+    /// Best-effort integer extraction. Accepts Int, Double, and
+    /// stringified numerics — some LiteLLM-adjacent tooling emits
+    /// stringified fields. Clamps to `[0, Int.max]` — a negative value
+    /// is a schema break we surface as zero rather than a negative
+    /// cost line. Public so tests can exercise the clamp against
+    /// hostile inputs (NaN, infinity, 1e300, negatives).
+    public static func safeInt(_ value: Any?) -> Int {
+        if let i = value as? Int { return max(0, i) }
+        if let d = value as? Double, d.isFinite {
+            let rounded = d.rounded()
+            if rounded <= 0 { return 0 }
+            // Codex round-1 finding #2: `Double(Int.max)` rounds UP to
+            // 2^63 (Int.max = 2^63-1 is not representable exactly as
+            // Double), so `rounded > Double(Int.max)` misses the exact
+            // Int.max boundary and `Int(rounded)` traps. `Int(exactly:)`
+            // is the correct guard — it returns nil if the double
+            // cannot be represented as an Int without losing magnitude.
+            if let n = Int(exactly: rounded) { return n }
+            return Int.max
+        }
+        if let s = value as? String, let i = Int(s) { return max(0, i) }
+        return 0
+    }
+
+    // MARK: - Dedupe key types
+
+    public struct PrimaryKey: Hashable, Sendable {
+        public let messageId: String
+        public let requestId: String
+        public init(messageId: String, requestId: String) {
+            self.messageId = messageId
+            self.requestId = requestId
+        }
+    }
+    public struct SecondaryKey: Hashable, Sendable {
+        public let messageId: String
+        public init(messageId: String) {
+            self.messageId = messageId
+        }
+    }
+}

--- a/app/ClaudeCodeUsageStore.swift
+++ b/app/ClaudeCodeUsageStore.swift
@@ -309,10 +309,18 @@ public final class ClaudeCodeUsageStore: @preconcurrency UsageProvider {
     public nonisolated static func formatUSD(_ amount: Double) -> String {
         guard amount.isFinite else { return "$0.00" }
         if amount > 0 && amount < 0.005 { return "<$0.01" }
-        // Round to cents, then split into integer and cents parts so the
-        // thousands separator (added via formatWithCommas) applies only
-        // to the dollars portion.
-        let cents = Int((amount * 100.0).rounded())
+        // 3cc round-3 finding #3: guard Int((huge * 100.0).rounded())
+        // against a trap. `Int(exactly:)` returns nil when the Double
+        // is outside Int range; clamp to Int.max / .min in that case.
+        let scaled = (amount * 100.0).rounded()
+        let cents: Int
+        if let n = Int(exactly: scaled) {
+            cents = n
+        } else if scaled > 0 {
+            cents = Int.max
+        } else {
+            cents = Int.min + 1     // reserve Int.min so abs() cannot trap
+        }
         let sign = cents < 0 ? "-" : ""
         let abs_ = abs(cents)
         let dollars = abs_ / 100

--- a/app/ClaudeCodeUsageStore.swift
+++ b/app/ClaudeCodeUsageStore.swift
@@ -1,0 +1,378 @@
+// PR 10b-BE — Claude Code UsageProvider store (feature-flag off).
+//
+// First "local file reader" provider. Watches the JSONL scan root that
+// Claude Code writes under `~/.claude/projects/**/*.jsonl` (or the
+// $CLAUDE_CONFIG_DIR / $XDG_CONFIG_HOME override), re-parses on
+// filesystem change, and emits four popover tiles:
+//
+//   cc-tokens-today  — Counter: today's tokens across all models
+//   cc-cost-today    — Text:    today's cost in USD, formatted "$X.XX"
+//   cc-cost-mtd      — Text:    month-to-date cost in USD
+//   cc-by-model      — Text:    top-3 models by MTD cost with per-model
+//                                cost and token counts
+//
+// The TCC/FDA story is different from PR 5's Zed store: Claude Code
+// files are inside the user's home under ~/.claude, which is NOT
+// TCC-protected. A dedicated user could still deny read via chmod, but
+// the normal case is "granted or path missing (never installed)". We
+// probe TCC once per fetch and render `.needsAccess` for `.denied` and
+// nothing for `.pathMissing` (an unused-Claude-Code Mac has nothing
+// worth showing).
+//
+// Concurrency model
+// -----------------
+// The heavy work — enumerating files, opening them, parsing JSONL — is
+// dispatched off the main actor via a background queue. Result is
+// applied on the main actor via `Task { @MainActor [weak self] in ... }`
+// to match the Hardening pass (PR #60) rule of NEVER using
+// `MainActor.assumeIsolated` from a background completion.
+//
+// Feature posture
+// ---------------
+// `features.claudeCode.enabled` defaults false. Nothing registers a
+// `ClaudeCodeUsageStore` into `AppDelegate.providers` yet — that lands
+// in PR 10b-UI along with `ProviderCopy.help(for: "claudeCode")`.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class ClaudeCodeUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "claudeCode"
+    public let displayName: String = "Claude Code"
+    public let featureFlagKey: String = "features.claudeCode.enabled"
+
+    // MARK: - Observable state
+
+    @Published public private(set) var snapshot: ClaudeCodeUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    @Published public private(set) var tccState: TCCState = .granted
+
+    // MARK: - Dependencies
+
+    private let defaults: UserDefaults
+    private let pricing: ClaudeCodePricing
+    /// Path resolver returns the JSONL scan root. Injected so tests can
+    /// point to a temp directory.
+    private let resolveScanRoot: @Sendable () -> String?
+    /// TCC probe. Injected so tests can force `.denied` / `.pathMissing`.
+    private let tccProbe: @Sendable (String) -> TCCState
+    /// File enumerator. Injected so tests can supply a fixed list.
+    private let discoverFiles: @Sendable (String) -> [URL]
+    /// Parser. Injected so tests can bypass real I/O and drive a
+    /// synthetic in-memory JSONL corpus.
+    private let parseFiles: @Sendable ([URL], ClaudeCodePricing) -> ClaudeCodeUsageSnapshot
+    /// Queue used to run I/O off-main. Serial so a burst of filesystem
+    /// events coalesces into one parse pass rather than N parallel
+    /// re-scans of overlapping files. Serial also protects the fetch
+    /// generation counter without an atomic.
+    private let workQueue: DispatchQueue
+    /// Clock used for bucket boundaries — injected so tests can pin
+    /// "today" against a deterministic date.
+    private let clock: @Sendable () -> Date
+
+    // Monotonic counter — bumped on every `clear()` and every fresh
+    // fetch so a completion arriving from a stale earlier fetch does
+    // not overwrite fresher state. Mirrors the pattern used by
+    // CopilotUsageStore (chk1 round-1 finding). Only touched on the
+    // main actor.
+    private var fetchGeneration: UInt64 = 0
+
+    public init(
+        defaults: UserDefaults = .standard,
+        pricing: ClaudeCodePricing = .default,
+        resolveScanRoot: @escaping @Sendable () -> String? = {
+            ClaudeCodePathResolver.resolveScanRoot(.current())
+        },
+        tccProbe: @escaping @Sendable (String) -> TCCState = { TCCProbe.probe(path: $0) },
+        discoverFiles: @escaping @Sendable (String) -> [URL] = { ClaudeCodeUsageFetcher.discoverFiles(under: $0) },
+        parseFiles: @escaping @Sendable ([URL], ClaudeCodePricing) -> ClaudeCodeUsageSnapshot = { urls, p in
+            ClaudeCodeUsageFetcher.parse(files: urls, pricing: p)
+        },
+        workQueue: DispatchQueue = DispatchQueue(
+            label: "com.claude.usagebar.claudecode.parse",
+            qos: .utility
+        ),
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.defaults = defaults
+        self.pricing = pricing
+        self.resolveScanRoot = resolveScanRoot
+        self.tccProbe = tccProbe
+        self.discoverFiles = discoverFiles
+        self.parseFiles = parseFiles
+        self.workQueue = workQueue
+        self.clock = clock
+    }
+
+    // MARK: - UsageProvider: metadata
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// The Claude Code reader is always "configured" once the flag is on
+    /// — there is no credential to enter. The path may not exist yet
+    /// (Claude Code never installed), which the tile surfaces as an
+    /// informational status; the store still considers itself configured.
+    public var isConfigured: Bool {
+        isEnabled
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // TCC gating — deny path renders one card that points the user
+        // at Full Disk Access. Path-missing renders nothing so an
+        // unused-Claude-Code Mac stays quiet.
+        switch tccState {
+        case .denied:
+            let copy = LocalProviderAccessGuide.copy(for: .denied, appName: displayName)
+            return [UsageTile(
+                id: "cc-needs-access",
+                title: copy.title,
+                kind: .needsAccess(path: "~/.claude/projects", guidance: copy.guidance)
+            )]
+        case .pathMissing:
+            // Nothing to show — the app is not on this Mac. Return a
+            // single explanatory text tile so an enabled-but-empty
+            // state is not confusing (the popover would otherwise show
+            // "Claude Code" section header with zero content).
+            return [UsageTile(
+                id: "cc-not-installed",
+                title: displayName,
+                kind: .text(status: "No sessions found", subtitle: "Launch Claude Code and click Refresh.")
+            )]
+        case .granted:
+            break
+        }
+
+        guard let snap = snapshot else {
+            // Enabled, granted, no snapshot yet — first fetch pending.
+            return [UsageTile(
+                id: "cc-loading",
+                title: displayName,
+                kind: .text(status: "Loading…", subtitle: nil)
+            )]
+        }
+
+        let now = clock()
+        let todayRange = Self.todayRange(around: now)
+        let mtdRange = Self.monthToDateRange(around: now)
+
+        let tokensToday = snap.tokens(in: todayRange)
+        let costToday = snap.cost(in: todayRange)
+        let costMTD = snap.cost(in: mtdRange)
+        let byModel = snap.breakdownByModel(in: mtdRange)
+
+        var out: [UsageTile] = []
+
+        out.append(UsageTile(
+            id: "cc-tokens-today",
+            title: "Tokens today",
+            kind: .counter(used: tokensToday, limit: nil, resetsAt: Self.startOfNextDay(after: now))
+        ))
+        out.append(UsageTile(
+            id: "cc-cost-today",
+            title: "Cost today",
+            kind: .text(status: Self.formatUSD(costToday), subtitle: nil)
+        ))
+        out.append(UsageTile(
+            id: "cc-cost-mtd",
+            title: "Cost month-to-date",
+            kind: .text(status: Self.formatUSD(costMTD), subtitle: nil)
+        ))
+        if !byModel.isEmpty {
+            let top = byModel.prefix(3)
+            let lines = top.map { entry in
+                "\(entry.model) — \(Self.formatUSD(entry.costUSD)) (\(Self.formatTokens(entry.tokens)))"
+            }
+            out.append(UsageTile(
+                id: "cc-by-model",
+                title: "Top models this month",
+                kind: .text(status: lines.first ?? "", subtitle: lines.dropFirst().joined(separator: "\n"))
+            ))
+        }
+
+        // Diagnostic tile — surfaces only when the pricing table missed
+        // at least one record on THIS snapshot. Keeps the popover quiet
+        // on healthy sessions.
+        if snap.unknownModelRecordCount > 0 {
+            out.append(UsageTile(
+                id: "cc-pricing-stale",
+                title: "Pricing update available",
+                kind: .text(
+                    status: "\(snap.unknownModelRecordCount) records used a model not in the bundled price list.",
+                    subtitle: "Cost figures may under-count until the app ships an updated snapshot."
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        // Codex round-2 finding #6: bump the fetch generation BEFORE
+        // any early-return path so an in-flight fetch cannot complete
+        // and repopulate stale data after access was denied. Without
+        // this, fetch A running on the queue can finish and apply its
+        // result after fetch B saw `.denied` and cleared state.
+        fetchGeneration &+= 1
+        let launchGeneration = fetchGeneration
+
+        let scanRoot = resolveScanRoot()
+        guard let root = scanRoot else {
+            lastError = "Could not resolve Claude Code data directory."
+            return
+        }
+
+        // Probe TCC on every fetch. The user might grant/revoke Full
+        // Disk Access at any time; we want to reflect that quickly.
+        let probed = tccProbe(root)
+        self.tccState = probed
+        if probed != .granted {
+            // Nothing to fetch — the tile message is enough. The
+            // generation bump above invalidates any prior in-flight
+            // fetch so a late completion cannot revive the snapshot
+            // after the user denied access.
+            self.snapshot = nil
+            self.lastError = nil
+            return
+        }
+
+        // Capture dependencies for the background queue. `self` is
+        // captured weakly on the main-actor apply hop only; the
+        // dispatched closure holds only value-type copies.
+        let root_ = root
+        let discover = self.discoverFiles
+        let parse = self.parseFiles
+        let pricing_ = self.pricing
+
+        workQueue.async { [weak self] in
+            let urls = discover(root_)
+            let snap = parse(urls, pricing_)
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                // Codex round-3 finding #3: guard on isEnabled too.
+                // Without this, a fetch started while enabled can
+                // complete after the user disabled the provider and
+                // repopulate stale state — which then flashes back if
+                // they re-enable.
+                guard self.isEnabled else { return }
+                guard launchGeneration == self.fetchGeneration else { return }
+                self.snapshot = snap
+                self.lastUpdatedAt = Date()
+                self.lastError = nil
+                Log.info("Claude Code JSONL parsed", .count(snap.records.count))
+            }
+        }
+    }
+
+    public func clear() {
+        // No credential to delete — local JSONL is Claude Code's file,
+        // not ours. Clearing drops in-memory state only, and invalidates
+        // any in-flight fetch via the generation bump.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        fetchGeneration &+= 1
+    }
+
+    // MARK: - Formatting helpers
+    //
+    // Marked `nonisolated` — these are pure static functions with no
+    // access to instance state. Without this, calling them from a test
+    // context (or any non-MainActor code path) requires an actor hop or
+    // await, which is unnecessary since they cannot observe or mutate
+    // main-actor state.
+
+    /// Format a USD amount with two decimal places. Amounts under $0.01
+    /// render as "<$0.01" — a raw "$0.00" line for a session that just
+    /// spent $0.003 would be misleading. Uses `String(format:)` with a
+    /// fixed locale (dot decimal separator, no thousands separators for
+    /// small dollar amounts) — `NumberFormatter.currency` with `en_US_POSIX`
+    /// injects a stray space between `$` and the digits which reads
+    /// wrongly in the popover.
+    public nonisolated static func formatUSD(_ amount: Double) -> String {
+        guard amount.isFinite else { return "$0.00" }
+        if amount > 0 && amount < 0.005 { return "<$0.01" }
+        // Round to cents, then split into integer and cents parts so the
+        // thousands separator (added via formatWithCommas) applies only
+        // to the dollars portion.
+        let cents = Int((amount * 100.0).rounded())
+        let sign = cents < 0 ? "-" : ""
+        let abs_ = abs(cents)
+        let dollars = abs_ / 100
+        let remainder = abs_ % 100
+        return "\(sign)$\(formatWithCommas(dollars)).\(String(format: "%02d", remainder))"
+    }
+
+    /// Format a token count with comma thousand separators
+    /// (e.g. "1,234,567 tokens"). Zero renders as "0 tokens".
+    public nonisolated static func formatTokens(_ count: Int) -> String {
+        return "\(formatWithCommas(count)) tokens"
+    }
+
+    /// Insert comma thousand separators into a non-negative integer.
+    /// Used by both `formatUSD` (dollars portion) and `formatTokens`.
+    /// Kept private and pure so both tests exercise it through their
+    /// public callers. Negative inputs are formatted absolute; the
+    /// caller re-prepends the sign.
+    private nonisolated static func formatWithCommas(_ n: Int) -> String {
+        let digits = String(abs(n))
+        var out = ""
+        for (i, ch) in digits.reversed().enumerated() {
+            if i > 0 && i % 3 == 0 { out += "," }
+            out += String(ch)
+        }
+        return String(out.reversed())
+    }
+
+    /// Range covering [start-of-day, end-of-day] in the user's current
+    /// calendar. Used to bucket today's records.
+    ///
+    /// Codex round-2 finding #8: DST-safe — calendar arithmetic for
+    /// nextDay handles 23h and 25h days.
+    ///
+    /// Codex round-3 finding #1: end is `nextDay - 1 nanosecond`, not
+    /// `nextDay - 1 second`. A fractional-seconds Claude Code timestamp
+    /// like `23:59:59.500` would be excluded from a ClosedRange ending
+    /// at `23:59:59.000`. Using `nextDown` on the Foundation Date's
+    /// underlying TimeInterval gives the largest representable Date
+    /// strictly less than `nextDay`, so every subsecond record in the
+    /// last second of the day is included.
+    public nonisolated static func todayRange(around now: Date, calendar: Calendar = .current) -> ClosedRange<Date> {
+        let start = calendar.startOfDay(for: now)
+        let nextDay = calendar.date(byAdding: .day, value: 1, to: start) ?? now
+        // largest representable Date < nextDay
+        let endOfDay = Date(timeIntervalSinceReferenceDate: nextDay.timeIntervalSinceReferenceDate.nextDown)
+        return start...endOfDay
+    }
+
+    /// The next midnight — used as the "resets at" hint on the tokens tile.
+    public nonisolated static func startOfNextDay(after now: Date, calendar: Calendar = .current) -> Date {
+        let start = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: 1, to: start) ?? now
+    }
+
+    /// Range covering [start-of-month, now] in the user's current
+    /// calendar. Used to bucket month-to-date records.
+    public nonisolated static func monthToDateRange(around now: Date, calendar: Calendar = .current) -> ClosedRange<Date> {
+        let comps = calendar.dateComponents([.year, .month], from: now)
+        let start = calendar.date(from: comps) ?? now
+        return start...now
+    }
+}

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import Combine
 
 // The categorical logger (enum Log, enum LogValue) lives in Log.swift so
 // the SwiftPM library target can compile it without also compiling this
@@ -21,6 +22,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // via `providers.append(...)`. The existing UsageManager continues to
     // drive Anthropic tiles — providers[0] is a thin wrapper around it.
     var providers: [ProviderBox] = []
+    // PR 3-UI: the ObservableObject SwiftUI watches for generic provider
+    // tiles. Holds the same ProviderBox instances as `providers`.
+    var providersModel: ProvidersModel!
     var eventMonitor: Any?
     var hotKeyRef: EventHotKeyRef?
 
@@ -45,9 +49,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize managers
         usageManager = UsageManager(statusItem: statusItem, delegate: self)
-        // Wrap the manager in a UsageProvider so future provider PRs can
-        // add themselves to `providers[]` without disturbing this one.
+        // Wrap the manager in a UsageProvider so additional providers can
+        // register alongside it without disturbing the Anthropic path.
         providers.append(ProviderBox(AnthropicUsageStore(manager: usageManager)))
+        // PR 3-UI: register the Codex provider. It is opt-in (feature flag
+        // features.codex.enabled defaults false), so registering it here is
+        // inert for existing users — it contributes no tiles until enabled.
+        providers.append(ProviderBox(CodexUsageStore()))
+        // Model SwiftUI observes for the generic (non-Anthropic) provider
+        // tiles. Anthropic continues to render through usageManager directly.
+        providersModel = ProvidersModel(providers: providers)
         statusManager = StatusManager()
         updateManager = UpdateManager()
 
@@ -59,13 +70,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.contentViewController = NSHostingController(rootView: UsageView(
             usageManager: usageManager,
             statusManager: statusManager,
-            updateManager: updateManager
+            updateManager: updateManager,
+            providersModel: providersModel
         ))
 
         // Fetch initial data
         usageManager.fetchUsage()
         statusManager.fetch()
         updateManager.fetch()
+        // Fetch any enabled non-Anthropic providers (Codex, etc.) on launch.
+        providersModel.fetchEnabled()
+
+        // Non-Anthropic providers poll on their own cadence. Codex documents
+        // 60s while active; a single 60s timer drives every enabled provider.
+        Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
+            self.providersModel.fetchEnabled()
+        }
 
         // Usage + Anthropic status are time-sensitive — poll every 5 min.
         Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
@@ -222,6 +242,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.main.async {
                 self.usageManager.updatePercentages()
             }
+            // Refresh enabled non-Anthropic providers (Codex, etc.) so their
+            // tiles are current when the popover appears.
+            providersModel?.fetchEnabled()
 
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
 
@@ -1243,6 +1266,71 @@ struct PasteableTextField: NSViewRepresentable {
     }
 }
 
+// PR 3-UI: the single ObservableObject SwiftUI watches for the generic
+// (non-Anthropic) provider tiles. SwiftUI cannot observe a bare
+// `[ProviderBox]`; it needs one ObservableObject to subscribe to. This model
+// holds the boxes and re-broadcasts each box's objectWillChange, so any
+// provider state change redraws the popover. Anthropic is intentionally
+// excluded from `genericProviders` — it renders through usageManager as
+// before; this model only drives the additional providers.
+//
+// @MainActor because it reads and drives @MainActor providers (ProviderBox,
+// the stores). Every call site (AppDelegate lifecycle, timers on the main
+// runloop, the SwiftUI popover) is already on the main actor, so this adds
+// no friction. AppDelegate is annotated @MainActor to match, which AppKit
+// already guarantees at runtime.
+@MainActor
+final class ProvidersModel: ObservableObject {
+    let providers: [ProviderBox]
+    private var cancellables: [AnyCancellable] = []
+
+    init(providers: [ProviderBox]) {
+        self.providers = providers
+        for box in providers {
+            box.objectWillChange
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.objectWillChange.send() }
+                .store(in: &cancellables)
+        }
+    }
+
+    /// Providers rendered through the generic path — everything except
+    /// Anthropic, which keeps its bespoke rendering in UsageView.content.
+    /// `nonisolated` because `providers` is an immutable `let` and `id` is a
+    /// nonisolated stored property on ProviderBox — no main-actor state is
+    /// touched, so AppDelegate's timer/lifecycle closures can call it.
+    nonisolated var genericProviders: [ProviderBox] {
+        providers.filter { $0.id != "anthropic" }
+    }
+
+    /// The subset of generic providers the user has enabled via Settings.
+    /// Reads each provider's `isEnabled` through the `any UsageProvider`
+    /// existential, whose protocol is not @MainActor (the stores add it with
+    /// @preconcurrency), so this stays nonisolated.
+    nonisolated var enabledGenericProviders: [ProviderBox] {
+        genericProviders.filter { $0.provider.isEnabled }
+    }
+
+    /// Fetch every enabled non-Anthropic provider. Called on launch, on the
+    /// 60s timer, when the popover opens, and from the Refresh button — all
+    /// on the main thread in practice. `nonisolated` so those synchronous
+    /// call sites do not need per-site actor hops.
+    nonisolated func fetchEnabled() {
+        for box in enabledGenericProviders {
+            box.provider.fetch()
+        }
+    }
+
+    /// Force the popover to re-evaluate which provider sections are visible.
+    /// A Settings toggle writes the feature flag straight to UserDefaults,
+    /// which does not itself fire objectWillChange; the toggle calls this so
+    /// a section appears or disappears immediately on both transitions
+    /// (enabling a provider also fetches; disabling it has no other signal).
+    func providersChanged() {
+        objectWillChange.send()
+    }
+}
+
 private struct ContentHeightKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
@@ -1254,6 +1342,8 @@ struct UsageView: View {
     @ObservedObject var usageManager: UsageManager
     @ObservedObject var statusManager: StatusManager
     @ObservedObject var updateManager: UpdateManager
+    // PR 3-UI: drives the generic (non-Anthropic) provider tiles.
+    @ObservedObject var providersModel: ProvidersModel
     @State private var sessionCookieInput: String = ""
     @State private var showingCookieInput: Bool = false
     @State private var showingSettings: Bool = false
@@ -1485,6 +1575,15 @@ struct UsageView: View {
             }
             }
 
+            // PR 3-UI: generic (non-Anthropic) provider tiles. Each enabled
+            // provider contributes a section; Anthropic is rendered above via
+            // usageManager and is excluded here. Renders nothing when no such
+            // provider is enabled, so existing users see no change.
+            ForEach(providersModel.enabledGenericProviders) { box in
+                Divider()
+                ProviderSectionView(box: box)
+            }
+
             if statusManager.hasFetched {
                 Divider()
             }
@@ -1626,6 +1725,7 @@ struct UsageView: View {
                     usageManager.fetchUsage()
                     statusManager.fetch()
                     updateManager.fetch()
+                    providersModel.fetchEnabled()
                 }
                 .buttonStyle(.borderless)
                 .font(.caption)
@@ -1787,6 +1887,30 @@ struct UsageView: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                    }
+
+                    Divider()
+
+                    // PR 3-UI: per-provider opt-in toggles. Each non-Anthropic
+                    // provider is off by default; enabling one writes its
+                    // featureFlagKey and triggers an immediate fetch.
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Providers")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                        Text("Track additional AI services. Each is opt-in; enable only the ones you use.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        ForEach(providersModel.genericProviders) { box in
+                            ProviderToggleRow(box: box) { enabled in
+                                // Re-evaluate section visibility on both
+                                // transitions; fetch immediately on enable.
+                                if enabled { box.provider.fetch() }
+                                providersModel.providersChanged()
+                            }
+                        }
                     }
 
                     Divider()
@@ -2003,3 +2127,237 @@ struct UsageView: View {
     }
 
 }
+
+// MARK: - Generic provider rendering (PR 3-UI)
+
+/// Renders one non-Anthropic provider: a section header (display name +
+/// optional error / last-updated) followed by one UsageTileView per tile.
+/// Observes the box so provider state changes redraw this section.
+struct ProviderSectionView: View {
+    @ObservedObject var box: ProviderBox
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(box.provider.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer()
+                if let updated = box.provider.lastUpdated {
+                    Text("Updated \(shortTime(updated))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let error = box.provider.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+
+            ForEach(box.provider.tiles) { tile in
+                UsageTileView(tile: tile)
+            }
+        }
+    }
+
+    private func shortTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f.string(from: date)
+    }
+}
+
+/// Renders a single UsageTile by switching on its Kind. This is the generic
+/// renderer every future provider reuses — adding a provider needs no new UI
+/// as long as it emits one of these kinds.
+struct UsageTileView: View {
+    let tile: UsageTile
+
+    var body: some View {
+        switch tile.kind {
+        case let .bar(fraction, resetsAt, badge):
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    if let badge = badge, !badge.isEmpty {
+                        Text(badge)
+                            .font(.caption2)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.2))
+                            .cornerRadius(3)
+                    }
+                    Spacer()
+                    if let resetsAt = resetsAt {
+                        Text("Resets \(resetLabel(resetsAt))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                ProgressView(value: fraction)
+                    .tint(color(for: fraction))
+                Text("\(Int((fraction * 100).rounded()))% used")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+        case let .balance(remainingMinorUnits, currency, plan, resetsAt):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    Text(formatBalance(remainingMinorUnits, currency: currency))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                }
+                if let plan = plan, !plan.isEmpty {
+                    Text(plan)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                if let resetsAt = resetsAt {
+                    Text("Resets \(resetLabel(resetsAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case let .counter(used, limit, resetsAt):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    if let limit = limit {
+                        Text("\(used) / \(limit)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    } else {
+                        Text("\(used)")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    }
+                }
+                if let resetsAt = resetsAt {
+                    Text("Resets \(resetLabel(resetsAt))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+        case let .text(status, subtitle):
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(tile.title)
+                        .font(.caption)
+                    Spacer()
+                    Text(status)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let subtitle = subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+        case let .needsAccess(path, guidance):
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tile.title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Text(guidance)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(path)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding(8)
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(6)
+        }
+    }
+
+    private func color(for fraction: Double) -> Color {
+        if fraction < 0.7 { return .green }
+        if fraction < 0.9 { return .orange }
+        return .red
+    }
+
+    private func resetLabel(_ date: Date) -> String {
+        let f = DateFormatter()
+        // Include the date when the reset is more than ~a day out (weekly
+        // windows); otherwise just the time (5-hour windows).
+        if date.timeIntervalSinceNow > 86_400 {
+            f.dateFormat = "d MMM 'at' h:mm a"
+            return "on \(f.string(from: date))"
+        }
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return "at \(f.string(from: date))"
+    }
+
+    private func formatBalance(_ minorUnits: Int, currency: String) -> String {
+        let major = Double(minorUnits) / 100.0
+        return String(format: "%@ %.2f", currency, major)
+    }
+}
+
+/// One opt-in checkbox for a non-Anthropic provider in Settings. Reads and
+/// writes the provider's featureFlagKey directly in UserDefaults; on enable
+/// it fires `onEnable` so the provider fetches immediately rather than
+/// waiting for the next timer tick. Below the toggle it shows provider-
+/// specific help and, where relevant, a private-API disclosure line.
+struct ProviderToggleRow: View {
+    @ObservedObject var box: ProviderBox
+    /// Called after the flag is written, with the new value, on every
+    /// toggle (both enable and disable).
+    let onChange: (Bool) -> Void
+
+    @State private var enabled: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: Binding(
+                get: { enabled },
+                set: { newValue in
+                    enabled = newValue
+                    UserDefaults.standard.set(newValue, forKey: box.provider.featureFlagKey)
+                    onChange(newValue)
+                }
+            )) {
+                Text(box.provider.displayName)
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+
+            if let help = ProviderCopy.help(for: box.id) {
+                Text(help)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let disclosure = ProviderCopy.disclosure(for: box.id) {
+                Text(disclosure)
+                    .font(.caption2)
+                    .foregroundColor(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .onAppear {
+            enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
+        }
+    }
+}
+

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -89,6 +89,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // (.granted) or an onboarding card (.denied → Full Disk Access
         // prompt; .pathMissing → "not installed"). Backend from PR #67.
         providers.append(ProviderBox(ClaudeCodeUsageStore()))
+        // PR 10c-UI: register Cline local ui_messages.json reader.
+        // Opt-in (features.cline.enabled defaults false); reads
+        // `saoudrizwan.claude-dev/tasks/{taskId}/ui_messages.json`
+        // under every VS Code family host (VS Code / Insiders /
+        // VSCodium / Cursor / Windsurf) AND the Cline CLI's
+        // $CLINE_DATA_DIR / $CLINE_DIR / ~/.cline/data. Nothing leaves
+        // the machine. Backend from PR #69.
+        providers.append(ProviderBox(ClineUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -444,16 +444,14 @@ class UsageManager: ObservableObject {
     }
 
     func fetchOrganizationId(completion: @escaping (String?) -> Void) {
-        // Get org ID from the lastActiveOrg cookie value
-        let cookieParts = sessionCookie.components(separatedBy: ";")
-        for part in cookieParts {
-            let trimmed = part.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("lastActiveOrg=") {
-                let orgId = trimmed.replacingOccurrences(of: "lastActiveOrg=", with: "")
-                Log.info("Found org ID in cookie", .identifier(orgId))
-                completion(orgId)
-                return
-            }
+        // PR 2b: parsing lives in AnthropicUsageFetcher. UsageManager keeps
+        // ownership of the network call (which needs to be in the manager
+        // for delegate/main-actor reasons) but delegates the string
+        // parsing.
+        if let orgId = AnthropicUsageFetcher.orgId(fromCookieString: sessionCookie) {
+            Log.info("Found org ID in cookie", .identifier(orgId))
+            completion(orgId)
+            return
         }
 
         // If not in cookie, fetch from bootstrap
@@ -574,113 +572,43 @@ class UsageManager: ObservableObject {
     }
 
     func parseUsageData(_ data: Data) {
+        // PR 2b: parsing extracted into AnthropicUsageFetcher (Sendable
+        // value type, no side effects). UsageManager only applies the
+        // resulting snapshot to observable state. Behaviour is identical
+        // to the pre-refactor code; every branch is locked in by fixture
+        // tests in Tests/TestRunner.
         do {
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                errorMessage = "Invalid JSON"
-                return
-            }
+            let snap = try AnthropicUsageFetcher.parse(data)
+            sessionUsage = snap.sessionUsage
+            sessionLimit = 100
+            sessionResetsAt = snap.sessionResetsAt
 
-            NSLog("📊 Parsing usage data...")
+            weeklyUsage = snap.weeklyUsage
+            weeklyLimit = 100
+            weeklyResetsAt = snap.weeklyResetsAt
 
-            let iso8601Formatter = ISO8601DateFormatter()
-            iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            hasWeeklySonnet = snap.hasWeeklySonnet
+            weeklySonnetUsage = snap.weeklySonnetUsage
+            weeklySonnetLimit = 100
+            weeklySonnetResetsAt = snap.weeklySonnetResetsAt
 
-            // Parse the actual claude.ai response format
-            if let fiveHour = json["five_hour"] as? [String: Any] {
-                if let sessionUtil = fiveHour["utilization"] as? Double {
-                    sessionUsage = Int(sessionUtil)
-                    sessionLimit = 100
-                }
-                if let resetsAtString = fiveHour["resets_at"] as? String {
-                    NSLog("🕐 Session resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        sessionResetsAt = resetsAt
-                        NSLog("✅ Parsed session reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse session reset time")
-                    }
-                }
-            }
+            hasWeeklyFable = snap.hasWeeklyFable
+            weeklyFableUsage = snap.weeklyFableUsage
+            weeklyFableLimit = 100
+            weeklyFableResetsAt = snap.weeklyFableResetsAt
 
-            if let sevenDay = json["seven_day"] as? [String: Any] {
-                if let weeklyUtil = sevenDay["utilization"] as? Double {
-                    weeklyUsage = Int(weeklyUtil)
-                    weeklyLimit = 100
-                }
-                if let resetsAtString = sevenDay["resets_at"] as? String {
-                    NSLog("🕐 Weekly resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        weeklyResetsAt = resetsAt
-                        NSLog("✅ Parsed weekly reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse weekly reset time")
-                    }
-                }
-            }
-
-            // Check for seven_day_sonnet (Pro plan feature)
-            if let sevenDaySonnet = json["seven_day_sonnet"] as? [String: Any] {
-                hasWeeklySonnet = true
-                if let sonnetUtil = sevenDaySonnet["utilization"] as? Double {
-                    weeklySonnetUsage = Int(sonnetUtil)
-                    weeklySonnetLimit = 100
-                }
-                if let resetsAtString = sevenDaySonnet["resets_at"] as? String {
-                    NSLog("🕐 Weekly Sonnet resets_at string: \(resetsAtString)")
-                    if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                        weeklySonnetResetsAt = resetsAt
-                        NSLog("✅ Parsed weekly Sonnet reset time: \(resetsAt)")
-                    } else {
-                        NSLog("❌ Failed to parse weekly Sonnet reset time")
-                    }
-                }
-            } else {
-                hasWeeklySonnet = false
-            }
-
-            // Fable is a new, separately-counted model. It isn't a top-level
-            // key like seven_day_sonnet — it lives in the `limits` array as a
-            // model-scoped weekly limit (scope.model.display_name == "Fable").
-            // The bar is only surfaced in the UI when usage is above 1%.
-            hasWeeklyFable = false
-            if let limits = json["limits"] as? [[String: Any]] {
-                let fableLimit = limits.first { entry in
-                    let scope = entry["scope"] as? [String: Any]
-                    let model = scope?["model"] as? [String: Any]
-                    return (model?["display_name"] as? String) == "Fable"
-                }
-                if let fable = fableLimit {
-                    hasWeeklyFable = true
-                    // `percent` may decode as Int or Double depending on payload.
-                    if let p = fable["percent"] as? Int {
-                        weeklyFableUsage = p
-                    } else if let p = fable["percent"] as? Double {
-                        weeklyFableUsage = Int(p)
-                    }
-                    weeklyFableLimit = 100
-                    if let resetsAtString = fable["resets_at"] as? String {
-                        NSLog("🕐 Weekly Fable resets_at string: \(resetsAtString)")
-                        if let resetsAt = iso8601Formatter.date(from: resetsAtString) {
-                            weeklyFableResetsAt = resetsAt
-                            NSLog("✅ Parsed weekly Fable reset time: \(resetsAt)")
-                        } else {
-                            NSLog("❌ Failed to parse weekly Fable reset time")
-                        }
-                    }
-                }
-            }
-
-            // Log what we found
-            NSLog("✅ Parsed: Session \(sessionUsage)%, Weekly \(weeklyUsage)%\(hasWeeklySonnet ? ", Weekly Sonnet \(weeklySonnetUsage)%" : "")\(hasWeeklyFable ? ", Weekly Fable \(weeklyFableUsage)%" : "")")
+            Log.info("Parsed usage",
+                     .public("session"), .count(sessionUsage),
+                     .public("weekly"), .count(weeklyUsage))
 
             lastUpdated = Date()
             errorMessage = nil
             hasFetchedData = true
-
-            // Update percentage values for progress bars
             updatePercentages()
+        } catch AnthropicUsageParseError.invalidJSON {
+            errorMessage = "Invalid JSON"
         } catch {
-            NSLog("❌ Parse error: \(error.localizedDescription)")
+            Log.info("Parse error", .public(error.localizedDescription))
             errorMessage = "Parse error"
         }
     }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -15,6 +15,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var usageManager: UsageManager!
     var statusManager: StatusManager!
     var updateManager: UpdateManager!
+
+    // PR 2c: multi-provider registry. Anthropic is the only provider today;
+    // subsequent PRs register additional stores (Codex, DeepSeek, Zed, ...)
+    // via `providers.append(...)`. The existing UsageManager continues to
+    // drive Anthropic tiles — providers[0] is a thin wrapper around it.
+    var providers: [ProviderBox] = []
     var eventMonitor: Any?
     var hotKeyRef: EventHotKeyRef?
 
@@ -39,6 +45,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Initialize managers
         usageManager = UsageManager(statusItem: statusItem, delegate: self)
+        // Wrap the manager in a UsageProvider so future provider PRs can
+        // add themselves to `providers[]` without disturbing this one.
+        providers.append(ProviderBox(AnthropicUsageStore(manager: usageManager)))
         statusManager = StatusManager()
         updateManager = UpdateManager()
 

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -60,6 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // defaults false) and additionally requires a pasted API key, so it
         // is doubly inert until the user both enables and configures it.
         providers.append(ProviderBox(DeepSeekUsageStore()))
+        // PR 5-UI: register Zed. Opt-in (features.zed.enabled defaults false);
+        // it reads Zed's own Keychain login on first fetch (one-time macOS
+        // prompt), so it is inert until enabled and the prompt is allowed.
+        providers.append(ProviderBox(ZedUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -68,6 +68,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // an optional gated management key for balance/history. Inert until
         // enabled and configured.
         providers.append(ProviderBox(XAIUsageStore()))
+        // PR 7-UI: register OpenAI Platform. Opt-in; requires a pasted Admin
+        // key (sk-admin-). Inert until enabled and configured.
+        providers.append(ProviderBox(OpenAIUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -56,6 +56,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // features.codex.enabled defaults false), so registering it here is
         // inert for existing users — it contributes no tiles until enabled.
         providers.append(ProviderBox(CodexUsageStore()))
+        // PR 4-UI: register DeepSeek. Also opt-in (features.deepseek.enabled
+        // defaults false) and additionally requires a pasted API key, so it
+        // is doubly inert until the user both enables and configures it.
+        providers.append(ProviderBox(DeepSeekUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2326,6 +2330,16 @@ struct ProviderToggleRow: View {
     let onChange: (Bool) -> Void
 
     @State private var enabled: Bool = false
+    // Local buffer for a pasted secret (PasteKeyProvider). Never pre-filled
+    // with the stored secret — we only ever write, never read it back out.
+    @State private var keyInput: String = ""
+    @State private var hasStoredKey: Bool = false
+
+    /// The provider as a PasteKeyProvider, when it is configured by pasting a
+    /// secret; nil otherwise.
+    private var pasteKeyProvider: PasteKeyProvider? {
+        box.provider as? PasteKeyProvider
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -2354,9 +2368,44 @@ struct ProviderToggleRow: View {
                     .foregroundColor(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            // Key-entry affordance for paste-a-secret providers, shown only
+            // when the provider is enabled. Uses a SecureField so the pasted
+            // value is masked on screen; the stored secret is never read back
+            // into the field.
+            if enabled, let keyProvider = pasteKeyProvider {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        SecureField(keyProvider.keyPlaceholder, text: $keyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.caption2)
+                        Button("Save") {
+                            keyProvider.saveKey(keyInput)
+                            keyInput = ""
+                            hasStoredKey = keyProvider.hasKey
+                            onChange(true)  // trigger a fetch now that a key exists
+                        }
+                        .controlSize(.small)
+                        .disabled(keyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                        if hasStoredKey {
+                            Button("Clear") {
+                                keyProvider.saveKey("")  // empty clears
+                                hasStoredKey = keyProvider.hasKey
+                                onChange(false)
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
         }
         .onAppear {
             enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
+            hasStoredKey = pasteKeyProvider?.hasKey ?? false
         }
     }
 }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -81,6 +81,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // fine-grained PAT (Plan: Read). Doubly inert until the user
         // both enables and configures it. Backend from PR #64.
         providers.append(ProviderBox(CopilotUsageStore()))
+        // PR 10b-UI: register Claude Code local JSONL reader. Opt-in
+        // (features.claudeCode.enabled defaults false); reads
+        // `~/.claude/projects/**/*.jsonl` on-disk only — nothing
+        // leaves the machine. Inert until enabled; on enable the
+        // store probes TCC once and either renders usage tiles
+        // (.granted) or an onboarding card (.denied → Full Disk Access
+        // prompt; .pathMissing → "not installed"). Backend from PR #67.
+        providers.append(ProviderBox(ClaudeCodeUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,6 +2,72 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
+import CryptoKit
+import Foundation
+
+// MARK: - Logging (categorical redaction)
+//
+// PR 1 replaces every NSLog site that touched cookies, org IDs, or response
+// bodies with the categorical logger below. The call site cannot interpolate
+// a raw String; every value goes through a category, and each category has
+// its own emission rule. This makes accidental credential logging a compile-
+// time impossibility rather than a discipline problem.
+//
+// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
+// reintroduce raw-interpolation NSLog calls or the deleted response-body
+// log line at the network fetch site. The exact banned pattern lives in
+// the workflow file to avoid embedding it here (which would self-trigger).
+
+enum LogValue {
+    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
+    case `public`(String)
+    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
+    /// bodies, tokens, API keys, anything that could leak a credential.
+    case sensitive(String)
+    /// Emitted as a short SHA-256 prefix so the value can be correlated
+    /// across log lines without revealing it. Use for org IDs, user IDs.
+    case identifier(String)
+    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
+    /// retry counts, threshold values).
+    case count(Int)
+
+    var rendered: String {
+        switch self {
+        case .public(let s):
+            return s
+        case .sensitive(let s):
+            return "<redacted: \(s.count) chars>"
+        case .identifier(let s):
+            let digest = SHA256.hash(data: Data(s.utf8))
+            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+            return "<id: \(hex.prefix(8))>"
+        case .count(let n):
+            return String(n)
+        }
+    }
+}
+
+enum Log {
+    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
+    /// gate. Accepts a plain message — no interpolation of untrusted values.
+    static func debug(_ message: String) {
+        #if DEBUG
+        NSLog("[debug] %@", message)
+        #endif
+    }
+
+    /// Info-level diagnostics. Retained in release builds. Values must be
+    /// wrapped in a `LogValue` category, forcing an explicit redaction
+    /// decision at the call site.
+    static func info(_ message: String, _ values: LogValue...) {
+        let rendered = values.map(\.rendered).joined(separator: ", ")
+        if rendered.isEmpty {
+            NSLog("%@", message)
+        } else {
+            NSLog("%@ | %@", message, rendered)
+        }
+    }
+}
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -403,15 +469,15 @@ class UsageManager: ObservableObject {
     }
 
     func saveSessionCookie(_ cookie: String) {
-        NSLog("ClaudeUsage: Saving cookie, length: \(cookie.count)")
+        Log.info("ClaudeUsage: saving cookie", .count(cookie.count))
         sessionCookie = cookie
         UserDefaults.standard.set(cookie, forKey: "claude_session_cookie")
         UserDefaults.standard.synchronize()
-        NSLog("ClaudeUsage: Cookie saved successfully")
+        Log.info("ClaudeUsage: cookie saved successfully")
     }
 
     func clearSessionCookie() {
-        NSLog("ClaudeUsage: Clearing cookie")
+        Log.info("ClaudeUsage: clearing cookie")
         sessionCookie = ""
         UserDefaults.standard.removeObject(forKey: "claude_session_cookie")
         UserDefaults.standard.synchronize()
@@ -435,7 +501,7 @@ class UsageManager: ObservableObject {
         // Update status bar to show 0%
         delegate?.updateStatusIcon(percentage: 0)
 
-        NSLog("ClaudeUsage: Cookie cleared, data reset")
+        Log.info("ClaudeUsage: cookie cleared, data reset")
     }
 
     func fetchOrganizationId(completion: @escaping (String?) -> Void) {
@@ -445,7 +511,7 @@ class UsageManager: ObservableObject {
             let trimmed = part.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("lastActiveOrg=") {
                 let orgId = trimmed.replacingOccurrences(of: "lastActiveOrg=", with: "")
-                NSLog("📋 Found org ID in cookie: \(orgId)")
+                Log.info("Found org ID in cookie", .identifier(orgId))
                 completion(orgId)
                 return
             }
@@ -545,11 +611,17 @@ class UsageManager: ObservableObject {
                     return
                 }
 
-                NSLog("📡 Status: \(httpResponse.statusCode)")
+                Log.info("Usage API response", .count(httpResponse.statusCode))
 
+                // Response body is intentionally NOT logged. It contains the
+                // full usage JSON tied to the user's cookie and would land in
+                // unified log. Diagnostics for debugging live parse issues
+                // must go through the DEBUG-only path.
+                #if DEBUG
                 if let data = data, let responseString = String(data: data, encoding: .utf8) {
-                    NSLog("📦 Response: \(responseString)")
+                    Log.debug("Usage API body (DEBUG only): \(responseString)")
                 }
+                #endif
 
                 if httpResponse.statusCode == 200, let data = data {
                     self?.parseUsageData(data)
@@ -1729,7 +1801,7 @@ struct UsageView: View {
 
                             HStack(spacing: 8) {
                                 Button("Save Cookie & Fetch") {
-                                    NSLog("ClaudeUsage: Save clicked, input length: \(sessionCookieInput.count)")
+                                    Log.info("ClaudeUsage: save clicked", .count(sessionCookieInput.count))
                                     if sessionCookieInput.isEmpty {
                                         usageManager.errorMessage = "Cookie field is empty!"
                                     } else {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -64,6 +64,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // it reads Zed's own Keychain login on first fetch (one-time macOS
         // prompt), so it is inert until enabled and the prompt is allowed.
         providers.append(ProviderBox(ZedUsageStore()))
+        // PR 6-UI: register xAI. Opt-in; requires a pasted inference key, with
+        // an optional gated management key for balance/history. Inert until
+        // enabled and configured.
+        providers.append(ProviderBox(XAIUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2338,11 +2342,20 @@ struct ProviderToggleRow: View {
     // with the stored secret — we only ever write, never read it back out.
     @State private var keyInput: String = ""
     @State private var hasStoredKey: Bool = false
+    // Secondary (gated, higher-privilege) key state — xAI's management key.
+    @State private var secondaryInput: String = ""
+    @State private var hasStoredSecondaryKey: Bool = false
 
     /// The provider as a PasteKeyProvider, when it is configured by pasting a
     /// secret; nil otherwise.
     private var pasteKeyProvider: PasteKeyProvider? {
         box.provider as? PasteKeyProvider
+    }
+
+    /// The provider as a SecondaryKeyProvider, when it accepts an optional
+    /// second (gated) key; nil otherwise.
+    private var secondaryKeyProvider: SecondaryKeyProvider? {
+        box.provider as? SecondaryKeyProvider
     }
 
     var body: some View {
@@ -2404,12 +2417,53 @@ struct ProviderToggleRow: View {
                     Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
                         .font(.caption2)
                         .foregroundColor(.secondary)
+
+                    // Secondary (gated, higher-privilege) key. Shown only once
+                    // the primary key is stored, and only for providers that
+                    // accept one (xAI's management key). Carries an explicit
+                    // warning before the field.
+                    if hasStoredKey, let secondary = secondaryKeyProvider {
+                        Divider()
+                        Text(secondary.secondaryKeyLabel)
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                        Text(secondary.secondaryKeyWarning)
+                            .font(.caption2)
+                            .foregroundColor(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                        HStack(spacing: 6) {
+                            SecureField(secondary.secondaryKeyPlaceholder, text: $secondaryInput)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.caption2)
+                            Button("Save") {
+                                secondary.saveSecondaryKey(secondaryInput)
+                                secondaryInput = ""
+                                hasStoredSecondaryKey = secondary.hasSecondaryKey
+                                onChange(true)
+                            }
+                            .controlSize(.small)
+                            .disabled(secondaryInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                            if hasStoredSecondaryKey {
+                                Button("Clear") {
+                                    secondary.saveSecondaryKey("")
+                                    hasStoredSecondaryKey = secondary.hasSecondaryKey
+                                    onChange(true)
+                                }
+                                .controlSize(.small)
+                            }
+                        }
+                        Text(hasStoredSecondaryKey ? "Management key saved in Keychain." : "No management key saved.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
         }
         .onAppear {
             enabled = UserDefaults.standard.bool(forKey: box.provider.featureFlagKey)
             hasStoredKey = pasteKeyProvider?.hasKey ?? false
+            hasStoredSecondaryKey = secondaryKeyProvider?.hasSecondaryKey ?? false
         }
     }
 }

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -76,6 +76,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // session cookie from perplexity.ai. Doubly inert until the user
         // both enables and configures it. Backend from PR #61.
         providers.append(ProviderBox(PerplexityUsageStore()))
+        // PR 9-UI: register GitHub Copilot. Opt-in
+        // (features.copilot.enabled defaults false); requires a pasted
+        // fine-grained PAT (Plan: Read). Doubly inert until the user
+        // both enables and configures it. Backend from PR #64.
+        providers.append(ProviderBox(CopilotUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -2,72 +2,11 @@ import SwiftUI
 import AppKit
 import WebKit
 import Carbon
-import CryptoKit
-import Foundation
 
-// MARK: - Logging (categorical redaction)
-//
-// PR 1 replaces every NSLog site that touched cookies, org IDs, or response
-// bodies with the categorical logger below. The call site cannot interpolate
-// a raw String; every value goes through a category, and each category has
-// its own emission rule. This makes accidental credential logging a compile-
-// time impossibility rather than a discipline problem.
-//
-// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
-// reintroduce raw-interpolation NSLog calls or the deleted response-body
-// log line at the network fetch site. The exact banned pattern lives in
-// the workflow file to avoid embedding it here (which would self-trigger).
-
-enum LogValue {
-    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
-    case `public`(String)
-    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
-    /// bodies, tokens, API keys, anything that could leak a credential.
-    case sensitive(String)
-    /// Emitted as a short SHA-256 prefix so the value can be correlated
-    /// across log lines without revealing it. Use for org IDs, user IDs.
-    case identifier(String)
-    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
-    /// retry counts, threshold values).
-    case count(Int)
-
-    var rendered: String {
-        switch self {
-        case .public(let s):
-            return s
-        case .sensitive(let s):
-            return "<redacted: \(s.count) chars>"
-        case .identifier(let s):
-            let digest = SHA256.hash(data: Data(s.utf8))
-            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
-            return "<id: \(hex.prefix(8))>"
-        case .count(let n):
-            return String(n)
-        }
-    }
-}
-
-enum Log {
-    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
-    /// gate. Accepts a plain message — no interpolation of untrusted values.
-    static func debug(_ message: String) {
-        #if DEBUG
-        NSLog("[debug] %@", message)
-        #endif
-    }
-
-    /// Info-level diagnostics. Retained in release builds. Values must be
-    /// wrapped in a `LogValue` category, forcing an explicit redaction
-    /// decision at the call site.
-    static func info(_ message: String, _ values: LogValue...) {
-        let rendered = values.map(\.rendered).joined(separator: ", ")
-        if rendered.isEmpty {
-            NSLog("%@", message)
-        } else {
-            NSLog("%@ | %@", message, rendered)
-        }
-    }
-}
+// The categorical logger (enum Log, enum LogValue) lives in Log.swift so
+// the SwiftPM library target can compile it without also compiling this
+// file's @main entry point. Both files are compiled together by
+// app/build.sh into the final .app bundle.
 
 // Main entry point
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -71,6 +71,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // PR 7-UI: register OpenAI Platform. Opt-in; requires a pasted Admin
         // key (sk-admin-). Inert until enabled and configured.
         providers.append(ProviderBox(OpenAIUsageStore()))
+        // PR 8-UI: register Perplexity Pro/Max. Opt-in
+        // (features.perplexity.enabled defaults false); requires a pasted
+        // session cookie from perplexity.ai. Doubly inert until the user
+        // both enables and configures it. Backend from PR #61.
+        providers.append(ProviderBox(PerplexityUsageStore()))
         // Model SwiftUI observes for the generic (non-Anthropic) provider
         // tiles. Anthropic continues to render through usageManager directly.
         providersModel = ProvidersModel(providers: providers)
@@ -2421,7 +2426,9 @@ struct ProviderToggleRow: View {
                             .controlSize(.small)
                         }
                     }
-                    Text(hasStoredKey ? "Key saved in Keychain." : "No key saved yet.")
+                    // Use the provider's declared noun ("Key" / "Cookie") so
+                    // the status line reflects what the user actually pasted.
+                    Text(hasStoredKey ? "\(keyProvider.secretKindNoun) saved in Keychain." : "No \(keyProvider.secretKindNoun.lowercased()) saved yet.")
                         .font(.caption2)
                         .foregroundColor(.secondary)
 

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -576,7 +576,11 @@ class UsageManager: ObservableObject {
         request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36", forHTTPHeaderField: "User-Agent")
         request.setValue("claude.ai", forHTTPHeaderField: "authority")
 
-        NSLog("🔍 Fetching from: \(urlString)")
+        // Do NOT log the full URL: it embeds the org id (a sensitive
+        // account identifier). Log a fixed endpoint label plus the org id
+        // through the categorical logger, which emits only a short SHA-256
+        // prefix rather than the plaintext id.
+        Log.info("Fetching Anthropic usage", .identifier(orgId))
 
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             DispatchQueue.main.async {

--- a/app/ClineUsageFetcher.swift
+++ b/app/ClineUsageFetcher.swift
@@ -397,13 +397,20 @@ public struct ClineUsageFetcher: Sendable {
         sourceFile: String,
         malformedRecordCount: inout Int
     ) -> [ClineUsageRecord]? {
+        // chk1 Bug #1: cast to `[Any]` at the top level, then per-element
+        // `as? [String: Any]` guard. Casting straight to `[[String: Any]]`
+        // is all-or-nothing — a single `null` / string / number in the
+        // array collapses the entire file to unreadable. A schema drift
+        // or a hand-edited log would otherwise silently drop hundreds of
+        // valid records.
         guard let data = contents.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data),
-              let arr = obj as? [[String: Any]] else {
+              let anyArr = obj as? [Any] else {
             return nil
         }
         var out: [ClineUsageRecord] = []
-        for msg in arr {
+        for element in anyArr {
+            guard let msg = element as? [String: Any] else { continue }
             // Only `type == "say"` records carry usage.
             guard let type = msg["type"] as? String, type == "say" else { continue }
             guard let sayRaw = msg["say"] as? String,
@@ -546,14 +553,17 @@ public struct ClineUsageFetcher: Sendable {
         var buffer = Data()
         buffer.reserveCapacity(chunkSize * 2)
         while true {
+            // chk1 Bug #3: the fallback `readData(ofLength:)` branch was
+            // gated on `#available(macOS 10.15.4, *)` but the app targets
+            // macOS 12.0 (see `app/build.sh` — `-target arm64-apple-macos12.0`),
+            // so the branch was unreachable dead code AND its
+            // `readData(ofLength:)` raises Objective-C NSException on error
+            // (uncatchable in Swift), unlike the throwing
+            // `read(upToCount:)`. Deleted entirely.
             let chunk: Data
             do {
-                if #available(macOS 10.15.4, *) {
-                    guard let read = try handle.read(upToCount: chunkSize) else { break }
-                    chunk = read
-                } else {
-                    chunk = handle.readData(ofLength: chunkSize)
-                }
+                guard let read = try handle.read(upToCount: chunkSize) else { break }
+                chunk = read
             } catch {
                 return nil
             }

--- a/app/ClineUsageFetcher.swift
+++ b/app/ClineUsageFetcher.swift
@@ -1,0 +1,616 @@
+// PR 10c-BE — Cline local usage fetcher (feature-flagged off).
+//
+// Second local-file provider (Milestone 6). Reads the Cline VS Code
+// extension's own on-disk usage records — `ui_messages.json` under the
+// per-task directory — and produces a token-and-cost rollup. Nothing
+// leaves the machine.
+//
+// Data source
+// -----------
+// Cline persists one JSON file per session at:
+//
+//   {globalStorage}/saoudrizwan.claude-dev/tasks/{taskId}/ui_messages.json
+//
+// where `{globalStorage}` is one of the following (searched in order):
+//
+//   1. `$CLINE_DATA_DIR` (Cline CLI/SDK override — v4+). Layout is
+//      `{CLINE_DATA_DIR}/tasks/{taskId}/ui_messages.json`. No extension
+//      id under this override (the CLI is a first-class citizen of
+//      Cline).
+//   2. `$CLINE_DIR/data` (Cline CLI/SDK convention).
+//   3. `~/.cline/data` (Cline CLI/SDK default when neither env-var is
+//      set).
+//   4. `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev`
+//      (VS Code stable).
+//   5. `~/Library/Application Support/Code - Insiders/User/globalStorage/saoudrizwan.claude-dev`.
+//   6. `~/Library/Application Support/VSCodium/User/globalStorage/saoudrizwan.claude-dev`.
+//   7. `~/Library/Application Support/Cursor/User/globalStorage/saoudrizwan.claude-dev`.
+//   8. `~/Library/Application Support/Windsurf/User/globalStorage/saoudrizwan.claude-dev`.
+//
+// Every path is treated as an INDEPENDENT scan root — a user with Cline
+// installed under BOTH VS Code stable and Insiders sees combined usage.
+// Deduplication is unnecessary because each host writes its own set of
+// task ids under its own scan root (task ids are UUIDs; a collision
+// across hosts would require re-using the same globalStorage folder).
+//
+// File format
+// -----------
+// `ui_messages.json` is a JSON ARRAY of `ClineMessage` objects — NOT
+// line-delimited JSON. Every element is a message with fields:
+//
+//   { "ts": 1_700_000_000_000,
+//     "type": "say" | "ask",
+//     "say": "api_req_started" | "deleted_api_reqs" | "subagent_usage" | …,
+//     "text": "{\"tokensIn\":10,\"tokensOut\":20,\"cost\":0.001,…}",
+//     "modelInfo": {"modelId": "claude-opus-4-7", "providerId": "…", "mode": "…"}
+//   }
+//
+// Only records of `type=="say"` AND `say` in the three usage-carrying
+// variants above contribute to the rollup, per Cline's own
+// `getApiMetrics` implementation
+// (github.com/cline/cline apps/vscode/src/shared/getApiMetrics.ts).
+//
+// The `text` field is a JSON-ENCODED STRING (double-encoded) that
+// parses to `{tokensIn, tokensOut, cacheWrites, cacheReads, cost}`.
+// Every field is optional and every field is a JSON Number. Cost is
+// already computed by the extension in USD — no pricing table needed
+// (unlike Claude Code, which requires our LiteLLM snapshot).
+//
+// Model attribution — `message.modelInfo?.modelId` is the raw model
+// name (e.g. "claude-opus-4-7", "gpt-5", "gemini-2.5-pro"). Absent on
+// older Cline versions; the rollup falls back to "unknown".
+//
+// Partial writes — Cline uses atomic-rename-via-tmp for `ui_messages.json`
+// (issue #7101 fix). A concurrent read during a rename either sees the
+// old file OR the new file; a torn write never surfaces. We still
+// tolerate a JSON parse failure (returns nil, file skipped) so an older
+// Cline version without the atomic-rename fix does not crash the tile.
+//
+// Feature posture
+// ---------------
+// `features.cline.enabled` defaults false. Nothing registers a
+// `ClineUsageStore` into the live registry yet (that lands in PR
+// 10c-UI). This file compiles and unit-tests but is inert at runtime
+// until enabled.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// One usage record extracted from a `say=="api_req_started" |
+/// "deleted_api_reqs" | "subagent_usage"` message in `ui_messages.json`.
+public struct ClineUsageRecord: Equatable, Sendable {
+    /// Model identifier as reported by Cline's `modelInfo.modelId`. Falls
+    /// back to "unknown" when the message predates the modelInfo field
+    /// (Cline versions before ~v3.5).
+    public var model: String
+    /// Wall-clock timestamp of the record from `message.ts` (ms since
+    /// epoch, converted to `Date`). Nil if the field was missing or
+    /// out-of-range (before 2000-01-01 or after 2100-01-01 — a schema
+    /// break we don't want to leak into the bucketing).
+    public var timestamp: Date?
+    /// The three usage-carrying say kinds. Kept so the rollup can
+    /// diagnose an unexpected mix of message kinds without re-parsing.
+    public var sayKind: SayKind
+    /// tokensIn (regular input tokens excluding cache).
+    public var tokensIn: Int
+    /// tokensOut (output tokens).
+    public var tokensOut: Int
+    /// cacheWrites (cache-creation tokens).
+    public var cacheWrites: Int
+    /// cacheReads (cache-read tokens).
+    public var cacheReads: Int
+    /// Cost in USD as computed by the Cline extension. Cline already
+    /// applies the correct per-model rate (LiteLLM-derived); we take
+    /// its number verbatim.
+    public var costUSD: Double
+    /// Absolute path of the source file. Used for diagnostics + the
+    /// per-file breakdown in the snapshot.
+    public var sourceFile: String
+
+    public enum SayKind: String, Sendable, Equatable {
+        case apiReqStarted = "api_req_started"
+        case deletedApiReqs = "deleted_api_reqs"
+        case subagentUsage = "subagent_usage"
+    }
+
+    public init(
+        model: String,
+        timestamp: Date?,
+        sayKind: SayKind,
+        tokensIn: Int,
+        tokensOut: Int,
+        cacheWrites: Int,
+        cacheReads: Int,
+        costUSD: Double,
+        sourceFile: String
+    ) {
+        self.model = model
+        self.timestamp = timestamp
+        self.sayKind = sayKind
+        self.tokensIn = tokensIn
+        self.tokensOut = tokensOut
+        self.cacheWrites = cacheWrites
+        self.cacheReads = cacheReads
+        self.costUSD = costUSD
+        self.sourceFile = sourceFile
+    }
+
+    /// Sum of every token category. Uses `ClaudeCodeUsageRecord.saturatingAdd`
+    /// so a hostile 1e300 in the wire data cannot wrap to a negative
+    /// count.
+    public var totalTokens: Int {
+        var s = ClaudeCodeUsageRecord.saturatingAdd(0, tokensIn)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, tokensOut)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, cacheWrites)
+        s = ClaudeCodeUsageRecord.saturatingAdd(s, cacheReads)
+        return s
+    }
+}
+
+/// Aggregate roll-up produced by `ClineUsageFetcher.parse(files:)`.
+public struct ClineUsageSnapshot: Equatable, Sendable {
+    /// All records after malformed-line filtering, sorted by timestamp
+    /// ascending (records without a timestamp sink to the end).
+    public var records: [ClineUsageRecord]
+    /// Path-relative file counts (absolute path → contributing record
+    /// count).
+    public var recordsPerFile: [String: Int]
+    /// Number of usage-carrying messages that failed to JSON-decode
+    /// their `text` field. Benign on a live file (Cline sometimes
+    /// updates message.text as the request progresses; a partial write
+    /// mid-stream may leave the text in an intermediate state). A
+    /// climbing count suggests a schema break.
+    public var malformedRecordCount: Int
+    /// Number of files that could not be parsed at all (JSON at the
+    /// top level failed).
+    public var unreadableFileCount: Int
+
+    public init(
+        records: [ClineUsageRecord],
+        recordsPerFile: [String: Int] = [:],
+        malformedRecordCount: Int = 0,
+        unreadableFileCount: Int = 0
+    ) {
+        self.records = records
+        self.recordsPerFile = recordsPerFile
+        self.malformedRecordCount = malformedRecordCount
+        self.unreadableFileCount = unreadableFileCount
+    }
+
+    /// Sum of tokens over records whose `timestamp` falls within `range`.
+    /// Uses saturating addition per the Claude Code precedent so an
+    /// Int-overflow cannot wrap negative.
+    public func tokens(in range: ClosedRange<Date>) -> Int {
+        var s = 0
+        for r in records {
+            guard let ts = r.timestamp, range.contains(ts) else { continue }
+            s = ClaudeCodeUsageRecord.saturatingAdd(s, r.totalTokens)
+        }
+        return s
+    }
+
+    /// Sum of cost over records whose `timestamp` falls within `range`.
+    public func cost(in range: ClosedRange<Date>) -> Double {
+        var s = 0.0
+        for r in records {
+            guard let ts = r.timestamp, range.contains(ts) else { continue }
+            s += r.costUSD
+        }
+        return s
+    }
+
+    public struct ModelBreakdown: Equatable, Sendable {
+        public var model: String
+        public var costUSD: Double
+        public var tokens: Int
+        public init(model: String, costUSD: Double, tokens: Int) {
+            self.model = model
+            self.costUSD = costUSD
+            self.tokens = tokens
+        }
+    }
+    public func breakdownByModel(in range: ClosedRange<Date>) -> [ModelBreakdown] {
+        var byModel: [String: (cost: Double, tokens: Int)] = [:]
+        for r in records {
+            guard let ts = r.timestamp, range.contains(ts) else { continue }
+            var entry = byModel[r.model] ?? (0.0, 0)
+            entry.cost += r.costUSD
+            entry.tokens = ClaudeCodeUsageRecord.saturatingAdd(entry.tokens, r.totalTokens)
+            byModel[r.model] = entry
+        }
+        return byModel
+            .map { ModelBreakdown(model: $0.key, costUSD: $0.value.cost, tokens: $0.value.tokens) }
+            .sorted { $0.costUSD > $1.costUSD }
+    }
+}
+
+// MARK: - Path resolution
+
+public enum ClinePathResolver {
+
+    /// Environment snapshot passed to `resolveScanRoots`. Tests build
+    /// this explicitly with fake env-vars and home; production uses
+    /// `Environment.current()`.
+    public struct Environment: Sendable {
+        public var clineDataDir: String?
+        public var clineDir: String?
+        public var homeDirectoryPath: String
+        /// Optional override for `~/Library/Application Support` — tests
+        /// point this at a temp directory to fabricate the VS Code /
+        /// Cursor / Windsurf layouts without touching the real user home.
+        public var applicationSupportPath: String
+        public init(
+            clineDataDir: String?,
+            clineDir: String?,
+            homeDirectoryPath: String,
+            applicationSupportPath: String
+        ) {
+            self.clineDataDir = clineDataDir
+            self.clineDir = clineDir
+            self.homeDirectoryPath = homeDirectoryPath
+            self.applicationSupportPath = applicationSupportPath
+        }
+
+        public static func current() -> Environment {
+            let env = ProcessInfo.processInfo.environment
+            let home = NSHomeDirectory()
+            return Environment(
+                clineDataDir: env["CLINE_DATA_DIR"].flatMap { $0.isEmpty ? nil : $0 },
+                clineDir: env["CLINE_DIR"].flatMap { $0.isEmpty ? nil : $0 },
+                homeDirectoryPath: home,
+                applicationSupportPath: (home as NSString).appendingPathComponent("Library/Application Support")
+            )
+        }
+    }
+
+    /// A single candidate scan root, with a stable id used for
+    /// diagnostics ("VS Code stable", "Cline CLI", "Cursor"). The id is
+    /// user-facing on the per-file diagnostic tile.
+    public struct ScanRoot: Equatable, Sendable {
+        public var id: String
+        public var tasksDirectoryPath: String
+        public init(id: String, tasksDirectoryPath: String) {
+            self.id = id
+            self.tasksDirectoryPath = tasksDirectoryPath
+        }
+    }
+
+    /// Return every plausible scan root — the caller decides which of
+    /// them actually exist and are readable. Duplicates are removed
+    /// (e.g. `$CLINE_DIR/data` and `~/.cline/data` collapse to one if
+    /// `$CLINE_DIR` resolves to `$HOME/.cline`).
+    ///
+    /// Codex round-1 finding #2: dedupe uses (1) filesystem identity
+    /// (`URLResourceKey.fileResourceIdentifierKey`) when the path
+    /// exists, so a case-insensitive HFS+/APFS mount does not fool us
+    /// with `$CLINE_DIR=/users/…` vs the default `/Users/…`, and (2)
+    /// case-folded standardized-path fallback for paths that do not
+    /// yet exist (a fresh install with no tasks dir written yet).
+    public static func resolveScanRoots(_ env: Environment) -> [ScanRoot] {
+        var out: [ScanRoot] = []
+        // Filesystem identity keys — collected when a path (or its
+        // parent) exists. Two paths with the same identity are the
+        // same on-disk directory regardless of case or symlink.
+        var seenIdentity: Set<String> = []
+        // Case-folded path fallback used ONLY when identity lookup
+        // failed for the given path. Codex round-2 finding #1: on a
+        // case-SENSITIVE APFS volume, two directories with names
+        // differing only in case are DISTINCT, so the case-fold key
+        // must not collapse them. We therefore run the case-fold
+        // fallback only when we have no identity to compare (i.e.
+        // neither path nor parent exists yet — a fresh install
+        // scenario, where the user is not yet configured on this
+        // Mac).
+        var seenPathKey: Set<String> = []
+        func add(_ id: String, _ rawBase: String) {
+            let tasks = (rawBase as NSString).appendingPathComponent("tasks")
+            let normalized = (tasks as NSString).standardizingPath
+            if let identity = fileIdentity(of: normalized) {
+                if !seenIdentity.insert(identity).inserted { return }
+                // Path exists — trust identity dedupe alone. Do NOT
+                // also apply the case-fold fallback (round-2 #1).
+                out.append(ScanRoot(id: id, tasksDirectoryPath: normalized))
+                return
+            }
+            // No identity available: fall back to case-folded path key.
+            let caseFolded = normalized.lowercased()
+            if !seenPathKey.insert(caseFolded).inserted { return }
+            out.append(ScanRoot(id: id, tasksDirectoryPath: normalized))
+        }
+        /// Return a stable identity string for `path`, based on
+        /// `stat()` device + inode when the path (or its parent) is
+        /// reachable. Codex round-2 finding #2: `stat` is direct and
+        /// avoids the URLResourceValues casting fragility on
+        /// non-APFS filesystems (network mounts, exotic loopback).
+        /// Returns nil when we cannot stat the path OR its parent.
+        func fileIdentity(of path: String) -> String? {
+            // Codex round-3 finding: use `stat()` (follows symlinks),
+            // not `lstat()`. Otherwise `~/.cline/data/tasks` and its
+            // symlink target (e.g. via `$CLINE_DATA_DIR`) look like
+            // distinct inodes and both survive dedupe, causing the
+            // same ui_messages.json files to be counted twice.
+            var st = stat()
+            let candidates: [String]
+            if stat(path, &st) == 0 {
+                candidates = [path]
+            } else {
+                let parent = (path as NSString).deletingLastPathComponent
+                candidates = [parent]
+            }
+            for candidate in candidates {
+                var s = stat()
+                guard stat(candidate, &s) == 0 else { continue }
+                let dev = UInt64(s.st_dev)
+                let ino = UInt64(s.st_ino)
+                if candidate == path {
+                    return "\(dev):\(ino)"
+                }
+                // Parent hit: append the tail so two *sibling*
+                // non-existing children under the same parent do NOT
+                // dedupe together (they will resolve to distinct
+                // (parent-dev:parent-ino:tail) strings).
+                let tail = (path as NSString).lastPathComponent
+                return "\(dev):\(ino):\(tail)"
+            }
+            return nil
+        }
+        if let dir = env.clineDataDir, !dir.isEmpty {
+            add("Cline CLI ($CLINE_DATA_DIR)", dir)
+        }
+        if let dir = env.clineDir, !dir.isEmpty {
+            add("Cline CLI ($CLINE_DIR)", (dir as NSString).appendingPathComponent("data"))
+        }
+        if !env.homeDirectoryPath.isEmpty {
+            add("Cline CLI (~/.cline)", (env.homeDirectoryPath as NSString).appendingPathComponent(".cline/data"))
+        }
+        // VS Code family — each host has its own globalStorage.
+        let hosts: [(String, String)] = [
+            ("VS Code", "Code"),
+            ("VS Code Insiders", "Code - Insiders"),
+            ("VSCodium", "VSCodium"),
+            ("Cursor", "Cursor"),
+            ("Windsurf", "Windsurf"),
+        ]
+        for (label, folder) in hosts {
+            if !env.applicationSupportPath.isEmpty {
+                let base = "\(env.applicationSupportPath)/\(folder)/User/globalStorage/saoudrizwan.claude-dev"
+                add(label, base)
+            }
+        }
+        return out
+    }
+}
+
+// MARK: - JSON parsing
+
+/// Sendable value-type fetcher. All parsing is pure.
+public struct ClineUsageFetcher: Sendable {
+
+    /// Parse a single `ui_messages.json` file's contents. `contents` is
+    /// the raw text of the file. Returns the records that parsed
+    /// successfully; malformed usage-carrying messages count in the
+    /// `malformedRecordCount` output. A non-JSON top-level content
+    /// yields nil (the caller counts it as an unreadable file).
+    public static func parse(
+        uiMessages contents: String,
+        sourceFile: String,
+        malformedRecordCount: inout Int
+    ) -> [ClineUsageRecord]? {
+        guard let data = contents.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data),
+              let arr = obj as? [[String: Any]] else {
+            return nil
+        }
+        var out: [ClineUsageRecord] = []
+        for msg in arr {
+            // Only `type == "say"` records carry usage.
+            guard let type = msg["type"] as? String, type == "say" else { continue }
+            guard let sayRaw = msg["say"] as? String,
+                  let sayKind = ClineUsageRecord.SayKind(rawValue: sayRaw) else { continue }
+            // The three usage-carrying kinds all encode their data in
+            // the `text` field as a JSON string.
+            guard let text = msg["text"] as? String else { continue }
+            guard let payload = text.data(using: .utf8),
+                  let payloadObj = try? JSONSerialization.jsonObject(with: payload),
+                  let payloadDict = payloadObj as? [String: Any] else {
+                malformedRecordCount += 1
+                continue
+            }
+            let tokensIn = ClaudeCodeUsageFetcher.safeInt(payloadDict["tokensIn"])
+            let tokensOut = ClaudeCodeUsageFetcher.safeInt(payloadDict["tokensOut"])
+            let cacheWrites = ClaudeCodeUsageFetcher.safeInt(payloadDict["cacheWrites"])
+            let cacheReads = ClaudeCodeUsageFetcher.safeInt(payloadDict["cacheReads"])
+            let cost = safeCost(payloadDict["cost"])
+
+            // Skip empty rows — a message.text that decoded successfully
+            // but had every numeric field zero/absent is Cline's own
+            // "no charge" marker (typical of a request that failed
+            // before any tokens were emitted). Counting it as a record
+            // would inflate the per-file diagnostic without changing
+            // the rollup, so we drop it.
+            if tokensIn == 0 && tokensOut == 0 && cacheWrites == 0
+                && cacheReads == 0 && cost == 0 {
+                continue
+            }
+
+            let timestamp = extractTimestamp(msg["ts"])
+            let model = extractModel(msg)
+
+            out.append(ClineUsageRecord(
+                model: model,
+                timestamp: timestamp,
+                sayKind: sayKind,
+                tokensIn: tokensIn,
+                tokensOut: tokensOut,
+                cacheWrites: cacheWrites,
+                cacheReads: cacheReads,
+                costUSD: cost,
+                sourceFile: sourceFile
+            ))
+        }
+        return out
+    }
+
+    /// Parse a set of `ui_messages.json` files into a full snapshot.
+    /// I/O errors on individual files are counted, not thrown.
+    public static func parse(files: [URL]) -> ClineUsageSnapshot {
+        var allRecords: [ClineUsageRecord] = []
+        var perFile: [String: Int] = [:]
+        var malformed = 0
+        var unreadable = 0
+
+        for url in files {
+            // Codex round-1 finding #3: read the file bytes directly
+            // (bounded by a 64 MB Cline-specific cap) rather than
+            // routing through the JSONL line-splitter — Cline's
+            // ui_messages.json is a single JSON array, not
+            // line-delimited, so splitting-then-rejoining is wasted
+            // memory. 64 MB is well above any realistic Cline session
+            // (~50 000 assistant turns) and matches ccusage's own cap.
+            guard let text = readClineUiMessagesText(from: url) else {
+                unreadable += 1
+                continue
+            }
+            let recs = parse(
+                uiMessages: text,
+                sourceFile: url.path,
+                malformedRecordCount: &malformed
+            )
+            guard let recs = recs else {
+                unreadable += 1
+                continue
+            }
+            perFile[url.path] = recs.count
+            allRecords.append(contentsOf: recs)
+        }
+
+        allRecords.sort { lhs, rhs in
+            switch (lhs.timestamp, rhs.timestamp) {
+            case let (l?, r?): return l < r
+            case (nil, _?):    return false
+            case (_?, nil):    return true
+            case (nil, nil):   return false
+            }
+        }
+        return ClineUsageSnapshot(
+            records: allRecords,
+            recordsPerFile: perFile,
+            malformedRecordCount: malformed,
+            unreadableFileCount: unreadable
+        )
+    }
+
+    /// Enumerate every `ui_messages.json` under every scan root's
+    /// `tasks/{taskId}/` subtree. A missing scan root or missing tasks
+    /// directory yields no files (not an error). Individual unreadable
+    /// entries are skipped.
+    public static func discoverFiles(under scanRoots: [ClinePathResolver.ScanRoot]) -> [URL] {
+        let fm = FileManager.default
+        var out: [URL] = []
+        for root in scanRoots {
+            let tasksDir = root.tasksDirectoryPath
+            guard fm.fileExists(atPath: tasksDir) else { continue }
+            guard let contents = try? fm.contentsOfDirectory(atPath: tasksDir) else { continue }
+            for entry in contents {
+                let taskDir = (tasksDir as NSString).appendingPathComponent(entry)
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: taskDir, isDirectory: &isDir), isDir.boolValue else { continue }
+                let candidate = (taskDir as NSString).appendingPathComponent("ui_messages.json")
+                if fm.fileExists(atPath: candidate) {
+                    out.append(URL(fileURLWithPath: candidate))
+                }
+            }
+        }
+        out.sort { $0.path < $1.path }
+        return out
+    }
+
+    /// Read a Cline `ui_messages.json` file into a decoded string.
+    /// Streams via FileHandle in 1 MiB chunks, aborting once the
+    /// cumulative buffer exceeds a 64 MB cap (well above any real
+    /// Cline session; matches ccusage's own cap for the same file).
+    /// UTF-8 decoding is tolerant — invalid bytes become U+FFFD, so a
+    /// torn write near end-of-file surfaces as invalid JSON rather
+    /// than a nil return that discards the whole file. Returns nil
+    /// only when the file cannot be opened.
+    static func readClineUiMessagesText(from url: URL) -> String? {
+        let sizeCap: Int64 = 64 * 1024 * 1024
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        if let size = (attrs?[.size] as? NSNumber)?.int64Value, size > sizeCap {
+            return nil
+        }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        let chunkSize = 1024 * 1024
+        var buffer = Data()
+        buffer.reserveCapacity(chunkSize * 2)
+        while true {
+            let chunk: Data
+            do {
+                if #available(macOS 10.15.4, *) {
+                    guard let read = try handle.read(upToCount: chunkSize) else { break }
+                    chunk = read
+                } else {
+                    chunk = handle.readData(ofLength: chunkSize)
+                }
+            } catch {
+                return nil
+            }
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+            if Int64(buffer.count) > sizeCap { return nil }
+        }
+        return String(decoding: buffer, as: UTF8.self)
+    }
+
+    // MARK: - Field helpers
+
+    /// Cline stores `ts` as milliseconds since epoch (JavaScript
+    /// `Date.now()` output). Clamp to a sane range so a schema break
+    /// cannot inject a distant-past or distant-future record into the
+    /// today/MTD bucketing. Public so tests exercise the range clamp
+    /// against hostile inputs (NaN, infinity, 1e18, negatives).
+    public static func extractTimestamp(_ raw: Any?) -> Date? {
+        let msSince1970: Double
+        if let d = raw as? Double { msSince1970 = d }
+        else if let i = raw as? Int { msSince1970 = Double(i) }
+        else if let s = raw as? String, let parsed = Double(s) { msSince1970 = parsed }
+        else { return nil }
+        guard msSince1970.isFinite else { return nil }
+        let seconds = msSince1970 / 1000.0
+        // Reject anything before 2000-01-01 or after 2100-01-01 —
+        // outside this range the value is unlikely to be a real Cline
+        // timestamp (typical values are in the 1.7e12 ms range).
+        let year2000: Double = 946_684_800   // 2000-01-01T00:00:00Z
+        let year2100: Double = 4_102_444_800 // 2100-01-01T00:00:00Z
+        guard seconds >= year2000 && seconds < year2100 else { return nil }
+        return Date(timeIntervalSince1970: seconds)
+    }
+
+    /// Extract `modelInfo.modelId` when present. Falls back to
+    /// "unknown" so a Cline version predating modelInfo (~<v3.5) still
+    /// contributes to token/cost rollups. Public so tests exercise the
+    /// fallback path.
+    public static func extractModel(_ msg: [String: Any]) -> String {
+        guard let modelInfo = msg["modelInfo"] as? [String: Any] else { return "unknown" }
+        if let id = modelInfo["modelId"] as? String, !id.isEmpty { return id }
+        return "unknown"
+    }
+
+    /// Cost is a JSON Number in USD. Reject NaN / infinity / negative
+    /// (a hostile or corrupt log). Clamp very large finite values to a
+    /// $1_000_000 cap so a single bad record cannot silently dominate
+    /// every rollup. Public so tests can exercise every rejection
+    /// branch.
+    public static func safeCost(_ raw: Any?) -> Double {
+        var value: Double
+        if let d = raw as? Double { value = d }
+        else if let i = raw as? Int { value = Double(i) }
+        else if let s = raw as? String, let parsed = Double(s) { value = parsed }
+        else { return 0.0 }
+        guard value.isFinite else { return 0.0 }
+        if value <= 0 { return 0.0 }
+        return min(value, 1_000_000.0)
+    }
+}

--- a/app/ClineUsageStore.swift
+++ b/app/ClineUsageStore.swift
@@ -220,6 +220,32 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
             ))
         }
 
+        // 3cc round-1 finding #2: surface file-level parse failures.
+        // Without this, a corrupt / over-cap / permission-denied
+        // ui_messages.json is silently skipped and the tile shows the
+        // remaining totals as complete — the user has no way to know
+        // some sessions are missing. Both counts are diagnostics, not
+        // errors, so the tile is informational, not alarming.
+        let unreadable = snap.unreadableFileCount
+        let malformed = snap.malformedRecordCount
+        if unreadable > 0 || malformed > 0 {
+            var lines: [String] = []
+            if unreadable > 0 {
+                lines.append("\(unreadable) session file\(unreadable == 1 ? "" : "s") could not be read (corrupt, over 64 MB, or unreadable).")
+            }
+            if malformed > 0 {
+                lines.append("\(malformed) usage record\(malformed == 1 ? "" : "s") could not be parsed (a partial write may be in flight).")
+            }
+            out.append(UsageTile(
+                id: "cline-diagnostics",
+                title: "Some sessions skipped",
+                kind: .text(
+                    status: lines.first ?? "",
+                    subtitle: lines.dropFirst().joined(separator: "\n")
+                )
+            ))
+        }
+
         // Codex round-1 finding #1 partial-access tile is now emitted
         // as a priority tile above (round-2 finding #3), so it stays
         // visible during a slow parse too.
@@ -306,6 +332,9 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
         // hop can record which set produced the snapshot (Codex
         // round-2 finding #4).
         let grantedKeyCopy = grantedKey
+        // Capture dependencies for the re-probe below (3cc round-1
+        // finding #1).
+        let tccProbeCopy = self.tccProbe
         workQueue.async { [weak self] in
             let urls = discover(rootsCopy)
             let snap = parse(urls)
@@ -316,6 +345,31 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
                 // disables the provider cannot repopulate.
                 guard self.isEnabled else { return }
                 guard launchGeneration == self.fetchGeneration else { return }
+                // 3cc round-1 finding #1: TCC may have been revoked
+                // between fetch-start and now. discoverFiles(⋯) on a
+                // now-unreadable root returns [] silently, so we would
+                // otherwise write an empty snapshot as if the user had
+                // no usage. Re-probe every root that was granted at
+                // fetch-start; if any turned .denied, discard this
+                // parse result, surface .denied, and rely on the next
+                // fetch tick to reconcile.
+                var stillAllGranted = true
+                var newDeniedCount = 0
+                for root in rootsCopy {
+                    switch tccProbeCopy(root.tasksDirectoryPath) {
+                    case .granted:      break
+                    case .denied:       stillAllGranted = false; newDeniedCount += 1
+                    case .pathMissing:  break  // was granted; now missing — treat
+                                               // as "no data" not "access revoked"
+                    }
+                }
+                if !stillAllGranted {
+                    self.tccState = .denied
+                    self.deniedRootCount = self.deniedRootCount + newDeniedCount
+                    self.snapshot = nil
+                    self.lastAppliedGrantedRootsKey = nil
+                    return
+                }
                 self.snapshot = snap
                 self.lastAppliedGrantedRootsKey = grantedKeyCopy
                 // Codex round-5 finding #2: use the injected clock so

--- a/app/ClineUsageStore.swift
+++ b/app/ClineUsageStore.swift
@@ -119,21 +119,33 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
         switch tccState {
         case .denied:
             let copy = LocalProviderAccessGuide.copy(for: .denied, appName: displayName)
+            // Codex round-2 + round-3 + round-4 findings: name every
+            // supported location — editor family AND CLI — in the
+            // WRAPPING guidance line, not the monospace `path` line
+            // (which UsageTileView renders `.lineLimit(1)` with
+            // middle-truncation and hides most of the string in a
+            // 360px popover).
+            let clineGuidance = copy.guidance
+                + " Cline data lives under: `<host>/User/globalStorage/saoudrizwan.claude-dev/tasks/` for VS Code, VS Code Insiders, VSCodium, Cursor, or Windsurf; or `$CLINE_DATA_DIR/tasks/`, `$CLINE_DIR/data/tasks/`, or `~/.cline/data/tasks/` for the Cline CLI."
             return [UsageTile(
                 id: "cline-needs-access",
                 title: copy.title,
                 kind: .needsAccess(
-                    path: "Code / Cursor / Windsurf globalStorage",
-                    guidance: copy.guidance
+                    path: "~/Library/Application Support/…/saoudrizwan.claude-dev/tasks",
+                    guidance: clineGuidance
                 )
             )]
         case .pathMissing:
+            // Codex round-3 finding: "not installed" was misleading
+            // for an editor user who has Cline installed but has not
+            // yet started a task, so `tasks/` is missing. Reframe as
+            // "no sessions" with two remediation paths.
             return [UsageTile(
                 id: "cline-not-installed",
                 title: displayName,
                 kind: .text(
-                    status: "No Cline install found",
-                    subtitle: "Install the Cline extension in VS Code / Cursor / Windsurf, or run the Cline CLI at least once."
+                    status: "No Cline sessions found",
+                    subtitle: "If Cline is installed in VS Code, VS Code Insiders, VSCodium, Cursor, or Windsurf, start a Cline task and click Refresh. If you use the Cline CLI, run it at least once."
                 )
             )]
         case .granted:
@@ -218,12 +230,18 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
     // MARK: - UsageProvider: actions
 
     public func fetch() {
-        guard isEnabled else { return }
-
-        // Bump generation BEFORE any early-return path so an in-flight
-        // fetch cannot revive stale state after e.g. TCC denial. Copies
-        // the Claude Code round-2 finding #6 fix.
+        // Codex round-5 finding #1: bump generation even when disabled
+        // so a rapid disable → fetch()-while-disabled → re-enable →
+        // fetch() sequence cannot let a pre-disable in-flight fetch's
+        // completion apply. The isEnabled guard on the completion
+        // still exists, but generation-bump gives defence-in-depth
+        // against a future refactor that removes it.
         fetchGeneration &+= 1
+        guard isEnabled else {
+            snapshot = nil
+            lastAppliedGrantedRootsKey = nil
+            return
+        }
         let launchGeneration = fetchGeneration
 
         let scanRoots = resolveScanRoots()
@@ -298,7 +316,9 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
                 guard launchGeneration == self.fetchGeneration else { return }
                 self.snapshot = snap
                 self.lastAppliedGrantedRootsKey = grantedKeyCopy
-                self.lastUpdatedAt = Date()
+                // Codex round-5 finding #2: use the injected clock so
+                // deterministic tests get deterministic lastUpdatedAt.
+                self.lastUpdatedAt = self.clock()
                 self.lastError = nil
                 Log.info("Cline ui_messages parsed", .count(snap.records.count))
             }

--- a/app/ClineUsageStore.swift
+++ b/app/ClineUsageStore.swift
@@ -255,14 +255,16 @@ public final class ClineUsageStore: @preconcurrency UsageProvider {
         // usage from the readable roots, but we surface the partial-
         // access warning via `deniedRootsCount` on the snapshot for a
         // future diagnostic tile (kept as store state below).
+        // chk1 Bug #2: `pathMissing` roots are counted by the "if no
+        // granted and no denied" branch below via the `.pathMissing`
+        // aggregate state, so we do not need a separate counter here.
         var grantedRoots: [ClinePathResolver.ScanRoot] = []
         var deniedRoots: [ClinePathResolver.ScanRoot] = []
-        var pathMissingCount = 0
         for root in scanRoots {
             switch tccProbe(root.tasksDirectoryPath) {
             case .granted:      grantedRoots.append(root)
             case .denied:       deniedRoots.append(root)
-            case .pathMissing:  pathMissingCount += 1
+            case .pathMissing:  break
             }
         }
         let aggregated: TCCState

--- a/app/ClineUsageStore.swift
+++ b/app/ClineUsageStore.swift
@@ -1,0 +1,315 @@
+// PR 10c-BE — Cline UsageProvider store (feature-flag off).
+//
+// Second local-file reader. Watches every candidate globalStorage path
+// (VS Code stable, Insiders, VSCodium, Cursor, Windsurf, plus the Cline
+// CLI variants under `~/.cline/data` / `$CLINE_DATA_DIR` / `$CLINE_DIR/data`)
+// and produces a token+cost rollup on demand. Nothing leaves the machine.
+//
+// Concurrency model mirrors ClaudeCodeUsageStore: parse work runs on a
+// serial background queue; results apply on the main actor via
+// `Task { @MainActor [weak self] in ... }`; `fetchGeneration` invalidates
+// any in-flight completion so a TCC transition, disable, or `clear()`
+// cannot repopulate stale state.
+//
+// Feature posture: `features.cline.enabled` defaults false. Nothing
+// registers a ClineUsageStore into `AppDelegate.providers` yet — that
+// lands in PR 10c-UI along with `ProviderCopy.help(for: "cline")`.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class ClineUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "cline"
+    public let displayName: String = "Cline"
+    public let featureFlagKey: String = "features.cline.enabled"
+
+    // MARK: - Observable state
+
+    @Published public private(set) var snapshot: ClineUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// Aggregated TCC state across all candidate scan roots. `.granted`
+    /// if at least one root is readable; `.pathMissing` if no root
+    /// exists; `.denied` if every existing root is unreadable (rare —
+    /// Cline lives under `~/Library/Application Support` which is NOT
+    /// TCC-protected on 12.0+, so this is generally reachable without
+    /// Full Disk Access, unlike Warp's Group Container path).
+    @Published public private(set) var tccState: TCCState = .granted
+    /// Number of scan roots that exist but were probed `.denied` on the
+    /// last fetch. Codex round-1 finding #1: if this is non-zero AND
+    /// `tccState == .granted`, the rollup is PARTIAL — some Cline
+    /// data is on disk but we could not read it. Surfaced as a
+    /// diagnostic tile so the user is not misled by an incomplete
+    /// number.
+    @Published public private(set) var deniedRootCount: Int = 0
+
+    // MARK: - Dependencies
+
+    private let defaults: UserDefaults
+    private let resolveScanRoots: @Sendable () -> [ClinePathResolver.ScanRoot]
+    private let tccProbe: @Sendable (String) -> TCCState
+    private let discoverFiles: @Sendable ([ClinePathResolver.ScanRoot]) -> [URL]
+    private let parseFiles: @Sendable ([URL]) -> ClineUsageSnapshot
+    private let workQueue: DispatchQueue
+    private let clock: @Sendable () -> Date
+
+    /// Monotonic counter — bumped on every fetch() start, clear(), and
+    /// disable-flag toggle so a completion arriving from a stale earlier
+    /// fetch cannot overwrite fresher state. Only touched on main actor.
+    private var fetchGeneration: UInt64 = 0
+    /// Hash of the granted-root-set from the last fetch that applied a
+    /// snapshot. Codex round-2 finding #4: when the set changes
+    /// (e.g. user revokes Cursor access), the OLD snapshot may still
+    /// include usage from a now-inaccessible root. Detected by
+    /// comparing the current granted-root-set against this stored
+    /// hash; a change clears the snapshot so the tile does not show
+    /// stale numbers while the new parse runs.
+    private var lastAppliedGrantedRootsKey: String?
+
+    public init(
+        defaults: UserDefaults = .standard,
+        resolveScanRoots: @escaping @Sendable () -> [ClinePathResolver.ScanRoot] = {
+            ClinePathResolver.resolveScanRoots(.current())
+        },
+        tccProbe: @escaping @Sendable (String) -> TCCState = { TCCProbe.probe(path: $0) },
+        discoverFiles: @escaping @Sendable ([ClinePathResolver.ScanRoot]) -> [URL] = {
+            ClineUsageFetcher.discoverFiles(under: $0)
+        },
+        parseFiles: @escaping @Sendable ([URL]) -> ClineUsageSnapshot = {
+            ClineUsageFetcher.parse(files: $0)
+        },
+        workQueue: DispatchQueue = DispatchQueue(
+            label: "com.claude.usagebar.cline.parse",
+            qos: .utility
+        ),
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.defaults = defaults
+        self.resolveScanRoots = resolveScanRoots
+        self.tccProbe = tccProbe
+        self.discoverFiles = discoverFiles
+        self.parseFiles = parseFiles
+        self.workQueue = workQueue
+        self.clock = clock
+    }
+
+    // MARK: - UsageProvider: metadata
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// "Configured" means the flag is on — there is no credential to
+    /// paste. The onboarding tile handles the case where Cline is not
+    /// installed on this Mac.
+    public var isConfigured: Bool { isEnabled }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        switch tccState {
+        case .denied:
+            let copy = LocalProviderAccessGuide.copy(for: .denied, appName: displayName)
+            return [UsageTile(
+                id: "cline-needs-access",
+                title: copy.title,
+                kind: .needsAccess(
+                    path: "Code / Cursor / Windsurf globalStorage",
+                    guidance: copy.guidance
+                )
+            )]
+        case .pathMissing:
+            return [UsageTile(
+                id: "cline-not-installed",
+                title: displayName,
+                kind: .text(
+                    status: "No Cline install found",
+                    subtitle: "Install the Cline extension in VS Code / Cursor / Windsurf, or run the Cline CLI at least once."
+                )
+            )]
+        case .granted:
+            break
+        }
+
+        // Codex round-2 finding #3: surface the partial-access tile
+        // BEFORE the snapshot guard so a slow parse does not hide the
+        // access problem from the user.
+        var priorityTiles: [UsageTile] = []
+        if deniedRootCount > 0 {
+            priorityTiles.append(UsageTile(
+                id: "cline-partial-access",
+                title: "Partial access",
+                kind: .text(
+                    status: "\(deniedRootCount) Cline install\(deniedRootCount == 1 ? "" : "s") could not be read.",
+                    subtitle: "Grant Full Disk Access in System Settings to include their usage."
+                )
+            ))
+        }
+
+        guard let snap = snapshot else {
+            return priorityTiles + [UsageTile(
+                id: "cline-loading",
+                title: displayName,
+                kind: .text(status: "Loading…", subtitle: nil)
+            )]
+        }
+
+        let now = clock()
+        let todayRange = ClaudeCodeUsageStore.todayRange(around: now)
+        let mtdRange = ClaudeCodeUsageStore.monthToDateRange(around: now)
+
+        let tokensToday = snap.tokens(in: todayRange)
+        let costToday = snap.cost(in: todayRange)
+        let costMTD = snap.cost(in: mtdRange)
+        let byModel = snap.breakdownByModel(in: mtdRange)
+
+        var out: [UsageTile] = []
+
+        out.append(UsageTile(
+            id: "cline-tokens-today",
+            title: "Tokens today",
+            kind: .counter(
+                used: tokensToday,
+                limit: nil,
+                resetsAt: ClaudeCodeUsageStore.startOfNextDay(after: now)
+            )
+        ))
+        out.append(UsageTile(
+            id: "cline-cost-today",
+            title: "Cost today",
+            kind: .text(status: ClaudeCodeUsageStore.formatUSD(costToday), subtitle: nil)
+        ))
+        out.append(UsageTile(
+            id: "cline-cost-mtd",
+            title: "Cost month-to-date",
+            kind: .text(status: ClaudeCodeUsageStore.formatUSD(costMTD), subtitle: nil)
+        ))
+        if !byModel.isEmpty {
+            let top = byModel.prefix(3)
+            let lines = top.map { entry in
+                "\(entry.model) — \(ClaudeCodeUsageStore.formatUSD(entry.costUSD)) (\(ClaudeCodeUsageStore.formatTokens(entry.tokens)))"
+            }
+            out.append(UsageTile(
+                id: "cline-by-model",
+                title: "Top models this month",
+                kind: .text(
+                    status: lines.first ?? "",
+                    subtitle: lines.dropFirst().joined(separator: "\n")
+                )
+            ))
+        }
+
+        // Codex round-1 finding #1 partial-access tile is now emitted
+        // as a priority tile above (round-2 finding #3), so it stays
+        // visible during a slow parse too.
+
+        return priorityTiles + out
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        // Bump generation BEFORE any early-return path so an in-flight
+        // fetch cannot revive stale state after e.g. TCC denial. Copies
+        // the Claude Code round-2 finding #6 fix.
+        fetchGeneration &+= 1
+        let launchGeneration = fetchGeneration
+
+        let scanRoots = resolveScanRoots()
+
+        // Codex round-1 finding #1: track granted vs denied roots
+        // SEPARATELY. Only pass GRANTED roots to discoverFiles so a
+        // denied root is never silently skipped mid-parse. If EVERY
+        // existing root is denied, surface `.denied` so the user is
+        // prompted to grant Full Disk Access. If any root is granted
+        // (regardless of a sibling denial), we can still deliver
+        // usage from the readable roots, but we surface the partial-
+        // access warning via `deniedRootsCount` on the snapshot for a
+        // future diagnostic tile (kept as store state below).
+        var grantedRoots: [ClinePathResolver.ScanRoot] = []
+        var deniedRoots: [ClinePathResolver.ScanRoot] = []
+        var pathMissingCount = 0
+        for root in scanRoots {
+            switch tccProbe(root.tasksDirectoryPath) {
+            case .granted:      grantedRoots.append(root)
+            case .denied:       deniedRoots.append(root)
+            case .pathMissing:  pathMissingCount += 1
+            }
+        }
+        let aggregated: TCCState
+        if !grantedRoots.isEmpty {
+            aggregated = .granted
+        } else if !deniedRoots.isEmpty {
+            // No granted roots at all — surface denial so the user
+            // grants access.
+            aggregated = .denied
+        } else {
+            aggregated = .pathMissing
+        }
+        self.tccState = aggregated
+        self.deniedRootCount = deniedRoots.count
+
+        if aggregated != .granted {
+            self.snapshot = nil
+            self.lastAppliedGrantedRootsKey = nil
+            self.lastError = nil
+            return
+        }
+
+        // Codex round-2 finding #4: if the granted-root-set changed
+        // since the last applied snapshot, drop the OLD snapshot so
+        // the tile does not show stale numbers (which may include
+        // usage from a now-denied root) while the new parse runs.
+        let grantedKey = grantedRoots.map(\.tasksDirectoryPath).sorted().joined(separator: "\n")
+        if grantedKey != lastAppliedGrantedRootsKey {
+            self.snapshot = nil
+        }
+
+        // Only scan roots that were probed .granted — never re-scan a
+        // denied root (which would silently drop its data).
+        let rootsCopy = grantedRoots
+        let discover = self.discoverFiles
+        let parse = self.parseFiles
+
+        // Sendable capture of the granted-root-set key so the apply
+        // hop can record which set produced the snapshot (Codex
+        // round-2 finding #4).
+        let grantedKeyCopy = grantedKey
+        workQueue.async { [weak self] in
+            let urls = discover(rootsCopy)
+            let snap = parse(urls)
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                // Claude Code round-3 finding #3: guard on isEnabled
+                // too, so a fetch that completes after the user
+                // disables the provider cannot repopulate.
+                guard self.isEnabled else { return }
+                guard launchGeneration == self.fetchGeneration else { return }
+                self.snapshot = snap
+                self.lastAppliedGrantedRootsKey = grantedKeyCopy
+                self.lastUpdatedAt = Date()
+                self.lastError = nil
+                Log.info("Cline ui_messages parsed", .count(snap.records.count))
+            }
+        }
+    }
+
+    public func clear() {
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        lastAppliedGrantedRootsKey = nil
+        fetchGeneration &+= 1
+    }
+}

--- a/app/CodexUsageFetcher.swift
+++ b/app/CodexUsageFetcher.swift
@@ -1,0 +1,387 @@
+// PR 3-BE — Codex usage fetcher.
+//
+// Mirrors AnthropicUsageFetcher (PR 2b): a Sendable value type with no
+// observable state, no delegates, no side effects. It exposes a pure
+// static parser that turns the raw bytes of a
+// `GET https://chatgpt.com/backend-api/wham/usage` response into a
+// CodexUsageSnapshot, and a credential reader that ingests
+// `~/.codex/auth.json` (respecting `CODEX_HOME`).
+//
+// The two-layer split (Fetcher value type + Store observable class) is the
+// same as Anthropic: this fetcher is what the TestRunner fixtures hit, and
+// CodexUsageStore (PR 3-BE, separate file) is what SwiftUI observes.
+//
+// Feature posture: this file is dark code in PR 3-BE. Nothing constructs a
+// CodexUsageStore into the live provider registry yet; the popover wiring
+// and Settings toggle land in PR 3-UI. Shipping the backend first, behind a
+// default-off feature flag, keeps the release non-breaking.
+//
+// Response shape: established by a live read-only probe of the real
+// endpoint (structure only, no credential retained) plus the Codex CLI's
+// own deserialization structs. The authoritative fields are:
+//
+//   rate_limit.allowed                      Bool
+//   rate_limit.limit_reached                Bool
+//   rate_limit.primary_window.used_percent  Int      (0…100)
+//   rate_limit.primary_window.reset_after_seconds  Int  (relative)
+//   rate_limit.primary_window.reset_at      Int      (Unix epoch seconds)
+//   rate_limit.secondary_window.*           (same shape as primary)
+//   additional_rate_limits                  [Window]? (null or array)
+//   credits.has_credits / unlimited / balance (String) / overage_limit_reached
+//   plan_type                               String
+//
+// Note the reset timing is Unix-epoch integers, NOT ISO-8601 strings — this
+// differs from the Anthropic endpoint. `used_percent` is an integer here.
+
+import Foundation
+
+// MARK: - Snapshot
+
+/// One usage-limit window parsed from the Codex usage response. The primary
+/// (5-hour) and secondary (weekly) windows share this shape, as do the
+/// nested windows inside each `additional_rate_limits[]` element.
+///
+/// Field names and types are the `RateLimitWindowSnapshot` model from
+/// openai/codex (`rate_limit_window_snapshot.rs`): every field is an i32 on
+/// the wire.
+public struct CodexRateWindow: Equatable, Sendable {
+    /// 0…100 integer utilisation for the window.
+    public var usedPercent: Int
+    /// Length of the window in seconds (18000 = 5h, 604800 = 7d).
+    public var limitWindowSeconds: Int?
+    /// Seconds until the window resets, relative to the response time.
+    public var resetAfterSeconds: Int?
+    /// Absolute reset time as a Unix epoch (seconds). The endpoint returns
+    /// this as an integer, not an ISO-8601 string, and not milliseconds.
+    public var resetAt: Date?
+
+    public init(
+        usedPercent: Int = 0,
+        limitWindowSeconds: Int? = nil,
+        resetAfterSeconds: Int? = nil,
+        resetAt: Date? = nil
+    ) {
+        self.usedPercent = usedPercent
+        self.limitWindowSeconds = limitWindowSeconds
+        self.resetAfterSeconds = resetAfterSeconds
+        self.resetAt = resetAt
+    }
+}
+
+/// One element of `additional_rate_limits[]` — a model-specific limit lane
+/// (e.g. "GPT-5.3-Codex-Spark"). This is the `AdditionalRateLimitDetails`
+/// model from openai/codex (`additional_rate_limit_details.rs`).
+///
+/// The usage is NOT flat on the element: it is nested one level deeper under
+/// `rate_limit.primary_window` / `rate_limit.secondary_window`, both of which
+/// are individually nullable. Reading `used_percent` off the element root is
+/// the single most common integration mistake against this endpoint, so the
+/// nesting is preserved here deliberately.
+public struct CodexAdditionalLimit: Equatable, Sendable {
+    /// Human-readable limit name, e.g. "GPT-5.3-Codex-Spark".
+    public var limitName: String?
+    /// Metered-feature slug used to identify the lane server-side.
+    public var meteredFeature: String?
+    /// The 5-hour window for this lane, if present.
+    public var primaryWindow: CodexRateWindow?
+    /// The weekly window for this lane, if present.
+    public var secondaryWindow: CodexRateWindow?
+
+    public init(
+        limitName: String? = nil,
+        meteredFeature: String? = nil,
+        primaryWindow: CodexRateWindow? = nil,
+        secondaryWindow: CodexRateWindow? = nil
+    ) {
+        self.limitName = limitName
+        self.meteredFeature = meteredFeature
+        self.primaryWindow = primaryWindow
+        self.secondaryWindow = secondaryWindow
+    }
+}
+
+/// Credit balance block. Present on accounts that carry pay-as-you-go
+/// credits; `balance` is returned as a String by the endpoint.
+public struct CodexCredits: Equatable, Sendable {
+    public var hasCredits: Bool
+    public var unlimited: Bool
+    public var overageLimitReached: Bool
+    /// Raw balance string exactly as returned (e.g. "0", "12.50"). Kept as a
+    /// String because the endpoint returns it as a String and the tile
+    /// renders it verbatim; we do not reinterpret currency here.
+    public var balance: String?
+
+    public init(
+        hasCredits: Bool = false,
+        unlimited: Bool = false,
+        overageLimitReached: Bool = false,
+        balance: String? = nil
+    ) {
+        self.hasCredits = hasCredits
+        self.unlimited = unlimited
+        self.overageLimitReached = overageLimitReached
+        self.balance = balance
+    }
+}
+
+/// A parsed snapshot of the `wham/usage` response. Every field is optional
+/// or defaulted in the same spirit as AnthropicUsageSnapshot — a fresh
+/// account with no additional windows has an empty `additionalWindows`, and
+/// an account with no credit block has `credits == nil`.
+public struct CodexUsageSnapshot: Equatable, Sendable {
+    /// Whether the account is currently allowed to make requests.
+    public var allowed: Bool
+    /// Whether any window has hit its limit.
+    public var limitReached: Bool
+
+    /// The 5-hour (primary) window. Always present in a well-formed
+    /// response; nil only if `rate_limit` is entirely absent.
+    public var primaryWindow: CodexRateWindow?
+    /// The weekly (secondary) window.
+    public var secondaryWindow: CodexRateWindow?
+    /// Zero or more model-specific limit lanes (per-model or promotional
+    /// caps, e.g. Spark). `additional_rate_limits` is `null` on most
+    /// accounts, which parses to an empty array.
+    public var additionalLimits: [CodexAdditionalLimit]
+
+    /// Pay-as-you-go credit block, if the account carries one.
+    public var credits: CodexCredits?
+
+    /// Account plan identifier ("plus", "team", "free", …). Surfaced for the
+    /// help panel copy, not for a tile.
+    public var planType: String?
+
+    public init(
+        allowed: Bool = true,
+        limitReached: Bool = false,
+        primaryWindow: CodexRateWindow? = nil,
+        secondaryWindow: CodexRateWindow? = nil,
+        additionalLimits: [CodexAdditionalLimit] = [],
+        credits: CodexCredits? = nil,
+        planType: String? = nil
+    ) {
+        self.allowed = allowed
+        self.limitReached = limitReached
+        self.primaryWindow = primaryWindow
+        self.secondaryWindow = secondaryWindow
+        self.additionalLimits = additionalLimits
+        self.credits = credits
+        self.planType = planType
+    }
+}
+
+// MARK: - Credentials
+
+/// Credentials read from `~/.codex/auth.json`. Only the two fields the usage
+/// request needs are surfaced; the id_token and refresh_token are never read
+/// out of the file by this app (PR 3-BE does not refresh — see the plan's
+/// Phase 1 note deferring writeback to Phase 1b).
+public struct CodexCredentials: Equatable, Sendable {
+    public let accessToken: String
+    public let accountId: String
+
+    public init(accessToken: String, accountId: String) {
+        self.accessToken = accessToken
+        self.accountId = accountId
+    }
+}
+
+public enum CodexUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+public enum CodexAuthError: Error, Equatable {
+    /// `auth.json` does not exist. UI should prompt `codex auth login`.
+    case authFileMissing
+    /// `auth.json` exists but could not be parsed as JSON.
+    case authFileMalformed
+    /// `auth.json` parsed but is missing access_token or account_id (e.g. an
+    /// API-key-only login with `auth_mode == "apikey"` and null tokens).
+    case authFileIncomplete
+}
+
+// MARK: - Fetcher
+
+/// Pure parser and credential reader for the Codex usage endpoint. Value
+/// type with no observable state; all callers receive a snapshot (or a
+/// thrown error) and apply it themselves on the main actor.
+public struct CodexUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: Credential ingestion
+
+    /// Resolve the Codex home directory, honouring `CODEX_HOME` when set and
+    /// non-empty, else `~/.codex`.
+    public static func codexHome(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let override = environment["CODEX_HOME"],
+           !override.trimmingCharacters(in: .whitespaces).isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        // FileManager.homeDirectoryForCurrentUser is the real user home even
+        // inside a sandbox container's mapped path; matches the CLI, which
+        // uses the OS home rather than $HOME string interpolation.
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true)
+    }
+
+    /// Full path to `auth.json` under the resolved Codex home.
+    public static func authFileURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        codexHome(environment: environment).appendingPathComponent("auth.json", isDirectory: false)
+    }
+
+    /// Read and parse `auth.json`, extracting the access token and account
+    /// id needed for the usage request. Throws a typed CodexAuthError so the
+    /// Store can map each case to a distinct UI state.
+    ///
+    /// This is separated from file IO so tests can exercise the parse
+    /// directly against synthetic bytes without touching the filesystem.
+    public static func parseAuth(_ data: Data) throws -> CodexCredentials {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexAuthError.authFileMalformed
+        }
+        guard let tokens = json["tokens"] as? [String: Any] else {
+            throw CodexAuthError.authFileIncomplete
+        }
+        guard
+            let access = tokens["access_token"] as? String, !access.isEmpty,
+            let account = tokens["account_id"] as? String, !account.isEmpty
+        else {
+            throw CodexAuthError.authFileIncomplete
+        }
+        return CodexCredentials(accessToken: access, accountId: account)
+    }
+
+    /// Read credentials from disk. Returns `.authFileMissing` when the file
+    /// does not exist so the Store can render the "run codex auth login"
+    /// onboarding card rather than an error.
+    public static func readCredentials(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> CodexCredentials {
+        let url = authFileURL(environment: environment)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CodexAuthError.authFileMissing
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            // Existence check passed but the read failed (permissions, race
+            // with a concurrent `codex auth login` rewrite). Treat as
+            // malformed rather than missing — the file is there.
+            throw CodexAuthError.authFileMalformed
+        }
+        return try parseAuth(data)
+    }
+
+    // MARK: Pure parsing (this is what the fixtures hit)
+
+    /// Parse one window object into a CodexRateWindow. Tolerant of absent
+    /// fields: an object with only `used_percent` still parses.
+    private static func parseWindow(_ obj: [String: Any]) -> CodexRateWindow {
+        var w = CodexRateWindow()
+        // used_percent is an Int in the live response; accept a Double too so
+        // a future server-side change to fractional percentages does not
+        // silently drop the value.
+        if let p = obj["used_percent"] as? Int {
+            w.usedPercent = p
+        } else if let p = obj["used_percent"] as? Double {
+            w.usedPercent = Int(p)
+        }
+        if let s = obj["limit_window_seconds"] as? Int {
+            w.limitWindowSeconds = s
+        } else if let s = obj["limit_window_seconds"] as? Double {
+            w.limitWindowSeconds = Int(s)
+        }
+        if let s = obj["reset_after_seconds"] as? Int {
+            w.resetAfterSeconds = s
+        } else if let s = obj["reset_after_seconds"] as? Double {
+            w.resetAfterSeconds = Int(s)
+        }
+        // reset_at is a Unix epoch integer (seconds). JSONSerialization may
+        // surface a large integer as Int or, on 32-bit-ish paths, Double —
+        // handle both.
+        if let epoch = obj["reset_at"] as? Int {
+            w.resetAt = Date(timeIntervalSince1970: TimeInterval(epoch))
+        } else if let epoch = obj["reset_at"] as? Double {
+            w.resetAt = Date(timeIntervalSince1970: epoch)
+        }
+        return w
+    }
+
+    /// Parse the JSON body of a `wham/usage` response into a snapshot.
+    /// Preserves every field the tiles consume. Throws `invalidJSON` only
+    /// when the top level is not a JSON object — a well-formed but sparse
+    /// response (missing credits, null additional_rate_limits) parses to a
+    /// snapshot with defaulted/absent fields, matching how AnthropicUsage
+    /// Fetcher tolerates Free-plan minimal bodies.
+    public static func parse(_ data: Data) throws -> CodexUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexUsageParseError.invalidJSON
+        }
+
+        var snap = CodexUsageSnapshot()
+
+        snap.planType = json["plan_type"] as? String
+
+        if let rl = json["rate_limit"] as? [String: Any] {
+            if let allowed = rl["allowed"] as? Bool { snap.allowed = allowed }
+            if let reached = rl["limit_reached"] as? Bool { snap.limitReached = reached }
+
+            if let primary = rl["primary_window"] as? [String: Any] {
+                snap.primaryWindow = parseWindow(primary)
+            }
+            if let secondary = rl["secondary_window"] as? [String: Any] {
+                snap.secondaryWindow = parseWindow(secondary)
+            }
+        }
+
+        // additional_rate_limits is null on most accounts. When present it is
+        // an array of AdditionalRateLimitDetails: each element carries
+        // limit_name + metered_feature, and its usage is nested under
+        // `rate_limit.primary_window` / `rate_limit.secondary_window` — NOT
+        // flat on the element. Anything that is not an array (including
+        // explicit null) yields an empty list.
+        if let additional = json["additional_rate_limits"] as? [[String: Any]] {
+            snap.additionalLimits = additional.map { entry in
+                var limit = CodexAdditionalLimit(
+                    limitName: entry["limit_name"] as? String,
+                    meteredFeature: entry["metered_feature"] as? String
+                )
+                if let nested = entry["rate_limit"] as? [String: Any] {
+                    if let primary = nested["primary_window"] as? [String: Any] {
+                        limit.primaryWindow = parseWindow(primary)
+                    }
+                    if let secondary = nested["secondary_window"] as? [String: Any] {
+                        limit.secondaryWindow = parseWindow(secondary)
+                    }
+                }
+                return limit
+            }
+        }
+
+        if let c = json["credits"] as? [String: Any] {
+            var credits = CodexCredits()
+            if let has = c["has_credits"] as? Bool { credits.hasCredits = has }
+            if let unlimited = c["unlimited"] as? Bool { credits.unlimited = unlimited }
+            if let overage = c["overage_limit_reached"] as? Bool { credits.overageLimitReached = overage }
+            // balance is a String in the live response; accept a number too
+            // and stringify it defensively.
+            if let b = c["balance"] as? String {
+                credits.balance = b
+            } else if let b = c["balance"] as? Int {
+                credits.balance = String(b)
+            } else if let b = c["balance"] as? Double {
+                credits.balance = String(b)
+            }
+            snap.credits = credits
+        }
+
+        return snap
+    }
+}

--- a/app/CodexUsageStore.swift
+++ b/app/CodexUsageStore.swift
@@ -1,0 +1,376 @@
+// PR 3-BE — Codex UsageProvider conformer (dark code, feature-flag off).
+//
+// CodexUsageStore is the second UsageProvider (after AnthropicUsageStore).
+// It holds the observable state for the Codex tiles and drives the fetch
+// against `GET https://chatgpt.com/backend-api/wham/usage`, parsing the
+// response through the Sendable CodexUsageFetcher.
+//
+// Feature posture in PR 3-BE:
+//   - `features.codex.enabled` defaults FALSE. Every provider except
+//     Anthropic is opt-in; existing v1.3.1 users see zero change.
+//   - Nothing appends a CodexUsageStore into AppDelegate.providers yet.
+//     The popover wiring, Settings toggle, and shared-timer registration
+//     land in PR 3-UI. This file is compiled and unit-tested but inert at
+//     runtime until the flag is turned on and the store is registered.
+//
+// Auth posture (plan Phase 1): read `~/.codex/auth.json` only. Do NOT
+// initiate an in-app OAuth PKCE flow — using the Codex CLI's client id from
+// a third-party GUI is impersonation-adjacent. Do NOT write back to
+// auth.json on 401; instead surface a "session expired, run codex auth
+// login" state. Writeback is deferred to Phase 1b.
+//
+// Labels: every tile is prefixed "Codex", never "ChatGPT". The 5-hour and
+// weekly windows cover the Codex CLI, IDE extensions, Slack, and Cloud
+// tasks — one shared pool. General GPT chat is not counted here.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// @MainActor because the store owns @Published state observed by SwiftUI.
+// @preconcurrency on the UsageProvider conformance defers strict
+// actor-isolation checking until PR 16 migrates the protocol to @MainActor —
+// identical staging to AnthropicUsageStore.
+@MainActor
+public final class CodexUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "codex"
+    public let displayName: String = "Codex (OpenAI)"
+    public let featureFlagKey: String = "features.codex.enabled"
+
+    // MARK: Observable state
+
+    /// The most recent successfully parsed snapshot. Nil before the first
+    /// successful fetch, or after a fetch that failed.
+    @Published public private(set) var snapshot: CodexUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// True when auth.json is present and yields usable credentials. Set by
+    /// each fetch attempt so the tile can distinguish "not configured yet"
+    /// (needs onboarding card) from "configured but fetch failed" (error).
+    @Published public private(set) var hasCredentials: Bool = false
+    /// True when the last failure was a 401 — the user must re-run
+    /// `codex auth login`. Distinct from a generic network error.
+    @Published public private(set) var sessionExpired: Bool = false
+
+    // Injected dependencies keep the store unit-testable. The default
+    // production values read the real environment and hit the real
+    // endpoint; tests inject a fixed environment and a stubbed transport.
+    private let environment: [String: String]
+    private let transport: CodexUsageTransport
+    // Overrides UserDefaults for the feature flag in tests so a test does
+    // not have to mutate the shared standard defaults. Defaults to .standard.
+    private let defaults: UserDefaults
+
+    public init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        transport: CodexUsageTransport = URLSessionCodexTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.environment = environment
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    /// Codex is opt-in. Unlike Anthropic (on by default for compat), an
+    /// unset flag means OFF. The user turns it on in Settings (PR 3-UI).
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured means auth.json exists and parses. We probe the file
+    /// lazily so `isConfigured` is honest even before the first fetch.
+    public var isConfigured: Bool {
+        (try? CodexUsageFetcher.readCredentials(environment: environment)) != nil
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Not configured — render the onboarding card telling the user to
+        // run `codex auth login`. This is a needsAccess tile, matching the
+        // protocol's first-run onboarding kind.
+        if !isConfigured {
+            return [UsageTile(
+                id: "codex-needs-auth",
+                title: "Codex",
+                kind: .needsAccess(
+                    path: CodexUsageFetcher.authFileURL(environment: environment).path,
+                    guidance: "Run `codex auth login` in a terminal, then click Refresh."
+                )
+            )]
+        }
+
+        // Configured but the session expired (401) — a distinct actionable
+        // state, again pointing at re-login rather than a generic error.
+        if sessionExpired {
+            return [UsageTile(
+                id: "codex-session-expired",
+                title: "Codex",
+                kind: .text(
+                    status: "Codex session expired",
+                    subtitle: "Run `codex auth login` in a terminal, then click Refresh."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else {
+            // Configured, no error, but no data yet (pre-first-fetch). Empty
+            // tiles — the popover shows nothing for Codex until data lands,
+            // matching Anthropic's pre-fetch behaviour.
+            return []
+        }
+
+        var out: [UsageTile] = []
+
+        if let primary = snap.primaryWindow {
+            out.append(UsageTile(
+                id: "codex-5h",
+                title: "Codex (5 hour)",
+                kind: .bar(
+                    fraction: fraction(primary.usedPercent),
+                    resetsAt: primary.resetAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        if let secondary = snap.secondaryWindow {
+            out.append(UsageTile(
+                id: "codex-weekly",
+                title: "Codex (7 day)",
+                kind: .bar(
+                    fraction: fraction(secondary.usedPercent),
+                    resetsAt: secondary.resetAt,
+                    badge: nil
+                )
+            ))
+        }
+
+        // Zero or more model-specific limit lanes (per-model or promotional
+        // caps, e.g. Spark). Empty on most accounts. Each lane's usage is
+        // nested under its own primary/secondary window; a lane can surface
+        // up to two bars. Index disambiguates the tile id when the server
+        // omits a limit_name.
+        for (index, limit) in snap.additionalLimits.enumerated() {
+            let label = limit.limitName ?? limit.meteredFeature ?? "Additional limit \(index + 1)"
+            if let primary = limit.primaryWindow {
+                out.append(UsageTile(
+                    id: "codex-additional-\(index)-5h",
+                    title: "Codex \(label) (5 hour)",
+                    kind: .bar(
+                        fraction: fraction(primary.usedPercent),
+                        resetsAt: primary.resetAt,
+                        badge: nil
+                    )
+                ))
+            }
+            if let secondary = limit.secondaryWindow {
+                out.append(UsageTile(
+                    id: "codex-additional-\(index)-weekly",
+                    title: "Codex \(label) (7 day)",
+                    kind: .bar(
+                        fraction: fraction(secondary.usedPercent),
+                        resetsAt: secondary.resetAt,
+                        badge: nil
+                    )
+                ))
+            }
+        }
+
+        // Optional credits tile — only when the account actually carries a
+        // credit balance. Suppressed otherwise so free/subscription accounts
+        // do not see a confusing "0" credit line.
+        if let credits = snap.credits, credits.hasCredits, let balance = credits.balance {
+            out.append(UsageTile(
+                id: "codex-credits",
+                title: "Codex credits",
+                kind: .text(
+                    status: credits.unlimited ? "Unlimited" : balance,
+                    subtitle: credits.overageLimitReached ? "Overage limit reached" : nil
+                )
+            ))
+        }
+
+        return out
+    }
+
+    /// Convert a 0…100 integer percentage into a 0.0…1.0 fraction, clamped
+    /// so a malformed >100 value cannot overflow a progress bar.
+    private func fraction(_ percent: Int) -> Double {
+        min(max(Double(percent) / 100.0, 0.0), 1.0)
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result to observable state. Extracted from the
+    /// async completion so the TestRunner can drive every branch (success,
+    /// 401 → sessionExpired, httpError, networkError) synchronously without
+    /// touching the network. `now` is injected so the lastUpdatedAt
+    /// assertion is deterministic.
+    public func apply(_ result: CodexUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try CodexUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+                self.sessionExpired = false
+            } catch {
+                self.lastError = "Could not parse Codex usage"
+            }
+        case .unauthorized:
+            // 401 — surface the re-login state. Do NOT write back to
+            // auth.json in PR 3-BE (Phase 1). Keep the last snapshot so the
+            // popover does not flash empty, but flag expiry.
+            self.sessionExpired = true
+            self.lastError = nil
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    /// Test-only helper to set credential presence without a real auth.json.
+    /// Used by tile-rendering tests that inject a store with a fixed
+    /// environment. Never called in production.
+    public func setHasCredentialsForTesting(_ value: Bool) {
+        self.hasCredentials = value
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        let creds: CodexCredentials
+        do {
+            creds = try CodexUsageFetcher.readCredentials(environment: environment)
+        } catch CodexAuthError.authFileMissing {
+            // Not configured. Clear any stale data; tiles render the
+            // onboarding card via isConfigured == false.
+            hasCredentials = false
+            snapshot = nil
+            lastError = nil
+            sessionExpired = false
+            return
+        } catch {
+            hasCredentials = false
+            snapshot = nil
+            lastError = "Codex credentials unreadable"
+            sessionExpired = false
+            return
+        }
+
+        hasCredentials = true
+
+        transport.fetchUsage(credentials: creds) { [weak self] result in
+            // Transport guarantees the completion is delivered on the main
+            // queue; applying @Published state here is main-actor safe. The
+            // application logic lives in `apply(_:)` so the TestRunner can
+            // drive every branch synchronously.
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // PR 3-BE does not own the credential file — auth.json belongs to the
+        // Codex CLI. "Clear" only drops our in-memory state; it never deletes
+        // the user's CLI login. Turning the provider off is done via the
+        // Settings toggle (PR 3-UI), not here.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        sessionExpired = false
+        hasCredentials = false
+    }
+}
+
+// MARK: - Transport abstraction
+
+/// Result of a usage fetch. `unauthorized` is split out from `httpError` so
+/// the store can render the distinct "session expired" state on 401.
+public enum CodexUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the network so the store is unit-testable without hitting the
+/// live endpoint. The completion MUST be delivered on the main queue.
+public protocol CodexUsageTransport: Sendable {
+    func fetchUsage(
+        credentials: CodexCredentials,
+        completion: @escaping @Sendable (CodexUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues the real request with the Bearer token and
+/// account-id header, mirroring the Codex CLI's own request. The response
+/// body is never logged (it is tied to the user's account) — only the
+/// status code goes through the categorical logger, matching the Anthropic
+/// fetch site and satisfying the CI credential-leak guard.
+public struct URLSessionCodexTransport: CodexUsageTransport {
+    private let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+
+    public init() {}
+
+    public func fetchUsage(
+        credentials: CodexCredentials,
+        completion: @escaping @Sendable (CodexUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(credentials.accountId, forHTTPHeaderField: "chatgpt-account-id")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (CodexUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                // Error object may reference the request; do not log it (it
+                // can carry the URL with headers in some transports). A
+                // generic marker is enough.
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("Codex usage API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/CodexUsageStore.swift
+++ b/app/CodexUsageStore.swift
@@ -275,14 +275,11 @@ public final class CodexUsageStore: @preconcurrency UsageProvider {
         hasCredentials = true
 
         transport.fetchUsage(credentials: creds) { [weak self] result in
-            // Transport guarantees the completion is delivered on the main
-            // queue; applying @Published state here is main-actor safe. The
-            // application logic lives in `apply(_:)` so the TestRunner can
-            // drive every branch synchronously.
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Hop to the main actor to apply @Published state. Task {
+            // @MainActor } is safe whichever queue the transport delivers on
+            // (cannot trap like assumeIsolated). The application logic lives
+            // in `apply(_:)` so the TestRunner can drive every branch directly.
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 

--- a/app/CopilotUsageFetcher.swift
+++ b/app/CopilotUsageFetcher.swift
@@ -1,0 +1,268 @@
+// PR 9-BE — GitHub Copilot usage fetcher (fine-grained PAT).
+//
+// Seventh non-Anthropic provider. Reads GitHub's public REST billing
+// endpoint for the authenticated user's AI Credit spend:
+//   GET /users/{username}/settings/billing/ai_credit/usage
+// on api.github.com, with a fine-grained PAT carrying the `Plan (Read)`
+// permission (Account permissions section). Verified against the mid-2026
+// canonical OpenAPI spec (github/rest-api-description, API version
+// 2026-03-10) and against docs.github.com/en/rest/billing/usage.
+//
+// Feature posture: features.copilot.enabled defaults false. Nothing
+// registers a store into the live registry yet (the tile + Settings PAT
+// paste sheet land in PR 9-UI). This file is compiled and unit-tested but
+// inert at runtime until enabled.
+//
+// Deliberately out of scope for PR 9-BE (deferred to a follow-up PR if
+// there's user demand):
+//   - OAuth Device Flow to a bespoke ClaudeUsageBar GitHub App. Requires
+//     a pre-registered client_id and a device-code prompt UX — meaningful
+//     additional surface area. PAT paste (the same UX as DeepSeek/xAI/
+//     OpenAI) is the shipped path for this milestone.
+//   - The internal copilot_internal/* endpoints. GitHub explicitly does
+//     not permit third-party clients to hit them, abuse-detection has
+//     suspended accounts using them (github/copilot-language-server-release
+//     #10), and their client_id gating (Iv1.b507a08c87ecfe98, VS Code
+//     Copilot's own OAuth App id) means a bespoke GitHub App token would
+//     be rejected anyway.
+//
+// Credential posture: the PAT is a spending credential (can view billing,
+// scope-appropriate account info). Stored in KeychainStore, never logged.
+// Only HTTP status codes go through Log.info(.count).
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// One entry from `usageItems[]`. Every field is present on the wire for a
+/// populated report (verified against the OpenAPI spec's required list); we
+/// parse defensively so a schema tweak that adds/removes an optional field
+/// does not throw.
+public struct CopilotUsageItem: Equatable, Sendable {
+    /// e.g. "Copilot AI Credits", "Copilot" for premium requests.
+    public var product: String
+    /// e.g. "AI Credit", "Copilot Premium Request".
+    public var sku: String
+    /// Model name, e.g. "GPT-5". Optional in some SKUs.
+    public var model: String?
+    /// e.g. "ai-credits", "requests". Do NOT gate the credit line on this
+    /// field — SKU strings are the reliable discriminator per the research
+    /// report (docs render `unitType: "credits"` in one place and
+    /// `"ai-credits"` in another).
+    public var unitType: String
+    /// Per-unit price in USD. Fixed at 0.01 for AI Credit today.
+    public var pricePerUnit: Double
+    /// Total volume before any included allowance is applied. May be
+    /// fractional (some captures show float grossQuantity like 3956.1799545)
+    /// — do NOT decode as Int.
+    public var grossQuantity: Double
+    /// Gross USD amount (pricePerUnit * grossQuantity).
+    public var grossAmount: Double
+    /// Allowance already consumed within the included per-plan bucket.
+    public var discountQuantity: Double
+    public var discountAmount: Double
+    /// Chargeable overage quantity (gross minus discount).
+    public var netQuantity: Double
+    /// Chargeable overage in USD. This is what the MTD tile sums.
+    public var netAmount: Double
+
+    public init(
+        product: String,
+        sku: String,
+        model: String? = nil,
+        unitType: String,
+        pricePerUnit: Double,
+        grossQuantity: Double,
+        grossAmount: Double,
+        discountQuantity: Double,
+        discountAmount: Double,
+        netQuantity: Double,
+        netAmount: Double
+    ) {
+        self.product = product
+        self.sku = sku
+        self.model = model
+        self.unitType = unitType
+        self.pricePerUnit = pricePerUnit
+        self.grossQuantity = grossQuantity
+        self.grossAmount = grossAmount
+        self.discountQuantity = discountQuantity
+        self.discountAmount = discountAmount
+        self.netQuantity = netQuantity
+        self.netAmount = netAmount
+    }
+}
+
+/// Parsed `/settings/billing/ai_credit/usage` body. `timePeriod` and `user`
+/// are always present on a 200; `usageItems` can legitimately be `[]` when
+/// the user's Copilot licence is billed through an organisation/enterprise
+/// (the personal endpoint returns 200 with an empty array, NOT a 404).
+public struct CopilotUsageSnapshot: Equatable, Sendable {
+    public var year: Int
+    public var month: Int?
+    public var day: Int?
+    public var user: String
+    /// Optional top-level filter echo — the endpoint returns whatever
+    /// `product` filter was requested, or nil when no filter.
+    public var product: String?
+    /// Same, for `model` filter.
+    public var model: String?
+    /// One entry per (SKU × model) combination for the requested period.
+    public var items: [CopilotUsageItem]
+
+    public init(
+        year: Int = 0,
+        month: Int? = nil,
+        day: Int? = nil,
+        user: String = "",
+        product: String? = nil,
+        model: String? = nil,
+        items: [CopilotUsageItem] = []
+    ) {
+        self.year = year
+        self.month = month
+        self.day = day
+        self.user = user
+        self.product = product
+        self.model = model
+        self.items = items
+    }
+
+    /// Sum of `netAmount` across items — this is what the tile displays as
+    /// "MTD spend". `max(0, …)` guards against a hostile server that emits
+    /// negative amounts.
+    public var netAmountMTDUSD: Double {
+        max(0, items.reduce(0.0) { $0 + $1.netAmount })
+    }
+
+    /// Grouping helper for a "by SKU" breakdown tile. Ordered by
+    /// descending net amount so the biggest line item is first.
+    public var itemsBySkuDescending: [CopilotUsageItem] {
+        items.sorted { $0.netAmount > $1.netAmount }
+    }
+
+    /// True when the endpoint returned a 200 with an empty items array —
+    /// the documented signal that the user's Copilot licence is managed
+    /// through an org/enterprise seat and the personal endpoint carries
+    /// no data for them.
+    public var isEmptyOrgBilled: Bool {
+        items.isEmpty
+    }
+}
+
+public enum CopilotUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct CopilotUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain key under which the fine-grained PAT is stored.
+    public static let patKeychainKey = "copilot.pat_token"
+
+    /// Keychain key under which the user's GitHub login (needed for the
+    /// path parameter) is stored. We derive this from the PAT via the
+    /// `/user` endpoint at fetch time and persist it so subsequent fetches
+    /// skip the extra round-trip.
+    public static let loginKeychainKey = "copilot.github_login"
+
+    /// GitHub REST API version this parser was verified against. Pinned so
+    /// a client-driven change to a new schema is deliberate. Sunset for
+    /// the previous version (2022-11-28) is 10 March 2028; migrating past
+    /// then is a separate future PR.
+    public static let apiVersion = "2026-03-10"
+
+    // MARK: - Parsers
+
+    /// Parse the `ai_credit/usage` response.
+    public static func parseUsage(_ data: Data) throws -> CopilotUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CopilotUsageParseError.invalidJSON
+        }
+        // Codex round-1 finding #6: `usageItems` is REQUIRED per the
+        // OpenAPI 2026-03-10 spec. A missing key is a schema violation
+        // (proxy stripped it, GitHub broke the response) — NOT the same
+        // as the documented `usageItems: []` "org-billed" signal, which
+        // is an empty array. Refuse the missing case so we surface a
+        // parse error rather than mis-labelling as org-billed.
+        guard let items = json["usageItems"] as? [[String: Any]] else {
+            throw CopilotUsageParseError.unexpectedShape("usageItems missing")
+        }
+
+        var snap = CopilotUsageSnapshot()
+        if let period = json["timePeriod"] as? [String: Any] {
+            snap.year = intOrZero(period["year"])
+            snap.month = intOrNil(period["month"])
+            snap.day = intOrNil(period["day"])
+        }
+        snap.user = (json["user"] as? String) ?? ""
+        snap.product = json["product"] as? String
+        snap.model = json["model"] as? String
+        snap.items = items.compactMap { parseItem($0) }
+        return snap
+    }
+
+    private static func parseItem(_ entry: [String: Any]) -> CopilotUsageItem? {
+        // sku and product are the load-bearing discriminators; refuse an
+        // item that lacks either rather than smuggling in an empty-string
+        // line.
+        guard let product = entry["product"] as? String, !product.isEmpty,
+              let sku = entry["sku"] as? String, !sku.isEmpty else {
+            return nil
+        }
+        return CopilotUsageItem(
+            product: product,
+            sku: sku,
+            model: entry["model"] as? String,
+            unitType: (entry["unitType"] as? String) ?? "",
+            pricePerUnit: doubleOrZero(entry["pricePerUnit"]),
+            grossQuantity: doubleOrZero(entry["grossQuantity"]),
+            grossAmount: doubleOrZero(entry["grossAmount"]),
+            discountQuantity: doubleOrZero(entry["discountQuantity"]),
+            discountAmount: doubleOrZero(entry["discountAmount"]),
+            netQuantity: doubleOrZero(entry["netQuantity"]),
+            netAmount: doubleOrZero(entry["netAmount"])
+        )
+    }
+
+    /// Parse `GET /user` (used to discover the authenticated user's login
+    /// for the billing endpoint's `{username}` path parameter). Only the
+    /// `login` field is consumed.
+    public static func parseAuthenticatedUserLogin(_ data: Data) throws -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let login = json["login"] as? String, !login.isEmpty else {
+            throw CopilotUsageParseError.unexpectedShape("missing user.login")
+        }
+        return login
+    }
+
+    // MARK: - Numeric coercion
+
+    /// Int coercion. Rejects non-finite / oversize Doubles rather than
+    /// trapping. Accepts numeric strings defensively (some third-party
+    /// GitHub proxies stringify small integers).
+    static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+    static func intOrZero(_ value: Any?) -> Int { intOrNil(value) ?? 0 }
+
+    /// Double coercion. Non-finite → nil. Preserves fractional precision
+    /// (GitHub's grossQuantity has been observed as 3956.1799545).
+    static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d.isFinite ? d : nil }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s).flatMap { $0.isFinite ? $0 : nil } }
+        return nil
+    }
+    static func doubleOrZero(_ value: Any?) -> Double { doubleOrNil(value) ?? 0 }
+}

--- a/app/CopilotUsageStore.swift
+++ b/app/CopilotUsageStore.swift
@@ -1,0 +1,556 @@
+// PR 9-BE — GitHub Copilot UsageProvider conformer (dark code, flag off).
+//
+// Seventh non-Anthropic provider. Reads GitHub's public REST billing
+// endpoint for the authenticated user's Copilot AI Credit spend via a
+// fine-grained PAT with the `Plan (Read)` permission. See CopilotUsageFetcher
+// for the full deferred-scope notes.
+//
+// Feature posture: features.copilot.enabled defaults false. Nothing registers
+// a store into the live registry yet (the tile + Settings paste sheet land
+// in PR 9-UI).
+//
+// Credential posture: the PAT is a spending credential (can view billing).
+// Stored in KeychainStore, never logged. Only HTTP status codes go through
+// Log.info(.count).
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class CopilotUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
+
+    public let id: String = "copilot"
+    public let displayName: String = "GitHub Copilot"
+    public let featureFlagKey: String = "features.copilot.enabled"
+
+    // PasteKeyProvider — the user pastes a fine-grained PAT prefixed
+    // `github_pat_`. The `Plan (Read)` permission is a per-user account
+    // permission (not an org permission), so the PAT resource owner MUST
+    // be the user's own account.
+    public let keyPlaceholder: String = "github_pat_… (fine-grained token, Plan: Read)"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: CopilotUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: CopilotUsageTransport
+    private let defaults: UserDefaults
+
+    /// Monotonically-increasing generation counter. Every credential-changing
+    /// event (`saveKey`, `clear`) bumps it; every `fetch()` snapshots the
+    /// current value into its completion closure and only applies the
+    /// result if the counter is still that value. This defeats two Codex
+    /// review #1/#2 races:
+    ///   - fetch launched with PAT A completes AFTER the user saved PAT B →
+    ///     the stale result would otherwise land in `snapshot`.
+    ///   - fetch launched, then `clear()` was called → the stale result
+    ///     would otherwise repopulate state that clear had just wiped.
+    private var fetchGeneration: UInt64 = 0
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: CopilotUsageTransport = URLSessionCopilotTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when a PAT is stored. `.unavailable` (locked keychain) counts
+    /// as configured so a locked screen does not drop the provider to
+    /// onboarding (parity with the PR #60 hardening pattern; and the
+    /// chk1-audit Bug #2 fix in Perplexity).
+    public var hasKey: Bool {
+        switch credentials.readResult(CopilotUsageFetcher.patKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
+    }
+
+    /// Save a pasted PAT. Empty input clears it and the cached login. We
+    /// clear the login too because a new PAT may belong to a different
+    /// GitHub user. Also bumps the fetch generation so any in-flight
+    /// fetch launched with the previous PAT will be discarded when its
+    /// completion fires.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(CopilotUsageFetcher.patKeychainKey)
+            credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+        } else {
+            credentials.write(CopilotUsageFetcher.patKeychainKey, Data(trimmed.utf8))
+            // Do NOT preserve a stale login here — the new PAT may belong
+            // to a different account. The next fetch discovers it via /user.
+            credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+        }
+        fetchGeneration &+= 1
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool { defaults.bool(forKey: featureFlagKey) }
+    public var isConfigured: Bool { hasKey }
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "copilot-needs-key",
+                title: "GitHub Copilot",
+                kind: .needsAccess(
+                    path: "api.github.com",
+                    guidance: "Paste a fine-grained GitHub PAT with 'Plan: Read' (Account permissions) in Settings. Resource owner must be your own account."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        // Org-billed / no-activity signal: 200 with usageItems == [] means
+        // the user has no personal spend to report (either their Copilot
+        // seat is managed through an org/enterprise, or they simply had
+        // zero AI Credit usage in the period). Surface a specific tile so
+        // an empty section is not mistaken for a fetch failure.
+        if snap.isEmptyOrgBilled {
+            return [UsageTile(
+                id: "copilot-empty",
+                title: "GitHub Copilot",
+                kind: .text(
+                    status: "No personal usage",
+                    subtitle: "If your Copilot seat is managed by an organisation or enterprise, personal usage is not reported on this endpoint."
+                )
+            )]
+        }
+
+        var out: [UsageTile] = []
+
+        // Headline MTD spend tile. netAmount is a USD Double; the balance
+        // tile takes minor units (cents). Crash-safe against a hostile
+        // 1e300 amount via the same Int(exactly:) clamp used in Perplexity.
+        let usdMTD = snap.netAmountMTDUSD
+        let cents: Int = {
+            let clamped = max(0.0, usdMTD * 100.0)
+            guard clamped.isFinite else { return 0 }
+            return Int(exactly: clamped.rounded()) ?? Int.max
+        }()
+        out.append(UsageTile(
+            id: "copilot-mtd",
+            title: "Copilot spend (MTD)",
+            kind: .balance(
+                remainingMinorUnits: cents,
+                currency: "USD",
+                plan: periodLabel(snap),
+                resetsAt: nil        // no month-end date on the wire
+            )
+        ))
+
+        // Per-SKU breakdown as `.text` tiles. Cap at the top three so the
+        // popover does not stretch on accounts with many SKUs.
+        for item in snap.itemsBySkuDescending.prefix(3) where item.netAmount > 0 {
+            let dollarString = String(format: "USD %.2f", item.netAmount)
+            let subtitle: String = {
+                var parts: [String] = []
+                if let model = item.model, !model.isEmpty { parts.append(model) }
+                let qty = item.netQuantity
+                // Codex round-1 finding #3: `Int(qty)` traps on non-finite
+                // or oversize Doubles (`Int(1e300)` is a trap, not a
+                // truncation). Guard with `Int(exactly:)` on the rounded
+                // integer path and fall back to a %.2f render for anything
+                // that would not round-trip cleanly.
+                let qtyString: String = {
+                    if qty.isFinite && qty == qty.rounded(),
+                       let asInt = Int(exactly: qty.rounded()) {
+                        return String(asInt)
+                    }
+                    return String(format: "%.2f", qty)
+                }()
+                let unit = item.unitType.isEmpty ? "units" : item.unitType
+                parts.append("\(qtyString) \(unit)")
+                return parts.joined(separator: " · ")
+            }()
+            out.append(UsageTile(
+                id: "copilot-sku-\(item.sku.lowercased().replacingOccurrences(of: " ", with: "-"))",
+                title: item.sku,
+                kind: .text(status: dollarString, subtitle: subtitle)
+            ))
+        }
+
+        return out
+    }
+
+    /// Human label for the reporting period, e.g. "July 2026" or "2026".
+    private func periodLabel(_ snap: CopilotUsageSnapshot) -> String {
+        // Codex round-1 finding #7: hostile `month: 13` would let
+        // `Calendar.date(from:)` roll over to January of the next year,
+        // labelling the wrong billing period. Validate 1…12 before use.
+        if let month = snap.month, (1 ... 12).contains(month) {
+            let fmt = DateFormatter()
+            fmt.dateFormat = "LLLL yyyy"
+            var comps = DateComponents()
+            comps.year = snap.year
+            comps.month = month
+            comps.day = 1
+            if let date = Calendar(identifier: .gregorian).date(from: comps) {
+                return fmt.string(from: date)
+            }
+        }
+        return String(snap.year)
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: CopilotUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            // 401 site-wide (or 403 with x-ratelimit-remaining > 0): the PAT
+            // is invalid, expired, or lacks the Plan permission. Drop the
+            // stale snapshot to match the Perplexity chk1 fix pattern.
+            self.snapshot = nil
+            self.lastError = "GitHub token invalid or missing Plan permission. Re-generate a fine-grained PAT with Plan: Read."
+        case .rateLimited(let retryAfterSeconds):
+            if let sec = retryAfterSeconds, sec > 0 {
+                self.lastError = "GitHub rate-limited (retry in \(sec)s)."
+            } else {
+                self.lastError = "GitHub rate-limited. Try again shortly."
+            }
+        case .httpError(let code):
+            if (500 ..< 600).contains(code) {
+                self.lastError = "GitHub server error (HTTP \(code)). Retry later."
+            } else {
+                self.lastError = "HTTP \(code)"
+            }
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        // Use readResult() so a locked keychain (.unavailable) is
+        // distinguished from a truly-missing PAT — same audit-hardened
+        // pattern the chk1-fix branch established for Perplexity.
+        let patData: Data
+        switch credentials.readResult(CopilotUsageFetcher.patKeychainKey) {
+        case .found(let value) where !value.isEmpty:
+            patData = value
+        case .found, .missing:
+            snapshot = nil
+            lastError = nil
+            return
+        case .unavailable:
+            snapshot = nil
+            lastError = "Keychain locked or unavailable. Unlock your Mac to refresh Copilot usage."
+            return
+        }
+        guard let pat = String(data: patData, encoding: .utf8) else {
+            snapshot = nil
+            lastError = "Could not decode the stored GitHub token. Re-paste it in Settings."
+            return
+        }
+        // Cached login (if any) from a prior fetch, so we can skip the
+        // /user round-trip. read() rather than readResult() is fine here —
+        // absence just triggers a fresh discovery.
+        let cachedLogin = credentials.read(CopilotUsageFetcher.loginKeychainKey)
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        // Codex round-2 finding #1: EVERY fetch bumps the generation, not
+        // just credential changes. That way two overlapping fetches (e.g.
+        // auto-refresh timer + user's Refresh button) never share the same
+        // launchedAt, so the earlier one is always superseded by the later.
+        fetchGeneration &+= 1
+        let launchedAt = fetchGeneration
+
+        transport.fetchAll(token: pat, cachedLogin: cachedLogin) { [weak self] result, discoveredLogin in
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                // Codex round-1 findings #1 + #2: discard if the credential
+                // that launched this fetch has since been rotated or cleared.
+                guard self.fetchGeneration == launchedAt else { return }
+                // Codex round-1 finding #5 (broadened per round-2 #2): if
+                // the fetch was launched with a CACHED login and it failed
+                // in any way that suggests the login is wrong (404, 401
+                // — the user's login may have been renamed such that the
+                // cached username is now someone else's, or 403 that isn't
+                // a rate limit), drop the cache. Next fetch re-discovers
+                // via /user. rateLimited is left alone — no reason to
+                // suspect the cached login there.
+                if cachedLogin != nil {
+                    switch result {
+                    case .httpError(404), .unauthorized:
+                        self.credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+                    default:
+                        break
+                    }
+                }
+                // Persist a freshly-discovered login so future fetches skip
+                // the /user hop. Only write when the login actually changed
+                // (i.e. the transport resolved one and it differs from cache).
+                if let login = discoveredLogin, cachedLogin != login {
+                    self.credentials.write(CopilotUsageFetcher.loginKeychainKey, Data(login.utf8))
+                }
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        credentials.delete(CopilotUsageFetcher.patKeychainKey)
+        credentials.delete(CopilotUsageFetcher.loginKeychainKey)
+        // Bump BEFORE clearing state — an in-flight fetch's completion
+        // will see the new generation and skip its apply() step.
+        fetchGeneration &+= 1
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum CopilotUsageResult: Sendable {
+    case success(CopilotUsageSnapshot)
+    case unauthorized
+    /// 429, or 403 with `x-ratelimit-remaining: 0`. Optional retry hint
+    /// from `Retry-After` (seconds) or `x-ratelimit-reset` (delta).
+    case rateLimited(retryAfterSeconds: Int?)
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the login-discovery-plus-billing chain. Completion MAY be
+/// delivered on any queue; the store hops to the main actor via
+/// `Task { @MainActor }`. `discoveredLogin` is nil when the transport
+/// reused a cached login (no /user hop), and populated when a fresh
+/// discovery occurred (so the store can persist it).
+public protocol CopilotUsageTransport: Sendable {
+    func fetchAll(
+        token: String,
+        cachedLogin: String?,
+        completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void
+    )
+}
+
+/// Production transport. Chains: `GET /user` (skipped when `cachedLogin`
+/// is present) → `GET /users/{login}/settings/billing/ai_credit/usage`.
+/// Uses a private URLSession with ephemeral configuration and bounded
+/// timeouts — same chk1-audit pattern the Perplexity transport landed.
+public struct URLSessionCopilotTransport: CopilotUsageTransport {
+
+    private let userURL = URL(string: "https://api.github.com/user")!
+    private let apiBase = "https://api.github.com"
+
+    /// Chrome-shaped User-Agent is unnecessary for api.github.com (no
+    /// Cloudflare browser fingerprinting here) but a non-empty User-Agent
+    /// IS required — GitHub rejects headerless requests with 403.
+    /// Version-tagged so a Sentry-style investigation can reproduce.
+    private let userAgent = "ClaudeUsageBar/1.7 (github.com/Artzainnn/ClaudeUsageBar)"
+
+    /// Private URLSession isolated from URLSession.shared (chk1-fix pattern
+    /// carried over from Perplexity). `.ephemeral` = in-memory cookie jar
+    /// (irrelevant here — GitHub sets no auth cookies — but keeps the
+    /// isolation guarantee), no disk cache, bounded timeouts.
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
+
+    public init() {}
+
+    public func fetchAll(
+        token: String,
+        cachedLogin: String?,
+        completion: @escaping @Sendable (CopilotUsageResult, String?) -> Void
+    ) {
+        let deliver: @Sendable (CopilotUsageResult, String?) -> Void = { result, login in
+            DispatchQueue.main.async { completion(result, login) }
+        }
+
+        // Reject a token that carries control chars before it reaches an
+        // Authorization header. Same defence-in-depth as Perplexity.
+        guard let safeToken = RequestSafety.headerValue(token) else {
+            deliver(.unauthorized, nil)
+            return
+        }
+        let authHeader = "Bearer \(safeToken)"
+
+        // If we have a cached login, skip /user and hit billing directly.
+        if let login = cachedLogin, !login.isEmpty {
+            fetchUsage(login: login, authHeader: authHeader) { result in
+                deliver(result, nil)   // no new login discovered
+            }
+            return
+        }
+
+        // Otherwise discover the login via /user first.
+        get(userURL, authHeader: authHeader) { data, status, headers in
+            guard let status = status else {
+                deliver(.networkError, nil); return
+            }
+            if status == 401 {
+                deliver(.unauthorized, nil); return
+            }
+            if status == 403 {
+                if Self.isRateLimitResponse(headers) {
+                    deliver(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)), nil)
+                } else {
+                    deliver(.unauthorized, nil)
+                }
+                return
+            }
+            if status == 429 {
+                deliver(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)), nil)
+                return
+            }
+            guard status == 200, let data = data,
+                  let login = try? CopilotUsageFetcher.parseAuthenticatedUserLogin(data) else {
+                deliver(status == 200 ? .networkError : .httpError(status), nil); return
+            }
+            self.fetchUsage(login: login, authHeader: authHeader) { result in
+                deliver(result, login)
+            }
+        }
+    }
+
+    /// True when the response is a rate-limit response. Two flavours:
+    ///   - Primary: `x-ratelimit-remaining: 0`.
+    ///   - Secondary (abuse) rate limit: 403 with `Retry-After` present
+    ///     regardless of remaining. Codex round-2 finding #3: a naive
+    ///     "remaining == 0" check misclassified secondary rate limits as
+    ///     auth failures. `public` for unit-testability (same rationale as
+    ///     the Perplexity accumulator — app-only module, no external
+    ///     consumers).
+    public static func isRateLimitResponse(_ headers: [String: String]?) -> Bool {
+        guard let headers = headers else { return false }
+        if let raw = headers["x-ratelimit-remaining"], let remaining = Int(raw), remaining == 0 {
+            return true
+        }
+        if headers["retry-after"] != nil {
+            return true
+        }
+        return false
+    }
+
+    /// Extract a seconds-hint from a rate-limit response. GitHub's contract:
+    /// `Retry-After` (seconds OR HTTP-date) is preferred; if absent,
+    /// `x-ratelimit-reset` (UTC epoch seconds) gives an absolute reset time
+    /// from which we compute a delta. Returns nil when nothing is usable.
+    /// `public` for unit-testability.
+    public static func retryAfterSeconds(from headers: [String: String]?) -> Int? {
+        guard let headers = headers else { return nil }
+        if let raw = headers["retry-after"] {
+            if let s = Int(raw), s > 0 { return s }
+            // Codex round-2 finding #4: Retry-After may be an HTTP-date
+            // per RFC 9110. Parse it against RFC 1123 format.
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(identifier: "GMT")
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+            if let date = fmt.date(from: raw) {
+                let delta = Int(date.timeIntervalSince(Date()))
+                return delta > 0 ? delta : nil
+            }
+        }
+        if let raw = headers["x-ratelimit-reset"], let epoch = Int(raw) {
+            let delta = epoch - Int(Date().timeIntervalSince1970)
+            return delta > 0 ? delta : nil
+        }
+        return nil
+    }
+
+    /// Hit the AI-Credit billing endpoint for the given login.
+    private func fetchUsage(
+        login: String,
+        authHeader: String,
+        done: @escaping @Sendable (CopilotUsageResult) -> Void
+    ) {
+        // Path segment safety: the login is a semi-trusted string (comes
+        // from either a Keychain-cached value or GitHub's /user response).
+        // Encode as a single path segment so a hostile value cannot alter
+        // the path.
+        guard let encodedLogin = RequestSafety.pathSegment(login) else {
+            done(.unauthorized); return
+        }
+        let urlString = "\(apiBase)/users/\(encodedLogin)/settings/billing/ai_credit/usage"
+        guard let url = URL(string: urlString) else {
+            done(.networkError); return
+        }
+        get(url, authHeader: authHeader) { data, status, headers in
+            guard let status = status else { done(.networkError); return }
+            if status == 401 {
+                done(.unauthorized); return
+            }
+            if status == 403 {
+                if Self.isRateLimitResponse(headers) {
+                    done(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)))
+                } else {
+                    done(.unauthorized)
+                }
+                return
+            }
+            if status == 429 {
+                done(.rateLimited(retryAfterSeconds: Self.retryAfterSeconds(from: headers)))
+                return
+            }
+            guard status == 200, let data = data,
+                  let snap = try? CopilotUsageFetcher.parseUsage(data) else {
+                done(.httpError(status)); return
+            }
+            done(.success(snap))
+        }
+    }
+
+    private func get(
+        _ url: URL,
+        authHeader: String,
+        done: @escaping @Sendable (Data?, Int?, [String: String]?) -> Void
+    ) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue(CopilotUsageFetcher.apiVersion, forHTTPHeaderField: "X-GitHub-Api-Version")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        session.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil, nil); return }
+            let http = response as? HTTPURLResponse
+            let status = http?.statusCode
+            Log.info("GitHub Copilot billing API response", .count(status ?? -1))
+            // Lower-case header keys for reliable lookup — HTTPURLResponse
+            // headers are case-insensitive per the docs but Foundation
+            // preserves the wire casing.
+            var headers: [String: String] = [:]
+            if let allHeaders = http?.allHeaderFields {
+                for (k, v) in allHeaders {
+                    if let ks = k as? String, let vs = v as? String {
+                        headers[ks.lowercased()] = vs
+                    }
+                }
+            }
+            done(data, status, headers)
+        }.resume()
+    }
+}

--- a/app/CursorUsageFetcher.swift
+++ b/app/CursorUsageFetcher.swift
@@ -1,0 +1,614 @@
+// PR 11-BE — Cursor usage fetcher (feature-flagged off).
+//
+// Fourth local+web hybrid provider. Reads Cursor's own state.vscdb for
+// the WorkOS session token, then hits Cursor's web dashboard API for
+// the authoritative usage numbers. Nothing except the session token
+// leaves the machine — and only ever to cursor.com and api2.cursor.sh
+// (Cursor's own hosts).
+//
+// Data sources
+// ------------
+// 1. `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`
+//    (SQLite `ItemTable`). Three keys:
+//      - `cursorAuth/accessToken`    (JWT / WorkOS session — 400 bytes)
+//      - `cursorAuth/refreshToken`   (JWT — 400 bytes)
+//      - `cursorAuth/stripeMembershipType` (short string like "free",
+//        "pro", "enterprise")
+//
+// 2. `GET https://cursor.com/api/usage-summary`
+//    Auth: `Cookie: WorkosCursorSessionToken=<accessToken value>`.
+//    Response shape (verified against Raycast's cursor-costs
+//    extension, extensions/cursor-costs/src/types.ts on
+//    github.com/raycast/extensions):
+//
+//      {
+//        billingCycleStart: string, billingCycleEnd: string,
+//        membershipType: string, limitType: string,
+//        isUnlimited: bool,
+//        individualUsage: {
+//          plan: { enabled, used, limit, remaining,
+//                  breakdown: {included, bonus, total},
+//                  autoPercentUsed?, apiPercentUsed?, totalPercentUsed? },
+//          onDemand: { enabled, used, limit?, remaining? }
+//        },
+//        teamUsage: { … }
+//      }
+//    `used`, `limit`, `remaining` and every `breakdown` value are in
+//    CENTS (`1207` = `$12.07`).
+//
+// 3. `POST https://cursor.com/api/dashboard/get-aggregated-usage-events`
+//    Auth: same cookie. Body: `{teamId: -1, startDate: <ms>,
+//    endDate: <ms>}` (JS Date.now milliseconds).
+//    Response: `{aggregations: [{modelIntent, inputTokens?, outputTokens?,
+//    cacheWriteTokens?, cacheReadTokens?, totalCents}], totalCents, …}`.
+//    NOTE: every token count is a STRING (Cursor sends them stringified
+//    to avoid JavaScript-Number precision loss on large integers).
+//
+// 4. `POST https://api2.cursor.sh/oauth/token` (refresh flow).
+//    Body: `{grant_type: "refresh_token", client_id: "…",
+//    refresh_token: "<refreshToken value>"}`.
+//    Response: `{access_token, id_token, shouldLogout}`.
+//    IMPORTANT: `shouldLogout: true` with empty tokens is a valid
+//    server signal — Cursor tells the client the refresh has expired
+//    and the user must sign in again on cursor.com. We surface this as
+//    `.sessionExpired`, NOT as a transient error.
+//
+// Client ID for the refresh flow: `KbZUR41cY7W6zRSdpSUJ7I7mLYBKOCmB`.
+// This is Cursor's own OAuth client id (the same the Cursor.app
+// binary uses); it is not a secret and appears in every OSS Cursor
+// tracker on GitHub. Cited in the plan and in Dwtexe's now-archived
+// `cursor-stats` extension.
+//
+// Feature posture
+// ---------------
+// `features.cursor.enabled` defaults false. Nothing registers a
+// `CursorUsageStore` into the live registry yet (that lands in PR
+// 11-UI). This file compiles and unit-tests but is inert until enabled.
+
+import Foundation
+
+// MARK: - Credential shape
+
+/// Auth blob Cursor stores in its own state.vscdb. `stripeMembershipType`
+/// is an optional hint for the UI ("Pro", "Free") when the live fetch
+/// hasn't run yet.
+public struct CursorCredentials: Equatable, Sendable {
+    public var accessToken: String        // WorkOS session token — cookie
+                                          // value on live API calls
+    public var refreshToken: String       // used only for the /oauth/token
+                                          // refresh flow
+    public var stripeMembershipType: String?
+
+    public init(accessToken: String, refreshToken: String, stripeMembershipType: String?) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.stripeMembershipType = stripeMembershipType
+    }
+}
+
+// MARK: - Snapshot pieces
+
+/// One line of Cursor's per-model aggregation. Token counts are
+/// STRINGIFIED on the wire — Cursor sends them as strings to avoid
+/// JavaScript-Number precision loss on cache-write counts that can
+/// exceed 2^53. We keep them as Int64 after parsing.
+public struct CursorModelUsage: Equatable, Sendable {
+    public var modelIntent: String        // e.g. "claude-opus-4-7"
+    public var inputTokens: Int64
+    public var outputTokens: Int64
+    public var cacheWriteTokens: Int64
+    public var cacheReadTokens: Int64
+    public var totalCents: Int?           // nil when Cursor omits it
+
+    public init(
+        modelIntent: String,
+        inputTokens: Int64,
+        outputTokens: Int64,
+        cacheWriteTokens: Int64,
+        cacheReadTokens: Int64,
+        totalCents: Int?
+    ) {
+        self.modelIntent = modelIntent
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheWriteTokens = cacheWriteTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.totalCents = totalCents
+    }
+}
+
+/// Aggregate parse result. Membership fields are strings the way Cursor
+/// sends them — the UI is responsible for mapping them to friendly
+/// labels.
+public struct CursorSnapshot: Equatable, Sendable {
+    public var membershipType: String            // "pro", "free", "enterprise", …
+    public var limitType: String                 // e.g. "monthly"
+    public var isUnlimited: Bool
+    public var billingCycleStart: Date?
+    public var billingCycleEnd: Date?
+    /// Individual plan `used` in cents. e.g. 1207 = $12.07.
+    public var planUsedCents: Int
+    public var planLimitCents: Int
+    public var planRemainingCents: Int
+    /// Bonus + included cents from `individualUsage.plan.breakdown`.
+    public var planIncludedCents: Int
+    public var planBonusCents: Int
+    /// On-demand usage. `limit`/`remaining` are nullable in Cursor's
+    /// schema — nil when the plan does not enforce an on-demand cap.
+    public var onDemandEnabled: Bool
+    public var onDemandUsedCents: Int
+    public var onDemandLimitCents: Int?
+    public var onDemandRemainingCents: Int?
+    /// Per-model aggregation from `/get-aggregated-usage-events`. Empty
+    /// when the aggregation endpoint was skipped (e.g. summary-only
+    /// mode) or produced no rows.
+    public var perModel: [CursorModelUsage]
+
+    public init(
+        membershipType: String,
+        limitType: String,
+        isUnlimited: Bool,
+        billingCycleStart: Date?,
+        billingCycleEnd: Date?,
+        planUsedCents: Int,
+        planLimitCents: Int,
+        planRemainingCents: Int,
+        planIncludedCents: Int,
+        planBonusCents: Int,
+        onDemandEnabled: Bool,
+        onDemandUsedCents: Int,
+        onDemandLimitCents: Int?,
+        onDemandRemainingCents: Int?,
+        perModel: [CursorModelUsage]
+    ) {
+        self.membershipType = membershipType
+        self.limitType = limitType
+        self.isUnlimited = isUnlimited
+        self.billingCycleStart = billingCycleStart
+        self.billingCycleEnd = billingCycleEnd
+        self.planUsedCents = planUsedCents
+        self.planLimitCents = planLimitCents
+        self.planRemainingCents = planRemainingCents
+        self.planIncludedCents = planIncludedCents
+        self.planBonusCents = planBonusCents
+        self.onDemandEnabled = onDemandEnabled
+        self.onDemandUsedCents = onDemandUsedCents
+        self.onDemandLimitCents = onDemandLimitCents
+        self.onDemandRemainingCents = onDemandRemainingCents
+        self.perModel = perModel
+    }
+}
+
+// MARK: - Path resolution + credential read
+
+public enum CursorPathResolver {
+    public struct Environment: Sendable {
+        public var homeDirectoryPath: String
+        public var applicationSupportPath: String
+        public init(homeDirectoryPath: String, applicationSupportPath: String) {
+            self.homeDirectoryPath = homeDirectoryPath
+            self.applicationSupportPath = applicationSupportPath
+        }
+        public static func current() -> Environment {
+            let home = NSHomeDirectory()
+            return Environment(
+                homeDirectoryPath: home,
+                applicationSupportPath: (home as NSString).appendingPathComponent("Library/Application Support")
+            )
+        }
+    }
+    public static func stateDbPath(_ env: Environment) -> String? {
+        guard !env.applicationSupportPath.isEmpty else { return nil }
+        return "\(env.applicationSupportPath)/Cursor/User/globalStorage/state.vscdb"
+    }
+}
+
+// MARK: - Response parsing
+
+public enum CursorResponseParser {
+
+    /// Parse a `/api/usage-summary` response into the summary-half of
+    /// `CursorSnapshot` (per-model fields are empty; the caller merges
+    /// the aggregation result into this record).
+    ///
+    /// Returns nil if the top-level JSON does not decode as an object
+    /// or is missing the two required fields `membershipType` and
+    /// `individualUsage`.
+    public static func parseUsageSummary(_ data: Data) -> CursorSnapshot? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data),
+              let dict = obj as? [String: Any],
+              let membershipType = dict["membershipType"] as? String,
+              let individual = dict["individualUsage"] as? [String: Any] else {
+            return nil
+        }
+        // Codex round-1 finding #3: `plan` MUST be a JSON object; if
+        // Cursor's schema drifts and sends `plan: []`, `plan: null`,
+        // or `plan: "…"` for the required section, the parser
+        // previously fell through to zero cents and the UI rendered
+        // the empty snapshot as success. Reject the whole response
+        // instead so the store shows an error tile.
+        guard let plan = individual["plan"] as? [String: Any] else {
+            return nil
+        }
+        let limitType = dict["limitType"] as? String ?? "unknown"
+        let isUnlimited = (dict["isUnlimited"] as? Bool) ?? false
+        let cycleStart = parseISO8601(dict["billingCycleStart"])
+        let cycleEnd = parseISO8601(dict["billingCycleEnd"])
+
+        let planUsed = safeInt(plan["used"])
+        let planLimit = safeInt(plan["limit"])
+        let planRemaining = safeInt(plan["remaining"])
+        let breakdown = plan["breakdown"] as? [String: Any] ?? [:]
+        let planIncluded = safeInt(breakdown["included"])
+        let planBonus = safeInt(breakdown["bonus"])
+
+        let onDemand = individual["onDemand"] as? [String: Any] ?? [:]
+        let onDemandEnabled = (onDemand["enabled"] as? Bool) ?? false
+        let onDemandUsed = safeInt(onDemand["used"])
+        let onDemandLimit = onDemand["limit"] as? NSNull == nil ? safeIntOptional(onDemand["limit"]) : nil
+        let onDemandRemaining = onDemand["remaining"] as? NSNull == nil ? safeIntOptional(onDemand["remaining"]) : nil
+
+        return CursorSnapshot(
+            membershipType: membershipType,
+            limitType: limitType,
+            isUnlimited: isUnlimited,
+            billingCycleStart: cycleStart,
+            billingCycleEnd: cycleEnd,
+            planUsedCents: planUsed,
+            planLimitCents: planLimit,
+            planRemainingCents: planRemaining,
+            planIncludedCents: planIncluded,
+            planBonusCents: planBonus,
+            onDemandEnabled: onDemandEnabled,
+            onDemandUsedCents: onDemandUsed,
+            onDemandLimitCents: onDemandLimit,
+            onDemandRemainingCents: onDemandRemaining,
+            perModel: []
+        )
+    }
+
+    /// Parse a `/api/dashboard/get-aggregated-usage-events` response
+    /// into `[CursorModelUsage]`. Returns [] on any shape it does not
+    /// recognise (the summary still renders).
+    public static func parseAggregations(_ data: Data) -> [CursorModelUsage] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data),
+              let dict = obj as? [String: Any],
+              let arr = dict["aggregations"] as? [[String: Any]] else {
+            return []
+        }
+        var out: [CursorModelUsage] = []
+        for row in arr {
+            guard let intent = row["modelIntent"] as? String else { continue }
+            out.append(CursorModelUsage(
+                modelIntent: intent,
+                inputTokens: safeInt64(row["inputTokens"]),
+                outputTokens: safeInt64(row["outputTokens"]),
+                cacheWriteTokens: safeInt64(row["cacheWriteTokens"]),
+                cacheReadTokens: safeInt64(row["cacheReadTokens"]),
+                totalCents: (row["totalCents"] as? NSNull) == nil ? safeIntOptional(row["totalCents"]) : nil
+            ))
+        }
+        return out
+    }
+
+    /// Parse a `/oauth/token` refresh response. Empty tokens with
+    /// `shouldLogout=true` are surfaced as `.sessionExpired`. Any other
+    /// shape yields `.malformed`.
+    public enum RefreshOutcome: Equatable, Sendable {
+        case success(accessToken: String, idToken: String?)
+        case sessionExpired            // shouldLogout=true with empty tokens
+        case malformed
+    }
+    public static func parseRefresh(_ data: Data) -> RefreshOutcome {
+        guard let obj = try? JSONSerialization.jsonObject(with: data),
+              let dict = obj as? [String: Any] else {
+            return .malformed
+        }
+        let accessToken = (dict["access_token"] as? String) ?? ""
+        let idToken = dict["id_token"] as? String
+        let shouldLogout = (dict["shouldLogout"] as? Bool) ?? false
+        if shouldLogout && accessToken.isEmpty {
+            return .sessionExpired
+        }
+        if accessToken.isEmpty {
+            return .malformed
+        }
+        return .success(accessToken: accessToken, idToken: idToken)
+    }
+
+    // MARK: - Field helpers
+
+    /// True when the value is a Foundation-bridged JSON boolean.
+    /// `JSONSerialization` bridges `true` / `false` into an NSNumber
+    /// whose CFTypeID matches `CFBooleanGetTypeID()` — a plain
+    /// `as? Int` succeeds and yields 0/1. Codex round-2 finding #3.
+    private static func isJSONBoolean(_ raw: Any?) -> Bool {
+        guard let n = raw as? NSNumber else { return false }
+        return CFGetTypeID(n) == CFBooleanGetTypeID()
+    }
+
+    /// Cursor sends token counts as stringified integers (avoiding
+    /// JavaScript-Number precision loss on ≥ 2^53). Accept both Int and
+    /// String forms. Clamps to Int64.max, rejects negatives. Rejects
+    /// JSON booleans (round-2 finding #3). String forms above
+    /// Int64.max clamp to Int64.max rather than silently returning 0
+    /// (3cc round-3 finding #4).
+    public static func safeInt64(_ raw: Any?) -> Int64 {
+        if isJSONBoolean(raw) { return 0 }
+        if let i = raw as? Int64 { return max(0, i) }
+        if let i = raw as? Int { return max(0, Int64(i)) }
+        if let d = raw as? Double, d.isFinite {
+            let rounded = d.rounded()
+            if rounded <= 0 { return 0 }
+            if let n = Int64(exactly: rounded) { return n }
+            return Int64.max
+        }
+        if let s = raw as? String {
+            if let i = Int64(s) { return max(0, i) }
+            // Above Int64.max as a positive string? Clamp instead of
+            // returning 0. Rejects leading '-' (negative) and
+            // non-numeric strings.
+            let trimmed = s.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty
+                && !trimmed.hasPrefix("-")
+                && trimmed.allSatisfy({ $0.isASCII && $0.isNumber }) {
+                return Int64.max
+            }
+        }
+        return 0
+    }
+
+    /// Non-negative Int (0-clamped) used for the cents fields, which the
+    /// Cursor schema always sends as bare JSON numbers. Rejects JSON
+    /// booleans (round-2 finding #3).
+    public static func safeInt(_ raw: Any?) -> Int {
+        if isJSONBoolean(raw) { return 0 }
+        if let i = raw as? Int { return max(0, i) }
+        if let d = raw as? Double, d.isFinite {
+            let rounded = d.rounded()
+            if rounded <= 0 { return 0 }
+            if let n = Int(exactly: rounded) { return n }
+            return Int.max
+        }
+        if let s = raw as? String, let i = Int(s) { return max(0, i) }
+        return 0
+    }
+
+    /// Cents fields that may legitimately be null (on-demand
+    /// remaining/limit on an unlimited plan). Returns nil for null /
+    /// missing / unparseable / boolean input; otherwise the
+    /// non-negative Int. Rejects JSON booleans (round-2 finding #3).
+    public static func safeIntOptional(_ raw: Any?) -> Int? {
+        if raw == nil || raw is NSNull { return nil }
+        if isJSONBoolean(raw) { return nil }
+        if let i = raw as? Int { return max(0, i) }
+        if let d = raw as? Double, d.isFinite {
+            let rounded = d.rounded()
+            if rounded <= 0 { return 0 }
+            if let n = Int(exactly: rounded) { return n }
+            return Int.max
+        }
+        if let s = raw as? String, let i = Int(s) { return max(0, i) }
+        return nil
+    }
+
+    /// ISO 8601 with fractional-second tolerance — same shape as
+    /// Claude Code timestamps.
+    public static func parseISO8601(_ raw: Any?) -> Date? {
+        guard let s = raw as? String else { return nil }
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = f.date(from: s) { return d }
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: s)
+    }
+}
+
+// MARK: - Credential read
+
+public enum CursorCredentialReader {
+
+    /// Read the three `cursorAuth/*` rows from Cursor's state.vscdb.
+    /// Throws every SQLiteReaderError variant; returns nil when the
+    /// database opened cleanly but the three keys are absent (fresh
+    /// Cursor install with no sign-in yet).
+    public static func read(from stateDbPath: String) throws -> CursorCredentials? {
+        let reader = try SQLiteReader(path: stateDbPath)
+        defer { reader.close() }
+        // One query per key — the ItemTable schema is `(key, value)`
+        // with `ON CONFLICT REPLACE`, so a straight WHERE lookup is
+        // O(index) and cheaper than a `WHERE key IN (…)` list.
+        func read(_ key: String) throws -> String? {
+            let rows = try reader.query(
+                "SELECT value FROM ItemTable WHERE key = ? LIMIT 1",
+                binds: [.text(key)]
+            ) { $0.string("value") }
+            return rows.first ?? nil
+        }
+        let access = try read("cursorAuth/accessToken")
+        let refresh = try read("cursorAuth/refreshToken")
+        let membership = try read("cursorAuth/stripeMembershipType")
+        guard let access = access, let refresh = refresh else { return nil }
+        return CursorCredentials(
+            accessToken: access,
+            refreshToken: refresh,
+            stripeMembershipType: membership
+        )
+    }
+}
+
+// MARK: - Transport
+
+/// Terminal outcomes the transport layer surfaces to the store. Every
+/// live-fetch code path (summary, aggregation, refresh) maps to one of
+/// these; keeping the enum flat means the store's apply hop is a
+/// single switch.
+public enum CursorTransportResult: Sendable {
+    case success(Data)                   // 2xx with a body
+    case unauthorized                    // 401/403 — trigger refresh
+    case rateLimited(retryAfterSec: Int?) // 429
+    case httpError(Int)                  // any other non-2xx
+    case networkError                    // URLSession error
+    case sessionExpired                  // Refresh flow returned
+                                         // shouldLogout=true. Store shows
+                                         // "sign in again in Cursor".
+}
+
+public protocol CursorTransport: Sendable {
+    func fetchUsageSummary(
+        cookieToken: String,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    )
+    func fetchAggregations(
+        cookieToken: String,
+        startDateMs: Int64,
+        endDateMs: Int64,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    )
+    func refreshAccessToken(
+        refreshToken: String,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    )
+}
+
+/// RFC 6265 §4.1.1 cookie-octet validator. Cursor's session tokens are
+/// base64url-encoded WorkOS JWTs (letters, digits, `-`, `_`, `.`), all
+/// of which are inside the cookie-octet range. A hostile token
+/// containing `;`, `,`, `"`, `\`, space, or a control character would
+/// splice a second cookie or split the header — this validator
+/// rejects that before the header is composed. Codex round-1 finding #4.
+public enum CursorTokenSafety {
+    public static func isValidCookieValue(_ raw: String) -> Bool {
+        guard !raw.isEmpty else { return false }
+        for scalar in raw.unicodeScalars {
+            let v = scalar.value
+            // %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E per RFC 6265.
+            // Anything outside those ranges is a cookie-octet violation
+            // (including CTLs, DQUOTE, comma, semicolon, whitespace,
+            // backslash, and every non-ASCII character).
+            let ok = v == 0x21
+                || (v >= 0x23 && v <= 0x2B)
+                || (v >= 0x2D && v <= 0x3A)
+                || (v >= 0x3C && v <= 0x5B)
+                || (v >= 0x5D && v <= 0x7E)
+            if !ok { return false }
+        }
+        return true
+    }
+}
+
+/// Production transport. Uses URLSession; all three endpoints share the
+/// same cookie shape. The refresh endpoint uses POST with a JSON body.
+public struct URLSessionCursorTransport: CursorTransport {
+    private static let clientId = "KbZUR41cY7W6zRSdpSUJ7I7mLYBKOCmB"
+    private static let summaryURL = URL(string: "https://cursor.com/api/usage-summary")!
+    private static let aggregationURL = URL(string: "https://cursor.com/api/dashboard/get-aggregated-usage-events")!
+    private static let refreshURL = URL(string: "https://api2.cursor.sh/oauth/token")!
+
+    public init() {}
+
+    public func fetchUsageSummary(
+        cookieToken: String,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    ) {
+        var req = URLRequest(url: Self.summaryURL)
+        req.httpMethod = "GET"
+        applyStandardHeaders(&req, cookieToken: cookieToken)
+        dispatch(req, completion: completion)
+    }
+
+    public func fetchAggregations(
+        cookieToken: String,
+        startDateMs: Int64,
+        endDateMs: Int64,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    ) {
+        var req = URLRequest(url: Self.aggregationURL)
+        req.httpMethod = "POST"
+        applyStandardHeaders(&req, cookieToken: cookieToken)
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "teamId": -1,
+            "startDate": startDateMs,
+            "endDate": endDateMs,
+        ]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+        dispatch(req, completion: completion)
+    }
+
+    public func refreshAccessToken(
+        refreshToken: String,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    ) {
+        guard let safeRefresh = RequestSafety.headerValue(refreshToken) else {
+            completion(.sessionExpired)
+            return
+        }
+        var req = URLRequest(url: Self.refreshURL)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+        let body: [String: Any] = [
+            "grant_type": "refresh_token",
+            "client_id": Self.clientId,
+            "refresh_token": safeRefresh,
+        ]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+        dispatch(req, completion: completion)
+    }
+
+    // MARK: - Helpers
+
+    /// Standard headers Cursor's dashboard sends. Kept identical to the
+    /// browser flow so a schema-level change (e.g. Referer-based auth
+    /// enforcement) doesn't tomb-stone the endpoint for us.
+    private func applyStandardHeaders(_ req: inout URLRequest, cookieToken: String) {
+        // Cookie name is documented in the OSS Raycast extension and
+        // matches Cursor's own web app. Value comes from
+        // cursorAuth/accessToken.
+        //
+        // Codex round-1 finding #4: `RequestSafety.headerValue`
+        // permits `;`, `,`, space, `\`, `"` — a compromised DB token
+        // like `abc; WorkosCursorSessionToken=other` would splice a
+        // second cookie into the header. Validate against RFC 6265
+        // §4.1.1 cookie-octet set BEFORE composing the header.
+        guard CursorTokenSafety.isValidCookieValue(cookieToken) else {
+            return  // caller receives the unauthorized branch when
+                    // Cursor rejects the missing/wrong cookie
+        }
+        req.setValue("WorkosCursorSessionToken=\(cookieToken)", forHTTPHeaderField: "Cookie")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+        req.setValue("https://cursor.com", forHTTPHeaderField: "Origin")
+        req.setValue("https://cursor.com/dashboard?tab=usage", forHTTPHeaderField: "Referer")
+    }
+
+    private func dispatch(
+        _ req: URLRequest,
+        completion: @escaping @Sendable (CursorTransportResult) -> Void
+    ) {
+        let deliver: @Sendable (CursorTransportResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+        URLSession.shared.dataTask(with: req) { data, response, error in
+            if error != nil { deliver(.networkError); return }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError); return
+            }
+            Log.info("Cursor API response", .count(http.statusCode))
+            switch http.statusCode {
+            case 200:
+                if let data = data { deliver(.success(data)) }
+                else { deliver(.networkError) }
+            case 401, 403:
+                deliver(.unauthorized)
+            case 429:
+                let retryAfter = (http.value(forHTTPHeaderField: "Retry-After")).flatMap { Int($0) }
+                deliver(.rateLimited(retryAfterSec: retryAfter))
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/CursorUsageStore.swift
+++ b/app/CursorUsageStore.swift
@@ -1,0 +1,598 @@
+// PR 11-BE — Cursor UsageProvider store (feature-flag off).
+//
+// Cursor hybrid provider: reads Cursor's own state.vscdb for the
+// WorkOS session token, then fetches usage from cursor.com. Refresh
+// flow via api2.cursor.sh is invoked ONLY on 401 — never proactively,
+// so a valid session stays valid.
+//
+// State machine (per fetch tick):
+//
+//   1. Read credentials from state.vscdb.
+//      Missing / SQLITE_CANTOPEN → .needsAccess or .pathMissing.
+//   2. GET /api/usage-summary with the accessToken cookie.
+//      2xx → parseUsageSummary → 3. Aggregation.
+//      401 → REFRESH sub-flow (once).
+//      Other → error tile.
+//   3. POST /get-aggregated-usage-events for the current billing cycle
+//      (from step 2's response). 2xx → merge; other → summary-only.
+//   4. REFRESH: POST /oauth/token. Success → update state.vscdb by the
+//      OS-native path? NO — Cursor itself writes back to state.vscdb;
+//      a third-party writing there would race Cursor's own writes.
+//      Instead we keep the new accessToken IN-MEMORY only for this
+//      session; a subsequent Cursor launch will write a fresh one to
+//      the DB and we'll pick it up naturally. shouldLogout → surface
+//      "sign in again in Cursor".
+//
+// Feature posture: `features.cursor.enabled` defaults false. Nothing
+// registers a CursorUsageStore into `AppDelegate.providers` yet —
+// that lands in PR 11-UI along with `ProviderCopy.help(for: "cursor")`.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class CursorUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "cursor"
+    public let displayName: String = "Cursor"
+    public let featureFlagKey: String = "features.cursor.enabled"
+
+    // MARK: - Observable state
+
+    @Published public private(set) var snapshot: CursorSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    @Published public private(set) var tccState: TCCState = .granted
+    /// True when the refresh token is also invalid and the user must
+    /// re-authenticate in Cursor itself. The tile becomes an
+    /// informational card until Cursor writes a new token to
+    /// state.vscdb (the next Cursor launch after a successful login).
+    @Published public private(set) var sessionExpired: Bool = false
+
+    // MARK: - Dependencies
+
+    private let defaults: UserDefaults
+    private let resolvePath: @Sendable () -> String?
+    private let tccProbe: @Sendable (String) -> TCCState
+    private let readCredentials: @Sendable (String) throws -> CursorCredentials?
+    private let transport: CursorTransport
+    private let workQueue: DispatchQueue
+    private let clock: @Sendable () -> Date
+
+    private var fetchGeneration: UInt64 = 0
+
+    /// In-memory override for the accessToken after a successful
+    /// refresh — Cursor itself writes back to state.vscdb; a
+    /// third-party writing there would race Cursor's own writes.
+    ///
+    /// Codex round-1 finding #5: we must remember the DB accessToken
+    /// value that was current WHEN the refresh happened. If the DB
+    /// later produces a DIFFERENT accessToken (a real re-login, a
+    /// second account, Cursor's own refresh finally committing), the
+    /// in-memory override is stale and must be dropped so the DB
+    /// value takes precedence.
+    private var refreshedAccessToken: String?
+    private var refreshedFromDbToken: String?
+    /// The DB accessToken value seen when `sessionExpired` was set to
+    /// true. Codex round-1 finding #6: on the next fetch, if the DB
+    /// value differs, the user has re-signed-in and we clear the
+    /// sticky flag. Prevents a 429/500/network error from leaving the
+    /// user stuck on "Sign in again" after they already did.
+    private var sessionExpiredForDbToken: String?
+
+    public init(
+        defaults: UserDefaults = .standard,
+        resolvePath: @escaping @Sendable () -> String? = {
+            CursorPathResolver.stateDbPath(.current())
+        },
+        tccProbe: @escaping @Sendable (String) -> TCCState = { TCCProbe.probe(path: $0) },
+        readCredentials: @escaping @Sendable (String) throws -> CursorCredentials? = {
+            try CursorCredentialReader.read(from: $0)
+        },
+        transport: CursorTransport = URLSessionCursorTransport(),
+        workQueue: DispatchQueue = DispatchQueue(
+            label: "com.claude.usagebar.cursor.parse",
+            qos: .utility
+        ),
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.defaults = defaults
+        self.resolvePath = resolvePath
+        self.tccProbe = tccProbe
+        self.readCredentials = readCredentials
+        self.transport = transport
+        self.workQueue = workQueue
+        self.clock = clock
+    }
+
+    // MARK: - UsageProvider
+
+    public var isEnabled: Bool { defaults.bool(forKey: featureFlagKey) }
+    public var isConfigured: Bool { isEnabled }
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if sessionExpired {
+            return [UsageTile(
+                id: "cursor-session-expired",
+                title: displayName,
+                kind: .text(
+                    status: "Sign in again in Cursor",
+                    subtitle: "Your Cursor session expired. Open Cursor, sign in, then click Refresh here."
+                )
+            )]
+        }
+
+        switch tccState {
+        case .denied:
+            let copy = LocalProviderAccessGuide.copy(for: .denied, appName: displayName)
+            return [UsageTile(
+                id: "cursor-needs-access",
+                title: copy.title,
+                kind: .needsAccess(
+                    path: "~/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+                    guidance: copy.guidance
+                )
+            )]
+        case .pathMissing:
+            return [UsageTile(
+                id: "cursor-not-installed",
+                title: displayName,
+                kind: .text(
+                    status: "No Cursor install found",
+                    subtitle: "Install Cursor and sign in once. If Cursor is not on this Mac, disable this provider in Settings."
+                )
+            )]
+        case .granted:
+            break
+        }
+
+        guard let snap = snapshot else {
+            return [UsageTile(
+                id: "cursor-loading",
+                title: displayName,
+                kind: .text(status: "Loading…", subtitle: nil)
+            )]
+        }
+
+        var out: [UsageTile] = []
+
+        // Plan tile — membershipType is Cursor's own string ("pro",
+        // "free", "enterprise", …). Displayed capitalised.
+        out.append(UsageTile(
+            id: "cursor-plan",
+            title: "Cursor plan",
+            kind: .text(
+                status: Self.friendlyPlanLabel(snap.membershipType),
+                subtitle: snap.isUnlimited ? "Unlimited" : nil
+            )
+        ))
+
+        // MTD usage tile. planLimitCents=0 renders as a fraction of 0 →
+        // hide the bar; use a counter with the used cents as major
+        // units. When limit>0, render a bar.
+        if snap.planLimitCents > 0 {
+            let fraction = min(1.0, max(0.0, Double(snap.planUsedCents) / Double(snap.planLimitCents)))
+            out.append(UsageTile(
+                id: "cursor-usage-mtd",
+                title: "Plan usage",
+                kind: .bar(
+                    fraction: fraction,
+                    resetsAt: snap.billingCycleEnd,
+                    badge: Self.formatDollarsFromCents(snap.planUsedCents)
+                )
+            ))
+        } else if snap.planUsedCents > 0 {
+            out.append(UsageTile(
+                id: "cursor-usage-mtd",
+                title: "Plan usage",
+                kind: .text(
+                    status: Self.formatDollarsFromCents(snap.planUsedCents),
+                    subtitle: snap.billingCycleEnd.map { "Resets \(Self.humanBillingReset($0))" }
+                )
+            ))
+        }
+
+        // On-demand tile — only when the plan actually has an on-demand
+        // component and it has non-zero usage.
+        if snap.onDemandEnabled && snap.onDemandUsedCents > 0 {
+            let subtitle: String?
+            if let limit = snap.onDemandLimitCents, limit > 0 {
+                let remaining = snap.onDemandRemainingCents ?? 0
+                subtitle = "\(Self.formatDollarsFromCents(remaining)) remaining of \(Self.formatDollarsFromCents(limit))"
+            } else {
+                subtitle = nil
+            }
+            out.append(UsageTile(
+                id: "cursor-on-demand",
+                title: "On-demand",
+                kind: .text(
+                    status: Self.formatDollarsFromCents(snap.onDemandUsedCents),
+                    subtitle: subtitle
+                )
+            ))
+        }
+
+        // Per-model tile — top-3 by totalCents descending.
+        let byModel = snap.perModel.sorted { ($0.totalCents ?? 0) > ($1.totalCents ?? 0) }
+        if !byModel.isEmpty {
+            let top = byModel.prefix(3)
+            let lines = top.map { entry -> String in
+                let cost = entry.totalCents.map { Self.formatDollarsFromCents($0) } ?? "—"
+                // Codex round-2 finding #1: saturating add — a
+                // hostile aggregation with Int64.max in one field
+                // would wrap `&+` to Int64.min and then trip
+                // `abs(Int.min)` in the formatter.
+                let totalTokens = Self.saturatingAddInt64(
+                    Self.saturatingAddInt64(entry.inputTokens, entry.outputTokens),
+                    Self.saturatingAddInt64(entry.cacheWriteTokens, entry.cacheReadTokens)
+                )
+                return "\(entry.modelIntent) — \(cost) (\(Self.formatTokens(totalTokens)))"
+            }
+            out.append(UsageTile(
+                id: "cursor-per-model",
+                title: "Top models this cycle",
+                kind: .text(
+                    status: lines.first ?? "",
+                    subtitle: lines.dropFirst().joined(separator: "\n")
+                )
+            ))
+        }
+        return out
+    }
+
+    // MARK: - Fetch state machine
+
+    public func fetch() {
+        fetchGeneration &+= 1
+        guard isEnabled else {
+            snapshot = nil
+            sessionExpired = false
+            refreshedAccessToken = nil
+            refreshedFromDbToken = nil
+            return
+        }
+        let launchGeneration = fetchGeneration
+
+        guard let path = resolvePath() else {
+            lastError = "Could not resolve Cursor data path."
+            return
+        }
+        let probed = tccProbe(path)
+        self.tccState = probed
+        if probed != .granted {
+            self.snapshot = nil
+            self.lastError = nil
+            self.sessionExpired = false
+            return
+        }
+
+        let readCreds = self.readCredentials
+        let inMemoryRefreshed = self.refreshedAccessToken
+        let refreshedFromDbToken = self.refreshedFromDbToken
+        workQueue.async { [weak self] in
+            let credOutcome: CredentialReadOutcome
+            do {
+                if let creds = try readCreds(path) {
+                    // Codex round-1 finding #5: overlay the in-memory
+                    // refreshed accessToken ONLY when the DB
+                    // accessToken is still the same one we refreshed
+                    // from. If the DB now holds a different value,
+                    // Cursor has since written a fresh token (a
+                    // re-login, or an account swap) and we must
+                    // prefer the DB value.
+                    let effectiveToken: String
+                    let usedRefreshed = (inMemoryRefreshed != nil
+                        && refreshedFromDbToken == creds.accessToken)
+                    if usedRefreshed, let refreshed = inMemoryRefreshed {
+                        effectiveToken = refreshed
+                    } else {
+                        effectiveToken = creds.accessToken
+                    }
+                    let effective = CursorCredentials(
+                        accessToken: effectiveToken,
+                        refreshToken: creds.refreshToken,
+                        stripeMembershipType: creds.stripeMembershipType
+                    )
+                    credOutcome = .success(effective, usedRefreshed: usedRefreshed, dbAccessToken: creds.accessToken)
+                } else {
+                    credOutcome = .missing
+                }
+            } catch SQLiteReaderError.notFound {
+                credOutcome = .pathMissing
+            } catch SQLiteReaderError.openFailed {
+                credOutcome = .denied
+            } catch SQLiteReaderError.notADatabase, SQLiteReaderError.encrypted {
+                credOutcome = .otherError("Cursor state.vscdb is not readable.")
+            } catch SQLiteReaderError.schemaMismatch {
+                credOutcome = .otherError("Cursor state.vscdb schema changed.")
+            } catch SQLiteReaderError.busy {
+                credOutcome = .transientBusy
+            } catch {
+                credOutcome = .otherError("\(error)")
+            }
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                guard self.isEnabled else { return }
+                guard launchGeneration == self.fetchGeneration else { return }
+                self.applyCredentialOutcome(credOutcome, launchGeneration: launchGeneration)
+            }
+        }
+    }
+
+    public func clear() {
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        sessionExpired = false
+        sessionExpiredForDbToken = nil
+        refreshedAccessToken = nil
+        refreshedFromDbToken = nil
+        fetchGeneration &+= 1
+    }
+
+    // MARK: - Credential-outcome application (main actor)
+
+    private enum CredentialReadOutcome: Sendable {
+        // usedRefreshed=true means the effective accessToken is our
+        // in-memory refresh, not the DB value; dbAccessToken carries the
+        // DB value regardless so a re-login can invalidate the override.
+        case success(CursorCredentials, usedRefreshed: Bool, dbAccessToken: String)
+        case missing                 // DB opened, but keys absent
+        case pathMissing
+        case denied
+        case transientBusy
+        case otherError(String)
+    }
+
+    private func applyCredentialOutcome(_ outcome: CredentialReadOutcome, launchGeneration: UInt64) {
+        switch outcome {
+        case .success(let creds, let usedRefreshed, let dbAccessToken):
+            // Codex round-1 finding #5: if the DB accessToken has
+            // changed since our last refresh, drop the in-memory
+            // override so the fresh DB value takes precedence.
+            if !usedRefreshed && refreshedAccessToken != nil {
+                refreshedAccessToken = nil
+                refreshedFromDbToken = nil
+            }
+            // Codex round-1 finding #6: clear the sticky
+            // sessionExpired flag if the DB token has changed since
+            // it was set (user has re-signed-in). Prevents a
+            // 429/500/network error on a fresh sign-in from leaving
+            // the user staring at "Sign in again" when they already
+            // did.
+            if sessionExpired && sessionExpiredForDbToken != dbAccessToken {
+                sessionExpired = false
+                sessionExpiredForDbToken = nil
+            }
+            // Codex round-2 finding #2: if sessionExpired is still
+            // true after the DB-token-change check above, the user
+            // has NOT re-signed-in. Skip the HTTP roundtrip
+            // entirely — otherwise every 60-second timer tick sends
+            // a known-expired refresh token to Cursor. Sign-in is
+            // detected on the next fetch when the DB accessToken
+            // finally changes.
+            if sessionExpired {
+                return
+            }
+            // Kick off the summary fetch. Aggregation is chained on
+            // success. 401 triggers refresh.
+            transport.fetchUsageSummary(cookieToken: creds.accessToken) { [weak self] result in
+                Task { @MainActor [weak self] in
+                    guard let self = self else { return }
+                    guard self.isEnabled else { return }
+                    guard launchGeneration == self.fetchGeneration else { return }
+                    self.applySummaryResult(result, creds: creds, launchGeneration: launchGeneration, isRetry: false, dbAccessToken: dbAccessToken)
+                }
+            }
+        case .missing:
+            snapshot = nil
+            lastError = "Cursor has no saved session — sign in to Cursor first."
+        case .pathMissing:
+            tccState = .pathMissing
+            snapshot = nil
+            lastError = nil
+        case .denied:
+            tccState = .denied
+            snapshot = nil
+            lastError = nil
+        case .transientBusy:
+            lastError = "Cursor is holding the database — retry on next tick."
+        case .otherError(let msg):
+            lastError = msg
+        }
+    }
+
+    // MARK: - Summary result
+
+    private func applySummaryResult(
+        _ result: CursorTransportResult,
+        creds: CursorCredentials,
+        launchGeneration: UInt64,
+        isRetry: Bool,
+        dbAccessToken: String
+    ) {
+        switch result {
+        case .success(let data):
+            guard let summary = CursorResponseParser.parseUsageSummary(data) else {
+                lastError = "Cursor usage-summary response did not decode."
+                return
+            }
+            // Chain aggregation with the billing-cycle window from the
+            // summary. If the summary omitted cycle bounds, fall back
+            // to the last 30 days.
+            let now = clock()
+            let startMs = Int64((summary.billingCycleStart ?? now.addingTimeInterval(-30 * 86_400)).timeIntervalSince1970 * 1000.0)
+            let endMs = Int64((summary.billingCycleEnd ?? now).timeIntervalSince1970 * 1000.0)
+            transport.fetchAggregations(cookieToken: creds.accessToken, startDateMs: startMs, endDateMs: endMs) { [weak self] result in
+                Task { @MainActor [weak self] in
+                    guard let self = self else { return }
+                    guard self.isEnabled else { return }
+                    guard launchGeneration == self.fetchGeneration else { return }
+                    self.applyAggregationResult(result, summary: summary, launchGeneration: launchGeneration)
+                }
+            }
+        case .unauthorized:
+            if isRetry {
+                // Second consecutive 401 after a successful refresh
+                // means the refreshed token is also being rejected —
+                // give up and surface session-expired.
+                sessionExpired = true
+                sessionExpiredForDbToken = dbAccessToken
+                snapshot = nil
+                lastError = nil
+                return
+            }
+            // Trigger refresh flow.
+            transport.refreshAccessToken(refreshToken: creds.refreshToken) { [weak self] result in
+                Task { @MainActor [weak self] in
+                    guard let self = self else { return }
+                    guard self.isEnabled else { return }
+                    guard launchGeneration == self.fetchGeneration else { return }
+                    self.applyRefreshResult(result, creds: creds, launchGeneration: launchGeneration, dbAccessToken: dbAccessToken)
+                }
+            }
+        case .rateLimited(let retryAfter):
+            // Slow polling — do not clear the existing snapshot; next
+            // tick will retry.
+            let sec = retryAfter.map { " (retry after \($0)s)" } ?? ""
+            lastError = "Cursor rate-limited — waiting for next tick\(sec)."
+        case .httpError(let code):
+            lastError = "Cursor API error: HTTP \(code)"
+        case .networkError:
+            lastError = "Network error — Cursor could not be reached."
+        case .sessionExpired:
+            sessionExpired = true
+            sessionExpiredForDbToken = dbAccessToken
+            snapshot = nil
+            lastError = nil
+        }
+    }
+
+    // MARK: - Aggregation result
+
+    private func applyAggregationResult(
+        _ result: CursorTransportResult,
+        summary: CursorSnapshot,
+        launchGeneration: UInt64
+    ) {
+        var merged = summary
+        if case .success(let data) = result {
+            merged.perModel = CursorResponseParser.parseAggregations(data)
+        }
+        // Aggregation failure is non-fatal — we still render the
+        // summary. Only overwrite snapshot with the merged value.
+        self.snapshot = merged
+        self.lastUpdatedAt = clock()
+        self.lastError = nil
+        self.sessionExpired = false
+        Log.info("Cursor snapshot parsed", .count(merged.perModel.count))
+    }
+
+    // MARK: - Refresh result
+
+    private func applyRefreshResult(
+        _ result: CursorTransportResult,
+        creds: CursorCredentials,
+        launchGeneration: UInt64,
+        dbAccessToken: String
+    ) {
+        switch result {
+        case .success(let data):
+            switch CursorResponseParser.parseRefresh(data) {
+            case .success(let newAccessToken, _):
+                self.refreshedAccessToken = newAccessToken
+                // Remember which DB accessToken we refreshed from —
+                // Codex round-1 finding #5. A future fetch whose DB
+                // token differs drops the override.
+                self.refreshedFromDbToken = dbAccessToken
+                // Retry the summary fetch with the new cookie. isRetry
+                // = true so a second 401 goes straight to
+                // session-expired.
+                let effective = CursorCredentials(
+                    accessToken: newAccessToken,
+                    refreshToken: creds.refreshToken,
+                    stripeMembershipType: creds.stripeMembershipType
+                )
+                transport.fetchUsageSummary(cookieToken: newAccessToken) { [weak self] result in
+                    Task { @MainActor [weak self] in
+                        guard let self = self else { return }
+                        guard self.isEnabled else { return }
+                        guard launchGeneration == self.fetchGeneration else { return }
+                        self.applySummaryResult(result, creds: effective, launchGeneration: launchGeneration, isRetry: true, dbAccessToken: dbAccessToken)
+                    }
+                }
+            case .sessionExpired:
+                self.sessionExpired = true
+                self.sessionExpiredForDbToken = dbAccessToken
+                self.snapshot = nil
+                self.lastError = nil
+                self.refreshedAccessToken = nil
+                self.refreshedFromDbToken = nil
+            case .malformed:
+                self.lastError = "Cursor refresh response did not decode."
+            }
+        case .unauthorized, .sessionExpired:
+            self.sessionExpired = true
+            self.sessionExpiredForDbToken = dbAccessToken
+            self.snapshot = nil
+            self.lastError = nil
+            self.refreshedAccessToken = nil
+            self.refreshedFromDbToken = nil
+        case .rateLimited(let retryAfter):
+            let sec = retryAfter.map { " (retry after \($0)s)" } ?? ""
+            self.lastError = "Cursor refresh rate-limited\(sec)."
+        case .httpError(let code):
+            self.lastError = "Cursor refresh error: HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error during refresh."
+        }
+    }
+
+    // MARK: - Formatting helpers
+
+    /// Cursor's `membershipType` values seen in the wild:
+    /// "free", "pro", "pro-plus", "business", "enterprise", "team".
+    /// Display capitalised with any hyphens turned into spaces.
+    public nonisolated static func friendlyPlanLabel(_ raw: String) -> String {
+        let cleaned = raw.replacingOccurrences(of: "-", with: " ")
+        return cleaned.split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+
+    /// Format a cent value as "$X.XX". Reuses the ClaudeCode formatter
+    /// via Double conversion so tests are consistent across providers.
+    public nonisolated static func formatDollarsFromCents(_ cents: Int) -> String {
+        return ClaudeCodeUsageStore.formatUSD(Double(cents) / 100.0)
+    }
+
+    public nonisolated static func formatTokens(_ count: Int64) -> String {
+        if count < 0 { return ClaudeCodeUsageStore.formatTokens(0) }
+        if count > Int64(Int.max) { return ClaudeCodeUsageStore.formatTokens(Int.max) }
+        return ClaudeCodeUsageStore.formatTokens(Int(count))
+    }
+
+    /// Non-wrapping non-negative Int64 addition. Codex round-2
+    /// finding #1: aggregation token counts (input+output+cache*)
+    /// summed with `&+` could wrap to Int64.min on hostile inputs,
+    /// producing a negative count that then crashes formatTokens via
+    /// `abs(Int.min)`. Saturating math clamps the total to Int64.max.
+    public nonisolated static func saturatingAddInt64(_ a: Int64, _ b: Int64) -> Int64 {
+        let a_ = max(0, a)
+        let b_ = max(0, b)
+        let (sum, overflow) = a_.addingReportingOverflow(b_)
+        return overflow ? Int64.max : sum
+    }
+
+    /// Short label for a billing-cycle reset — the Cursor tile's badge.
+    public nonisolated static func humanBillingReset(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "d MMM"
+        return "on \(f.string(from: date))"
+    }
+}

--- a/app/DeepSeekUsageFetcher.swift
+++ b/app/DeepSeekUsageFetcher.swift
@@ -147,34 +147,73 @@ public struct KeychainStore: CredentialStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
+            // Use the modern data-protection keychain for every item, as the
+            // security standard requires for spending credentials. Set on the
+            // base query so read/update/delete all target the same keychain
+            // the item was written to.
+            kSecUseDataProtectionKeychain as String: true,
         ]
     }
 
     public func read(_ key: String) -> Data? {
+        if case .found(let data) = readResult(key) { return data }
+        return nil
+    }
+
+    /// Richer read that distinguishes a missing item from a keychain that is
+    /// present but unavailable (locked, access denied). Callers that gate a
+    /// "not configured" onboarding state should use this so a transient
+    /// unavailability is not mistaken for "no credential", which would wrongly
+    /// prompt the user to re-paste. `read` remains for the common case.
+    public func readResult(_ key: String) -> CredentialReadResult {
         var query = baseQuery(key)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
 
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess else { return nil }
-        return item as? Data
+        switch status {
+        case errSecSuccess:
+            if let data = item as? Data { return .found(data) }
+            return .missing
+        case errSecItemNotFound:
+            return .missing
+        default:
+            // errSecInteractionNotAllowed (locked), errSecAuthFailed, etc.
+            return .unavailable(status)
+        }
     }
 
     public func write(_ key: String, _ value: Data) {
-        // Upsert: try to update an existing item first; if none exists, add.
+        // Upsert. Update first; if the item does not exist, add it. Crucially,
+        // the update path ALSO refreshes kSecAttrAccessible so an item created
+        // by an older build with a weaker accessibility class is upgraded to
+        // the current one (rather than silently keeping the weak attribute).
         let query = baseQuery(key)
-        let attributes: [String: Any] = [kSecValueData as String: value]
+        let attributes: [String: Any] = [
+            kSecValueData as String: value,
+            // WhenUnlockedThisDeviceOnly: the credential is inaccessible
+            // whenever the device is locked, never syncs to iCloud Keychain,
+            // and does not migrate to a new device. This is the least-
+            // privilege class mandated for spending credentials (stricter than
+            // AfterFirstUnlock, which stays readable while locked).
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
 
         if updateStatus == errSecItemNotFound {
             var addQuery = baseQuery(key)
             addQuery[kSecValueData as String] = value
-            // Only unlocked-while-this-device flags; the credential never
-            // syncs to iCloud Keychain and is unavailable before first
-            // unlock. Matches least-privilege for a spending credential.
-            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-            SecItemAdd(addQuery as CFDictionary, nil)
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                // The item was neither updated nor added (e.g. locked keychain
+                // or a duplicate race). Log the failure category (never the
+                // value) so a silently-dropped write is diagnosable.
+                Log.info("Keychain write failed", .count(Int(addStatus)))
+            }
+        } else if updateStatus != errSecSuccess {
+            Log.info("Keychain update failed", .count(Int(updateStatus)))
         }
     }
 

--- a/app/DeepSeekUsageFetcher.swift
+++ b/app/DeepSeekUsageFetcher.swift
@@ -1,0 +1,184 @@
+// PR 4-BE — DeepSeek usage fetcher + the first Keychain credential store.
+//
+// DeepSeek is the template "paste-a-key" provider: the user pastes an
+// `sk-...` API key, which is stored in the macOS Keychain (a spending
+// credential — it must never sit in UserDefaults). The provider then polls
+// `GET https://api.deepseek.com/user/balance` for the account balance.
+//
+// This file ships two things:
+//   1. DeepSeekUsageFetcher — Sendable value type, pure parser, mirroring
+//      the Anthropic/Codex fetchers. Fixtures hit `parse(_:)`.
+//   2. KeychainStore — the first concrete CredentialStore (the protocol was
+//      introduced in PR 47). Backs every future spending credential
+//      (DeepSeek key, Perplexity cookie, OpenAI admin key, ...).
+//
+// Response shape (verified against api-docs.deepseek.com/api/get-user-balance):
+//   {
+//     "is_available": Bool,          // is the balance sufficient for calls
+//     "balance_infos": [
+//       { "currency": "USD" | "CNY",
+//         "total_balance":     String,   // amounts are STRINGS, not numbers
+//         "granted_balance":   String,   // from promotions
+//         "topped_up_balance": String }  // paid top-ups
+//     ]
+//   }
+// All amounts are strings and are preserved verbatim — we do not reinterpret
+// currency or arithmetic on them beyond what the balance tile needs.
+
+import Foundation
+import Security
+
+// MARK: - Snapshot
+
+/// One currency's balance breakdown from `balance_infos[]`.
+public struct DeepSeekBalance: Equatable, Sendable {
+    /// "USD" or "CNY" as returned by the endpoint.
+    public var currency: String
+    /// Total balance, verbatim string (e.g. "110.00").
+    public var totalBalance: String
+    /// Promotional / granted portion, verbatim string.
+    public var grantedBalance: String
+    /// Paid top-up portion, verbatim string.
+    public var toppedUpBalance: String
+
+    public init(
+        currency: String,
+        totalBalance: String,
+        grantedBalance: String,
+        toppedUpBalance: String
+    ) {
+        self.currency = currency
+        self.totalBalance = totalBalance
+        self.grantedBalance = grantedBalance
+        self.toppedUpBalance = toppedUpBalance
+    }
+}
+
+/// A parsed snapshot of the `/user/balance` response.
+public struct DeepSeekUsageSnapshot: Equatable, Sendable {
+    /// Whether the balance is sufficient for API calls. When false the tile
+    /// turns amber and the balance is de-emphasised.
+    public var isAvailable: Bool
+    /// One entry per currency present on the account. Usually a single
+    /// currency, but the endpoint returns an array.
+    public var balances: [DeepSeekBalance]
+
+    public init(isAvailable: Bool = false, balances: [DeepSeekBalance] = []) {
+        self.isAvailable = isAvailable
+        self.balances = balances
+    }
+}
+
+public enum DeepSeekUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+/// Pure parser for the DeepSeek balance endpoint. Value type, no observable
+/// state. The Store owns the HTTP call and applies the snapshot.
+public struct DeepSeekUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Parse the JSON body of a `/user/balance` response. Throws
+    /// `invalidJSON` only when the top level is not a JSON object. A sparse
+    /// but well-formed body (empty balance_infos) parses to a snapshot with
+    /// an empty `balances` array, matching how the sibling fetchers tolerate
+    /// minimal shapes.
+    public static func parse(_ data: Data) throws -> DeepSeekUsageSnapshot {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DeepSeekUsageParseError.invalidJSON
+        }
+
+        var snap = DeepSeekUsageSnapshot()
+        if let available = json["is_available"] as? Bool {
+            snap.isAvailable = available
+        }
+
+        if let infos = json["balance_infos"] as? [[String: Any]] {
+            snap.balances = infos.compactMap { info in
+                guard let currency = info["currency"] as? String else { return nil }
+                return DeepSeekBalance(
+                    currency: currency,
+                    totalBalance: stringAmount(info["total_balance"]),
+                    grantedBalance: stringAmount(info["granted_balance"]),
+                    toppedUpBalance: stringAmount(info["topped_up_balance"])
+                )
+            }
+        }
+
+        return snap
+    }
+
+    /// Balances are strings on the wire; preserve them verbatim. Accept a
+    /// number defensively (in case the API ever returns one) and stringify
+    /// it, and fall back to "0" when the field is absent.
+    private static func stringAmount(_ value: Any?) -> String {
+        if let s = value as? String { return s }
+        if let i = value as? Int { return String(i) }
+        if let d = value as? Double { return String(d) }
+        return "0"
+    }
+}
+
+// MARK: - KeychainStore
+
+/// First concrete CredentialStore (protocol from PR 47). Stores spending
+/// credentials in the macOS login Keychain as generic passwords, keyed by a
+/// per-app service plus the caller's key. Every provider that holds a
+/// spending credential (DeepSeek API key, Perplexity cookie, OpenAI admin
+/// key) uses this rather than UserDefaults.
+///
+/// The service string namespaces our items so they never collide with other
+/// apps' Keychain entries. `read` returns nil for a missing item (not an
+/// error); `write` upserts; `delete` is idempotent.
+public struct KeychainStore: CredentialStore {
+    /// Keychain service used to namespace this app's items.
+    private let service: String
+
+    public init(service: String = "com.claude.usagebar.credentials") {
+        self.service = service
+    }
+
+    private func baseQuery(_ key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    public func read(_ key: String) -> Data? {
+        var query = baseQuery(key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else { return nil }
+        return item as? Data
+    }
+
+    public func write(_ key: String, _ value: Data) {
+        // Upsert: try to update an existing item first; if none exists, add.
+        let query = baseQuery(key)
+        let attributes: [String: Any] = [kSecValueData as String: value]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            var addQuery = baseQuery(key)
+            addQuery[kSecValueData as String] = value
+            // Only unlocked-while-this-device flags; the credential never
+            // syncs to iCloud Keychain and is unavailable before first
+            // unlock. Matches least-privilege for a spending credential.
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            SecItemAdd(addQuery as CFDictionary, nil)
+        }
+    }
+
+    public func delete(_ key: String) {
+        SecItemDelete(baseQuery(key) as CFDictionary)
+    }
+}

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -1,0 +1,261 @@
+// PR 4-BE — DeepSeek UsageProvider conformer (dark code, feature-flag off).
+//
+// Third provider (after Anthropic and Codex). DeepSeek is the "paste-a-key"
+// template: the user pastes an `sk-...` API key, stored in the Keychain via
+// KeychainStore, and the provider polls the account balance.
+//
+// Feature posture in PR 4-BE:
+//   - `features.deepseek.enabled` defaults FALSE (opt-in, like every
+//     non-Anthropic provider).
+//   - Nothing registers a DeepSeekUsageStore into AppDelegate.providers yet;
+//     the tile + Settings key-paste sheet land in PR 4-UI. This file is
+//     compiled and unit-tested but inert at runtime until then.
+//
+// Credential posture: the API key is a spending credential. It is stored in
+// the Keychain (never UserDefaults) and never logged. Only the HTTP status
+// code is logged, satisfying the CI credential-leak guard.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class DeepSeekUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "deepseek"
+    public let displayName: String = "DeepSeek"
+    public let featureFlagKey: String = "features.deepseek.enabled"
+
+    /// Keychain key under which the DeepSeek API key is stored.
+    public static let apiKeyKeychainKey = "deepseek.api_key"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: DeepSeekUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: DeepSeekUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: DeepSeekUsageTransport = URLSessionDeepSeekTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when an API key is stored. The key itself is never exposed.
+    public var hasKey: Bool {
+        guard let data = credentials.read(Self.apiKeyKeychainKey) else { return false }
+        return !data.isEmpty
+    }
+
+    /// Store a pasted API key (trimmed). Empty input clears the key instead.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(Self.apiKeyKeychainKey)
+        } else {
+            credentials.write(Self.apiKeyKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    public var isConfigured: Bool {
+        hasKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Not configured — onboarding card prompting the user to paste a key.
+        if !isConfigured {
+            return [UsageTile(
+                id: "deepseek-needs-key",
+                title: "DeepSeek",
+                kind: .needsAccess(
+                    path: "api.deepseek.com",
+                    guidance: "Paste your DeepSeek API key (sk-…) in Settings to track your balance."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Availability warning tile — shown only when the balance is not
+        // sufficient for API calls, so a healthy account stays uncluttered.
+        if !snap.isAvailable {
+            out.append(UsageTile(
+                id: "deepseek-status",
+                title: "DeepSeek",
+                kind: .text(
+                    status: "Balance too low",
+                    subtitle: "Top up your DeepSeek account to keep making API calls."
+                )
+            ))
+        }
+
+        // One balance tile per currency. Total headline with the granted +
+        // topped-up split as the subtitle. Amounts are shown verbatim (the
+        // endpoint returns decimal strings), prefixed with the currency.
+        for balance in snap.balances {
+            out.append(UsageTile(
+                id: "deepseek-balance-\(balance.currency.lowercased())",
+                title: "DeepSeek balance (\(balance.currency))",
+                kind: .text(
+                    status: "\(balance.currency) \(balance.totalBalance)",
+                    subtitle: "Granted \(balance.grantedBalance) + topped-up \(balance.toppedUpBalance)"
+                )
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result to observable state. Extracted so the
+    /// TestRunner can drive every branch synchronously.
+    public func apply(_ result: DeepSeekUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try DeepSeekUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+            } catch {
+                self.lastError = "Could not parse DeepSeek balance"
+            }
+        case .unauthorized:
+            // 401 — the pasted key is invalid or revoked. Surface an
+            // actionable message; keep the key so the user can correct it in
+            // Settings rather than silently losing it.
+            self.lastError = "Invalid DeepSeek API key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let keyData = credentials.read(Self.apiKeyKeychainKey),
+              !keyData.isEmpty,
+              let key = String(data: keyData, encoding: .utf8) else {
+            // No key stored; tiles render the onboarding card.
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchBalance(apiKey: key) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Clearing DeepSeek DOES delete its credential — unlike Codex, the
+        // key belongs to this app (the user pasted it here), not to an
+        // external CLI. This is the "Clear API key" action in Settings.
+        credentials.delete(Self.apiKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum DeepSeekUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the network for unit testing. The completion MUST be delivered
+/// on the main queue.
+public protocol DeepSeekUsageTransport: Sendable {
+    func fetchBalance(
+        apiKey: String,
+        completion: @escaping @Sendable (DeepSeekUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues the real request with the Bearer key. The
+/// response body is never logged; only the status code goes through the
+/// categorical logger.
+public struct URLSessionDeepSeekTransport: DeepSeekUsageTransport {
+    private let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
+
+    public init() {}
+
+    public func fetchBalance(
+        apiKey: String,
+        completion: @escaping @Sendable (DeepSeekUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: balanceURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (DeepSeekUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("DeepSeek balance API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -20,11 +20,14 @@ import SwiftUI
 import Combine
 
 @MainActor
-public final class DeepSeekUsageStore: @preconcurrency UsageProvider {
+public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
 
     public let id: String = "deepseek"
     public let displayName: String = "DeepSeek"
     public let featureFlagKey: String = "features.deepseek.enabled"
+
+    // PasteKeyProvider: the DeepSeek key is pasted by the user into Settings.
+    public let keyPlaceholder: String = "sk-…"
 
     /// Keychain key under which the DeepSeek API key is stored.
     public static let apiKeyKeychainKey = "deepseek.api_key"

--- a/app/DeepSeekUsageStore.swift
+++ b/app/DeepSeekUsageStore.swift
@@ -54,10 +54,16 @@ public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyPr
 
     // MARK: - Credential management
 
-    /// True when an API key is stored. The key itself is never exposed.
+    /// True when an API key is stored. The key itself is never exposed. A
+    /// keychain that is present but temporarily unreadable (locked) counts as
+    /// configured, so a locked screen does not drop the provider back to the
+    /// paste-key onboarding card.
     public var hasKey: Bool {
-        guard let data = credentials.read(Self.apiKeyKeychainKey) else { return false }
-        return !data.isEmpty
+        switch credentials.readResult(Self.apiKeyKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
     }
 
     /// Store a pasted API key (trimmed). Empty input clears the key instead.
@@ -177,10 +183,9 @@ public final class DeepSeekUsageStore: @preconcurrency UsageProvider, PasteKeyPr
         }
 
         transport.fetchBalance(apiKey: key) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 

--- a/app/FileWatcher.swift
+++ b/app/FileWatcher.swift
@@ -1,0 +1,417 @@
+// PR 10a — FileWatcher (shared local-provider infrastructure).
+//
+// Watches a directory tree for changes and calls a Sendable closure
+// whenever files under the tree are modified. Used by every local-file
+// provider (Claude Code JSONL, Cline, JetBrains XML, etc.) to know when
+// to re-parse.
+//
+// Two backends:
+//
+//   1. FSEventStreamCreate (primary). The macOS-native, high-fidelity
+//      path — kernel-level notifications, no polling cost. Requires the
+//      process to have permission to enumerate the target directory.
+//      When granted, the callback fires within ~100 ms of a write.
+//
+//   2. 30-second dispatch-timer poll (fallback). Used when the caller
+//      explicitly requests it (unit tests) OR when FSEventStreamStart
+//      returns false. Compares directory-tree mtimes on each tick;
+//      fires the callback only when at least one mtime changed since
+//      the last tick.
+//
+// The class deliberately owns its Dispatch queue so the callback context
+// is deterministic — every fire runs on a serial private queue, never on
+// the FSEvents thread or on the main thread. Consumers hop to
+// `Task { @MainActor }` themselves if they need main-actor state.
+//
+// Codex round-1 hardening — every one of these is a real bug in the
+// naive implementation:
+//
+// A. FSEvents context. `Unmanaged.passRetained(self)` (not passUnretained)
+//    plus an explicit release callback so an event in flight cannot
+//    dereference a freed watcher.
+//
+// B. Queue-serialised lifecycle. ALL state mutation (start, stop, tick,
+//    lastMtimes, onChange) is done on the private serial queue via
+//    queue.sync from external callers. This means an already-enqueued
+//    tick from before stop() runs, sees `running == false`, and returns
+//    without invoking the callback — no race.
+//
+// C. Baseline is captured SYNCHRONOUSLY on the queue during start(),
+//    not async. `queue.sync` from a public API called on some other
+//    thread is fine; from the queue itself would deadlock, but our API
+//    is only ever called by external owners.
+//
+// D. Generation counter. Every start() bumps `generation`; every
+//    scheduled work item captures its launch generation. A tick from a
+//    prior start() sees a mismatched generation and returns without
+//    firing.
+
+import Foundation
+import CoreServices
+
+/// A change event fired by `FileWatcher`. Every fire carries the paths
+/// that FSEvents reported (or, in the poll fallback, the paths whose
+/// mtimes advanced since the last tick).
+public struct FileWatcherEvent: Sendable {
+    /// The absolute paths that changed. For FSEvents, this may be
+    /// directories rather than files — FSEvents coalesces per-file
+    /// changes into directory-level events by default; the caller is
+    /// expected to re-scan directory contents. For the poll fallback,
+    /// this is the exact set of files whose mtimes advanced.
+    public let paths: [String]
+    /// True when this is the initial synthetic event fired shortly after
+    /// `start()`. Local providers use this to trigger a first-run scan
+    /// without waiting for a real filesystem change.
+    public let isInitial: Bool
+
+    public init(paths: [String], isInitial: Bool) {
+        self.paths = paths
+        self.isInitial = isInitial
+    }
+}
+
+/// Backend the watcher runs. Callers rarely pick this explicitly — the
+/// default `.auto` chooses FSEvents when available and falls back to
+/// polling. Tests use `.pollOnly(interval:)` for determinism.
+public enum FileWatcherBackend: Sendable {
+    /// FSEvents preferred; falls back to polling if FSEventStreamStart
+    /// returns false. The interval is used only for the fallback path.
+    case auto(pollFallbackInterval: TimeInterval = 30.0)
+    /// Force the poll fallback. Interval in seconds. Used by tests.
+    case pollOnly(interval: TimeInterval)
+}
+
+/// A directory-tree watcher. `paths` is the set of directories to
+/// observe; the callback fires whenever files under any of them change.
+public final class FileWatcher {
+
+    /// Directory paths to watch. Each is a directory root; FSEvents
+    /// watches recursively, and the poll fallback enumerates recursively.
+    public let paths: [String]
+
+    private let backend: FileWatcherBackend
+    /// Serial queue where the callback fires. Owned by the watcher.
+    private let queue: DispatchQueue
+    /// Sendable callback. Retained until stop().
+    private var onChange: (@Sendable (FileWatcherEvent) -> Void)?
+
+    // FSEvents state — nil while stopped.
+    private var stream: FSEventStreamRef?
+
+    /// Per-stream context object owned by the FSEvents info pointer.
+    /// Codex round-2 finding #1: storing generation on `self` was
+    /// staleness-vulnerable — an FSEvents callback from stream N could
+    /// read `self.streamGeneration` AFTER a stop+start had advanced it,
+    /// and appear "current" to the guard. The per-stream context binds
+    /// the generation to the specific stream instance, so a late
+    /// callback from an old stream carries the OLD generation and drops
+    /// on the guard.
+    private final class FSEventsContext {
+        weak var watcher: FileWatcher?
+        let generation: UInt64
+        init(watcher: FileWatcher, generation: UInt64) {
+            self.watcher = watcher
+            self.generation = generation
+        }
+    }
+
+    // Poll state — nil while stopped.
+    private var pollSource: DispatchSourceTimer?
+    /// mtimes observed on the previous poll tick, keyed by absolute path.
+    /// Nil while stopped; populated synchronously on start().
+    private var lastMtimes: [String: Date]?
+
+    /// True after `start()` — used to make `stop()` idempotent and to
+    /// short-circuit already-enqueued tick handlers that fire after stop.
+    private var running = false
+
+    /// Monotonic counter bumped on every `start()`. Every scheduled work
+    /// item captures its launch generation; a stale handler that fires
+    /// after a stop/restart sees a mismatch and returns immediately.
+    /// Closes Codex round-1 finding #4.
+    private var generation: UInt64 = 0
+
+    /// Key used to identify the private queue's context. `queue.sync`
+    /// from within a callback that itself runs on the queue would
+    /// deadlock (Codex round-2 finding #2); this key lets us detect
+    /// that case and run the block inline instead.
+    private let queueKey = DispatchSpecificKey<ObjectIdentifier>()
+
+    /// Construct a watcher. `paths` is the list of directory roots to
+    /// observe (they need not exist — a missing directory is treated as
+    /// empty and re-checked every tick). `backend` picks FSEvents (auto)
+    /// or the poll fallback (pollOnly, for tests).
+    public init(paths: [String], backend: FileWatcherBackend = .auto()) {
+        self.paths = paths
+        self.backend = backend
+        self.queue = DispatchQueue(label: "com.claude.usagebar.filewatcher.\(UUID().uuidString)")
+        // Tag the queue so `runSerial` can detect re-entry from a
+        // callback running on the queue and switch to inline execution
+        // instead of a self-deadlocking queue.sync.
+        queue.setSpecific(key: queueKey, value: ObjectIdentifier(self))
+    }
+
+    /// Run `block` serially on the private queue. If the caller is
+    /// already on the queue (i.e. this is being called from an onChange
+    /// closure), run inline to avoid a queue.sync self-deadlock. Codex
+    /// round-2 finding #2.
+    private func runSerial(_ block: () -> Void) {
+        if DispatchQueue.getSpecific(key: queueKey) == ObjectIdentifier(self) {
+            block()
+        } else {
+            queue.sync(execute: block)
+        }
+    }
+
+    deinit {
+        // Cannot call stop() directly on the queue from deinit — the
+        // final release may be happening on that very queue if a
+        // callback is in flight (see Codex round-1 finding #1 for why
+        // that is defensively prevented via passRetained). Instead,
+        // tear down FSEvents and cancel the timer on the calling thread;
+        // both APIs are documented as safe to call from any thread when
+        // the object is fully going away.
+        if let stream = stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+        if let source = pollSource {
+            source.cancel()
+        }
+    }
+
+    /// Start watching. Fires an "initial" event on the queue shortly
+    /// after start returns so consumers can bootstrap without waiting
+    /// for a real change. Idempotent — calling twice is a no-op.
+    public func start(onChange: @escaping @Sendable (FileWatcherEvent) -> Void) {
+        // Serialise all state mutation through the private queue via
+        // runSerial(), which detects re-entry from an onChange callback
+        // and runs inline. Codex round-1 #2 + round-2 #2.
+        runSerial {
+            if running { return }
+            running = true
+            generation &+= 1
+            self.onChange = onChange
+            let launchGeneration = generation
+
+            switch backend {
+            case .auto(let pollInterval):
+                if !startFSEvents(generation: launchGeneration) {
+                    startPoll(interval: pollInterval, generation: launchGeneration)
+                }
+            case .pollOnly(let interval):
+                startPoll(interval: interval, generation: launchGeneration)
+            }
+
+            // Synthetic initial event so consumers can do a first scan
+            // without waiting for a filesystem change. Enqueued async on
+            // the same queue so it is delivered in order after any
+            // baseline snapshot the poll fallback captured synchronously
+            // above.
+            let paths = self.paths
+            queue.async { [weak self] in
+                guard let self = self else { return }
+                // Same generation check — a stop+start race between the
+                // enqueue and the fire drops this event.
+                guard self.running && self.generation == launchGeneration else { return }
+                self.onChange?(FileWatcherEvent(paths: paths, isInitial: true))
+            }
+        }
+    }
+
+    /// Stop watching. Idempotent and safe from any queue.
+    public func stop() {
+        runSerial {
+            if !running { return }
+            running = false
+            generation &+= 1  // invalidate any pending work items
+
+            if let stream = stream {
+                FSEventStreamStop(stream)
+                FSEventStreamInvalidate(stream)
+                FSEventStreamRelease(stream)
+                self.stream = nil
+            }
+            if let source = pollSource {
+                source.cancel()
+                self.pollSource = nil
+            }
+            self.lastMtimes = nil
+            self.onChange = nil
+        }
+    }
+
+    // MARK: - FSEvents backend
+
+    /// Build and start an FSEvents stream. Returns true on success, false
+    /// if FSEventStreamStart refused (a signal we should fall back).
+    /// Assumes it is called on the private queue.
+    private func startFSEvents(generation: UInt64) -> Bool {
+        guard !paths.isEmpty else { return false }
+        let cfPaths = paths as CFArray
+
+        // Codex round-1 finding #1 + round-2 finding #1 + round-3 leak:
+        // the info pointer owns a per-stream FSEventsContext that binds
+        // the generation to THIS specific stream. Even if a late
+        // callback arrives after stop+start, it carries the OLD
+        // generation and fireIfCurrent drops it. The watcher reference
+        // is `weak` — if the watcher deallocates for any reason, the
+        // callback finds watcher=nil and returns.
+        //
+        // Ownership pattern per Codex round-3: `passRetained(ctx)`
+        // creates the single +1 that represents "FSEvents owns this
+        // context." NO retain callback, so FSEvents does not attempt
+        // to bump the count — Apple's docs say retain/release are
+        // optional, and if retain is nil, FSEvents treats the info
+        // pointer as opaque and does not manage its refcount. The
+        // single release callback drops that +1 when FSEvents itself
+        // releases (via FSEventStreamRelease). Symmetric — no leak,
+        // no UAF.
+        //
+        // Create-fail path: if FSEventStreamCreate returns nil, no
+        // release callback ever fires, so we manually release the +1
+        // before returning false.
+        let ctx = FSEventsContext(watcher: self, generation: generation)
+        let ctxPtr = Unmanaged.passRetained(ctx).toOpaque()
+        var context = FSEventStreamContext(
+            version: 0,
+            info: ctxPtr,
+            retain: nil,
+            release: { info in
+                guard let info = info else { return }
+                Unmanaged<FSEventsContext>.fromOpaque(info).release()
+            },
+            copyDescription: nil
+        )
+
+        let flags = UInt32(kFSEventStreamCreateFlagFileEvents |
+                           kFSEventStreamCreateFlagNoDefer |
+                           kFSEventStreamCreateFlagIgnoreSelf)
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            { _, info, numEvents, eventPathsRaw, _, _ in
+                guard let info = info else { return }
+                let ctx = Unmanaged<FSEventsContext>.fromOpaque(info).takeUnretainedValue()
+                guard let watcher = ctx.watcher else { return }
+                let raw = eventPathsRaw.assumingMemoryBound(to: UnsafePointer<CChar>?.self)
+                var out: [String] = []
+                out.reserveCapacity(Int(numEvents))
+                for i in 0 ..< Int(numEvents) {
+                    if let ptr = raw[i] {
+                        out.append(String(cString: ptr))
+                    }
+                }
+                let genAtFire = ctx.generation
+                watcher.queue.async {
+                    watcher.fireIfCurrent(paths: out, generation: genAtFire)
+                }
+            },
+            &context,
+            cfPaths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.5,
+            flags
+        ) else {
+            // Create failed — release the +1 we took above with passRetained.
+            Unmanaged<FSEventsContext>.fromOpaque(ctxPtr).release()
+            return false
+        }
+
+        FSEventStreamSetDispatchQueue(stream, queue)
+        if !FSEventStreamStart(stream) {
+            // FSEventStreamRelease invokes our release callback, which
+            // drops the +1 that `Unmanaged.passRetained(ctx)` created.
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            return false
+        }
+        self.stream = stream
+        return true
+    }
+
+    /// Called from the FSEvents callback (via a queue.async hop) and
+    /// from the poll tick. Serialised on the private queue.
+    fileprivate func fireIfCurrent(paths: [String], generation: UInt64) {
+        // Generation guard — stop+start could have advanced generation
+        // while this event was in flight.
+        guard running && self.generation == generation else { return }
+        onChange?(FileWatcherEvent(paths: paths, isInitial: false))
+    }
+
+    // MARK: - Poll fallback backend
+
+    /// Assumes it is called on the private queue.
+    private func startPoll(interval: TimeInterval, generation: UInt64) {
+        let safeInterval = max(1.0, interval)
+        // Codex round-1 finding #3: capture baseline SYNCHRONOUSLY, on
+        // the queue, right now. We are already on the queue (see caller
+        // in start()), so this is a direct assignment. Anything created
+        // between start() returning and the first tick is genuinely a
+        // change; the diff will fire on the very next tick.
+        lastMtimes = snapshotMtimes()
+
+        let source = DispatchSource.makeTimerSource(queue: queue)
+        source.schedule(deadline: .now() + safeInterval, repeating: safeInterval)
+        source.setEventHandler { [weak self] in
+            self?.pollTick(generation: generation)
+        }
+        source.resume()
+        self.pollSource = source
+    }
+
+    /// One tick of the poll fallback. Assumes it is called on the
+    /// private queue. Generation check drops stale ticks from a prior
+    /// start().
+    private func pollTick(generation: UInt64) {
+        guard running && self.generation == generation else { return }
+        let current = snapshotMtimes()
+        guard let last = lastMtimes else {
+            // Baseline lost (should not happen — start() sets it) —
+            // record and return without firing.
+            lastMtimes = current
+            return
+        }
+        var changed: [String] = []
+        for (path, mtime) in current where last[path] != mtime {
+            changed.append(path)
+        }
+        for path in last.keys where current[path] == nil {
+            changed.append(path)
+        }
+        if !changed.isEmpty {
+            onChange?(FileWatcherEvent(paths: changed, isInitial: false))
+        }
+        lastMtimes = current
+    }
+
+    /// Walk every watched directory recursively and record mtimes.
+    /// Assumes it is called on the private queue.
+    private func snapshotMtimes() -> [String: Date] {
+        var out: [String: Date] = [:]
+        let fm = FileManager.default
+        for root in paths {
+            guard fm.fileExists(atPath: root) else { continue }
+            guard let enumerator = fm.enumerator(
+                at: URL(fileURLWithPath: root),
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles],
+                errorHandler: nil
+            ) else { continue }
+            for case let url as URL in enumerator {
+                do {
+                    let vals = try url.resourceValues(forKeys: [.contentModificationDateKey])
+                    if let mtime = vals.contentModificationDate {
+                        out[url.path] = mtime
+                    }
+                } catch {
+                    // Individual file stat can fail (transient
+                    // permission errors, race with deletion) — skip and
+                    // continue rather than blowing up the whole tick.
+                }
+            }
+        }
+        return out
+    }
+}

--- a/app/Log.swift
+++ b/app/Log.swift
@@ -1,0 +1,72 @@
+// MARK: - Logging (categorical redaction)
+//
+// PR 1 introduced the categorical logger below to replace every NSLog site
+// in the app that touched cookies, org IDs, or response bodies. The call
+// site cannot interpolate a raw String; every value goes through a
+// category, and each category has its own emission rule. This makes
+// accidental credential logging a compile-time impossibility rather than a
+// discipline problem.
+//
+// PR 2a extracted the types out of ClaudeUsageBar.swift into this file so
+// the SwiftPM library target can compile them without also trying to
+// compile the @main entry point (which would conflict with TestRunner's
+// own main).
+//
+// The CI static grep guard (see .github/workflows/ci.yml) refuses PRs that
+// reintroduce raw-interpolation NSLog calls or the deleted response-body
+// log line at the network fetch site. The exact banned pattern lives in
+// the workflow file to avoid embedding it here (which would self-trigger).
+
+import Foundation
+import CryptoKit
+
+public enum LogValue {
+    /// Safe to log verbatim (status codes, event names, HTTP methods, etc.).
+    case `public`(String)
+    /// Redacted to `<redacted: N chars>` in every build. Use for cookies,
+    /// bodies, tokens, API keys, anything that could leak a credential.
+    case sensitive(String)
+    /// Emitted as a short SHA-256 prefix so the value can be correlated
+    /// across log lines without revealing it. Use for org IDs, user IDs.
+    case identifier(String)
+    /// Numeric counts are safe to log as-is (lengths, HTTP status codes,
+    /// retry counts, threshold values).
+    case count(Int)
+
+    public var rendered: String {
+        switch self {
+        case .public(let s):
+            return s
+        case .sensitive(let s):
+            return "<redacted: \(s.count) chars>"
+        case .identifier(let s):
+            let digest = SHA256.hash(data: Data(s.utf8))
+            let hex = digest.compactMap { String(format: "%02x", $0) }.joined()
+            return "<id: \(hex.prefix(8))>"
+        case .count(let n):
+            return String(n)
+        }
+    }
+}
+
+public enum Log {
+    /// Debug-only diagnostics. Stripped in release builds by the `#if DEBUG`
+    /// gate. Accepts a plain message — no interpolation of untrusted values.
+    public static func debug(_ message: String) {
+        #if DEBUG
+        NSLog("[debug] %@", message)
+        #endif
+    }
+
+    /// Info-level diagnostics. Retained in release builds. Values must be
+    /// wrapped in a `LogValue` category, forcing an explicit redaction
+    /// decision at the call site.
+    public static func info(_ message: String, _ values: LogValue...) {
+        let rendered = values.map(\.rendered).joined(separator: ", ")
+        if rendered.isEmpty {
+            NSLog("%@", message)
+        } else {
+            NSLog("%@ | %@", message, rendered)
+        }
+    }
+}

--- a/app/OpenAIUsageFetcher.swift
+++ b/app/OpenAIUsageFetcher.swift
@@ -1,0 +1,173 @@
+// PR 7-BE — OpenAI Platform usage fetcher (developer API, Admin key).
+//
+// Reads an OpenAI ORGANIZATION's usage, cost, and configured rate limits via
+// an Admin key (sk-admin-...). Admin keys can view billing and manage users
+// but cannot make inference calls; the UI gates the paste behind a warning.
+//
+// Feature posture: features.openai.enabled defaults false; nothing registers
+// a store into the live registry yet (tile + admin-key sheet land in PR 7-UI).
+//
+// Endpoints (all officially documented, Authorization: Bearer sk-admin-...):
+//   GET /v1/organization/usage/completions?bucket_width=1d&group_by=model
+//       -> tokens + request counts by model, bucketed by time.
+//   GET /v1/organization/costs?bucket_width=1d&start_time=<month start>
+//       -> spend by line item, bucketed; amount.value is USD dollars.
+//   GET /v1/organization/projects/{project_id}/rate_limits
+//       -> configured per-model RPM/TPM ceilings.
+//
+// The usage + costs endpoints share a bucketed page shape:
+//   { "object": "page", "data": [ { "object": "bucket", "start_time": Int,
+//     "end_time": Int, "results": [ <result> ] } ], "has_more": Bool,
+//     "next_page": String|null }
+// Results differ per endpoint. This fetcher parses each into flat aggregates
+// the tiles consume.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// Per-model token totals aggregated across the returned usage buckets.
+public struct OpenAIModelTokens: Equatable, Sendable {
+    public var model: String
+    public var inputTokens: Int
+    public var outputTokens: Int
+    public var requests: Int
+
+    public init(model: String, inputTokens: Int = 0, outputTokens: Int = 0, requests: Int = 0) {
+        self.model = model
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.requests = requests
+    }
+
+    public var totalTokens: Int { inputTokens + outputTokens }
+}
+
+/// Per-model configured rate-limit ceilings (context, not remaining).
+public struct OpenAIRateLimit: Equatable, Sendable {
+    public var model: String
+    public var maxRequestsPerMinute: Int?
+    public var maxTokensPerMinute: Int?
+
+    public init(model: String, maxRequestsPerMinute: Int? = nil, maxTokensPerMinute: Int? = nil) {
+        self.model = model
+        self.maxRequestsPerMinute = maxRequestsPerMinute
+        self.maxTokensPerMinute = maxTokensPerMinute
+    }
+}
+
+public struct OpenAIUsageSnapshot: Equatable, Sendable {
+    /// Per-model token usage over the queried window (last 24h by default).
+    public var tokensByModel: [OpenAIModelTokens]
+    /// Month-to-date spend in USD, summed across cost buckets/line items.
+    public var costMTDUSD: Double
+    public var costCurrency: String?
+    /// Configured per-model rate-limit ceilings.
+    public var rateLimits: [OpenAIRateLimit]
+
+    public init(
+        tokensByModel: [OpenAIModelTokens] = [],
+        costMTDUSD: Double = 0,
+        costCurrency: String? = nil,
+        rateLimits: [OpenAIRateLimit] = []
+    ) {
+        self.tokensByModel = tokensByModel
+        self.costMTDUSD = costMTDUSD
+        self.costCurrency = costCurrency
+        self.rateLimits = rateLimits
+    }
+}
+
+public enum OpenAIUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct OpenAIUsageFetcher: Sendable {
+
+    public init() {}
+
+    public static let adminKeyKeychainKey = "openai.admin_key"
+
+    /// Iterate the `data[].results[]` buckets of a page response, calling
+    /// `handle` for each result dictionary. Shared by usage and costs.
+    private static func forEachResult(_ json: [String: Any], _ handle: ([String: Any]) -> Void) {
+        guard let buckets = json["data"] as? [[String: Any]] else { return }
+        for bucket in buckets {
+            guard let results = bucket["results"] as? [[String: Any]] else { continue }
+            for result in results { handle(result) }
+        }
+    }
+
+    /// Parse GET /v1/organization/usage/completions. Aggregates token and
+    /// request counts by model across all buckets. When group_by=model is
+    /// not set, results carry no model field and fold into an "all" bucket.
+    public static func parseCompletions(_ data: Data) throws -> [OpenAIModelTokens] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIUsageParseError.invalidJSON
+        }
+        var byModel: [String: OpenAIModelTokens] = [:]
+        forEachResult(json) { result in
+            let model = (result["model"] as? String) ?? "all"
+            var entry = byModel[model] ?? OpenAIModelTokens(model: model)
+            entry.inputTokens += intOr0(result["input_tokens"])
+            entry.outputTokens += intOr0(result["output_tokens"])
+            entry.requests += intOr0(result["num_model_requests"])
+            byModel[model] = entry
+        }
+        // Stable order: highest total tokens first.
+        return byModel.values.sorted { $0.totalTokens > $1.totalTokens }
+    }
+
+    /// Parse GET /v1/organization/costs. Sums `amount.value` (USD dollars)
+    /// across all buckets/line items. Returns the total and the currency.
+    public static func parseCosts(_ data: Data) throws -> (usd: Double, currency: String?) {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIUsageParseError.invalidJSON
+        }
+        var total = 0.0
+        var currency: String?
+        forEachResult(json) { result in
+            guard let amount = result["amount"] as? [String: Any] else { return }
+            total += doubleOr0(amount["value"])
+            if currency == nil { currency = amount["currency"] as? String }
+        }
+        return (total, currency)
+    }
+
+    /// Parse GET /v1/organization/projects/{id}/rate_limits.
+    public static func parseRateLimits(_ data: Data) throws -> [OpenAIRateLimit] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIUsageParseError.invalidJSON
+        }
+        guard let arr = json["data"] as? [[String: Any]] else { return [] }
+        return arr.compactMap { entry in
+            guard let model = entry["model"] as? String else { return nil }
+            return OpenAIRateLimit(
+                model: model,
+                maxRequestsPerMinute: intOrNil(entry["max_requests_per_1_minute"]),
+                maxTokensPerMinute: intOrNil(entry["max_tokens_per_1_minute"])
+            )
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func intOr0(_ v: Any?) -> Int { intOrNil(v) ?? 0 }
+    private static func doubleOr0(_ v: Any?) -> Double { doubleOrNil(v) ?? 0 }
+
+    private static func intOrNil(_ v: Any?) -> Int? {
+        if let i = v as? Int { return i }
+        if let d = v as? Double { return Int(d) }
+        if let s = v as? String { return Int(s) }
+        return nil
+    }
+    private static func doubleOrNil(_ v: Any?) -> Double? {
+        if let d = v as? Double { return d }
+        if let i = v as? Int { return Double(i) }
+        if let s = v as? String { return Double(s) }
+        return nil
+    }
+}

--- a/app/OpenAIUsageFetcher.swift
+++ b/app/OpenAIUsageFetcher.swift
@@ -92,13 +92,22 @@ public struct OpenAIUsageFetcher: Sendable {
 
     public static let adminKeyKeychainKey = "openai.admin_key"
 
+    /// Defensive caps on how much of a response we traverse. A hostile or
+    /// buggy API could return an enormous data[]/results[] after
+    /// JSONSerialization has already materialised it; capping the traversal
+    /// bounds the CPU spent aggregating. The real endpoint returns at most
+    /// ~31 buckets (limit=31) each with a handful of per-model results, so
+    /// these caps are far above any legitimate response.
+    private static let maxBuckets = 400
+    private static let maxResultsPerBucket = 2000
+
     /// Iterate the `data[].results[]` buckets of a page response, calling
     /// `handle` for each result dictionary. Shared by usage and costs.
     private static func forEachResult(_ json: [String: Any], _ handle: ([String: Any]) -> Void) {
         guard let buckets = json["data"] as? [[String: Any]] else { return }
-        for bucket in buckets {
+        for bucket in buckets.prefix(maxBuckets) {
             guard let results = bucket["results"] as? [[String: Any]] else { continue }
-            for result in results { handle(result) }
+            for result in results.prefix(maxResultsPerBucket) { handle(result) }
         }
     }
 
@@ -113,9 +122,11 @@ public struct OpenAIUsageFetcher: Sendable {
         forEachResult(json) { result in
             let model = (result["model"] as? String) ?? "all"
             var entry = byModel[model] ?? OpenAIModelTokens(model: model)
-            entry.inputTokens += intOr0(result["input_tokens"])
-            entry.outputTokens += intOr0(result["output_tokens"])
-            entry.requests += intOr0(result["num_model_requests"])
+            // Clamp negatives to 0: a negative token/request count is
+            // meaningless and would corrupt the sort and the tile total.
+            entry.inputTokens += max(0, intOr0(result["input_tokens"]))
+            entry.outputTokens += max(0, intOr0(result["output_tokens"]))
+            entry.requests += max(0, intOr0(result["num_model_requests"]))
             byModel[model] = entry
         }
         // Stable order: highest total tokens first.
@@ -161,12 +172,17 @@ public struct OpenAIUsageFetcher: Sendable {
 
     private static func intOrNil(_ v: Any?) -> Int? {
         if let i = v as? Int { return i }
-        if let d = v as? Double { return Int(d) }
+        // Int(Double) TRAPS on a non-finite or out-of-range value; a hostile
+        // API can send 1e300 as valid JSON. Int(exactly:) is crash-safe.
+        if let d = v as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
         if let s = v as? String { return Int(s) }
         return nil
     }
     private static func doubleOrNil(_ v: Any?) -> Double? {
-        if let d = v as? Double { return d }
+        if let d = v as? Double { return d.isFinite ? d : nil }
         if let i = v as? Int { return Double(i) }
         if let s = v as? String { return Double(s) }
         return nil

--- a/app/OpenAIUsageFetcher.swift
+++ b/app/OpenAIUsageFetcher.swift
@@ -8,8 +8,9 @@
 // a store into the live registry yet (tile + admin-key sheet land in PR 7-UI).
 //
 // Endpoints (all officially documented, Authorization: Bearer sk-admin-...):
-//   GET /v1/organization/usage/completions?bucket_width=1d&group_by=model
-//       -> tokens + request counts by model, bucketed by time.
+//   GET /v1/organization/usage/completions?bucket_width=1h&group_by=model
+//       -> tokens + request counts by model, hourly buckets over a rolling
+//          24h window (see URLSessionOpenAITransport.completionsQuery).
 //   GET /v1/organization/costs?bucket_width=1d&start_time=<month start>
 //       -> spend by line item, bucketed; amount.value is USD dollars.
 //   GET /v1/organization/projects/{project_id}/rate_limits

--- a/app/OpenAIUsageStore.swift
+++ b/app/OpenAIUsageStore.swift
@@ -91,8 +91,10 @@ public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProv
         var out: [UsageTile] = []
 
         // Month-to-date cost as a balance-style tile (a spend total, so no
-        // reset; shown as an amount).
-        let currency = snap.costCurrency ?? "USD"
+        // reset; shown as an amount). The costs API returns the currency
+        // lowercase ("usd"); uppercase it for display consistency with the
+        // "USD" fallback.
+        let currency = snap.costCurrency?.uppercased() ?? "USD"
         out.append(UsageTile(
             id: "openai-cost-mtd",
             title: "OpenAI spend (month to date)",
@@ -197,20 +199,9 @@ public struct URLSessionOpenAITransport: OpenAIUsageTransport {
             DispatchQueue.main.async { completion(result) }
         }
 
-        // Query windows: last ~24h of completions grouped by model; costs
-        // from the start of the current UTC month. start_time is computed by
-        // the caller-agnostic helper so tests can stub the transport entirely.
         let now = Date()
-        let dayAgo = Int(now.timeIntervalSince1970) - 24 * 3600
-        let monthStart = Self.startOfUTCMonth(now)
-
-        // `limit=31` is the max for bucket_width=1d and covers a full month in
-        // a SINGLE page, so neither the 24h nor the month-to-date window ever
-        // spans multiple pages — we do not need to follow has_more/next_page
-        // here. (Multi-page pagination would only matter for windows longer
-        // than 31 daily buckets, which these tiles never request.)
-        let completionsURL = "\(base)/usage/completions?bucket_width=1d&group_by=model&limit=31&start_time=\(dayAgo)"
-        let costsURL = "\(base)/costs?bucket_width=1d&group_by=line_item&limit=31&start_time=\(monthStart)"
+        let completionsURL = base + Self.completionsQuery(now: now)
+        let costsURL = base + Self.costsQuery(now: now)
 
         get(completionsURL, bearer: adminKey) { compData, compStatus in
             guard compStatus == 200, let compData = compData,
@@ -251,6 +242,28 @@ public struct URLSessionOpenAITransport: OpenAIUsageTransport {
                 }
             }
         }
+    }
+
+    /// Query path (relative to `base`) for the completions/token-usage tile.
+    ///
+    /// Uses `bucket_width=1h` with `limit=24` for a TRUE rolling 24-hour
+    /// window. A previous version used `bucket_width=1d`, which returns whole
+    /// UTC-day buckets: with `start_time=now-24h` that folds in usage from
+    /// 00:00 UTC of the prior day, so a tile labelled "(24h)" could sum up to
+    /// ~48h of tokens. Hourly buckets bounded to 24 give exactly the last 24h.
+    /// 24 hourly buckets fit a single page (the 1h max is 168), so no
+    /// pagination is needed.
+    public static func completionsQuery(now: Date) -> String {
+        let dayAgo = Int(now.timeIntervalSince1970) - 24 * 3600
+        return "/usage/completions?bucket_width=1h&group_by=model&limit=24&start_time=\(dayAgo)"
+    }
+
+    /// Query path (relative to `base`) for the month-to-date cost tile.
+    /// `bucket_width=1d` from the start of the UTC month; `limit=31` is the
+    /// 1d max and covers every day of the longest month in a single page.
+    public static func costsQuery(now: Date) -> String {
+        let monthStart = startOfUTCMonth(now)
+        return "/costs?bucket_width=1d&group_by=line_item&limit=31&start_time=\(monthStart)"
     }
 
     /// Start of the current month in UTC, as a Unix timestamp.

--- a/app/OpenAIUsageStore.swift
+++ b/app/OpenAIUsageStore.swift
@@ -49,8 +49,15 @@ public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProv
 
     // MARK: - Credential (PasteKeyProvider)
 
+    /// True when the admin key is stored. An unreadable (locked) keychain
+    /// counts as configured so a locked screen does not drop the provider
+    /// back to the paste-key onboarding card.
     public var hasKey: Bool {
-        !(credentials.read(OpenAIUsageFetcher.adminKeyKeychainKey)?.isEmpty ?? true)
+        switch credentials.readResult(OpenAIUsageFetcher.adminKeyKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
     }
 
     public func saveKey(_ raw: String) {
@@ -154,8 +161,11 @@ public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProv
         }
 
         transport.fetchAll(adminKey: key) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated { self.apply(result) }
+            // Hop to the main actor to apply state. Task { @MainActor } is
+            // safe whichever queue the transport delivers on — unlike
+            // assumeIsolated, it cannot trap if a future/custom transport
+            // calls back off-main.
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 
@@ -225,7 +235,11 @@ public struct URLSessionOpenAITransport: OpenAIUsageTransport {
                           let projJSON = try? JSONSerialization.jsonObject(with: projData) as? [String: Any],
                           let projects = projJSON["data"] as? [[String: Any]],
                           let firstProject = projects.first,
-                          let projectId = firstProject["id"] as? String else {
+                          let rawProjectId = firstProject["id"] as? String,
+                          // The project id comes from the API response; encode
+                          // it as a single path segment so it cannot alter the
+                          // request path.
+                          let projectId = RequestSafety.pathSegment(rawProjectId) else {
                         deliver(.success(base))
                         return
                     }

--- a/app/OpenAIUsageStore.swift
+++ b/app/OpenAIUsageStore.swift
@@ -1,0 +1,280 @@
+// PR 7-BE — OpenAI Platform UsageProvider conformer (dark code, flag off).
+//
+// Sixth provider. Reads an OpenAI organisation's token usage, month-to-date
+// cost, and configured rate-limit ceilings via an Admin key (sk-admin-...),
+// stored in the Keychain. Admin keys can view billing and manage users but
+// cannot make inference calls — the UI gates the paste behind a warning.
+//
+// Feature posture: features.openai.enabled defaults false; nothing registers
+// a store into the live registry yet (admin-key sheet + tiles land in PR 7-UI).
+//
+// The admin key never reaches a log line; only HTTP status codes are logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class OpenAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
+
+    public let id: String = "openai"
+    public let displayName: String = "OpenAI Platform"
+    public let featureFlagKey: String = "features.openai.enabled"
+
+    // PasteKeyProvider — an Organization Admin key. These org endpoints are
+    // admin-gated; there is no api.usage.read scoped-key fallback (confirmed
+    // against the OpenAI Admin API reference), so the placeholder names the
+    // admin key specifically.
+    public let keyPlaceholder: String = "sk-admin-…"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: OpenAIUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: OpenAIUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: OpenAIUsageTransport = URLSessionOpenAITransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential (PasteKeyProvider)
+
+    public var hasKey: Bool {
+        !(credentials.read(OpenAIUsageFetcher.adminKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(OpenAIUsageFetcher.adminKeyKeychainKey)
+        } else {
+            credentials.write(OpenAIUsageFetcher.adminKeyKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool { defaults.bool(forKey: featureFlagKey) }
+    public var isConfigured: Bool { hasKey }
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "openai-needs-key",
+                title: "OpenAI Platform",
+                kind: .needsAccess(
+                    path: "platform.openai.com",
+                    guidance: "Paste an OpenAI Admin key (sk-admin-…) in Settings to track org spend and usage."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Month-to-date cost as a balance-style tile (a spend total, so no
+        // reset; shown as an amount).
+        let currency = snap.costCurrency ?? "USD"
+        out.append(UsageTile(
+            id: "openai-cost-mtd",
+            title: "OpenAI spend (month to date)",
+            kind: .text(status: String(format: "%@ %.2f", currency, snap.costMTDUSD), subtitle: nil)
+        ))
+
+        // Token usage over the last 24h, top models. Rendered as counter
+        // tiles (total tokens per model) so the generic renderer handles it.
+        for model in snap.tokensByModel.prefix(4) {
+            out.append(UsageTile(
+                id: "openai-tokens-\(model.model)",
+                title: "OpenAI \(model.model) (24h)",
+                kind: .counter(used: model.totalTokens, limit: nil, resetsAt: nil)
+            ))
+        }
+
+        // Configured ceilings — reference context, top models by TPM.
+        for limit in snap.rateLimits.prefix(3) {
+            let tpm = limit.maxTokensPerMinute.map { "\($0) TPM" } ?? "—"
+            let rpm = limit.maxRequestsPerMinute.map { "\($0) RPM" } ?? "—"
+            out.append(UsageTile(
+                id: "openai-ceiling-\(limit.model)",
+                title: "OpenAI \(limit.model) limits",
+                kind: .text(status: tpm, subtitle: rpm)
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: OpenAIUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            self.lastError = "Invalid OpenAI Admin key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let data = credentials.read(OpenAIUsageFetcher.adminKeyKeychainKey),
+              !data.isEmpty, let key = String(data: data, encoding: .utf8) else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchAll(adminKey: key) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated { self.apply(result) }
+        }
+    }
+
+    public func clear() {
+        credentials.delete(OpenAIUsageFetcher.adminKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum OpenAIUsageResult: Sendable {
+    case success(OpenAIUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+public protocol OpenAIUsageTransport: Sendable {
+    func fetchAll(
+        adminKey: String,
+        completion: @escaping @Sendable (OpenAIUsageResult) -> Void
+    )
+}
+
+/// Production transport. Chains usage/completions + costs (both required for
+/// the headline tiles); rate_limits is best-effort (needs a project id, which
+/// it discovers from /v1/organization/projects). Bodies are never logged.
+public struct URLSessionOpenAITransport: OpenAIUsageTransport {
+    private let base = "https://api.openai.com/v1/organization"
+
+    public init() {}
+
+    public func fetchAll(
+        adminKey: String,
+        completion: @escaping @Sendable (OpenAIUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (OpenAIUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Query windows: last ~24h of completions grouped by model; costs
+        // from the start of the current UTC month. start_time is computed by
+        // the caller-agnostic helper so tests can stub the transport entirely.
+        let now = Date()
+        let dayAgo = Int(now.timeIntervalSince1970) - 24 * 3600
+        let monthStart = Self.startOfUTCMonth(now)
+
+        // `limit=31` is the max for bucket_width=1d and covers a full month in
+        // a SINGLE page, so neither the 24h nor the month-to-date window ever
+        // spans multiple pages — we do not need to follow has_more/next_page
+        // here. (Multi-page pagination would only matter for windows longer
+        // than 31 daily buckets, which these tiles never request.)
+        let completionsURL = "\(base)/usage/completions?bucket_width=1d&group_by=model&limit=31&start_time=\(dayAgo)"
+        let costsURL = "\(base)/costs?bucket_width=1d&group_by=line_item&limit=31&start_time=\(monthStart)"
+
+        get(completionsURL, bearer: adminKey) { compData, compStatus in
+            guard compStatus == 200, let compData = compData,
+                  let tokens = try? OpenAIUsageFetcher.parseCompletions(compData) else {
+                deliver(compStatus == 401 || compStatus == 403 ? .unauthorized
+                        : (compStatus == nil ? .networkError : .httpError(compStatus!)))
+                return
+            }
+
+            self.get(costsURL, bearer: adminKey) { costData, _ in
+                let cost = costData.flatMap { try? OpenAIUsageFetcher.parseCosts($0) }
+                let base = OpenAIUsageSnapshot(
+                    tokensByModel: tokens,
+                    costMTDUSD: cost?.usd ?? 0,
+                    costCurrency: cost?.currency
+                )
+                // Rate limits are best-effort: discover a project id, then
+                // fetch its ceilings. Any failure just omits that section.
+                self.get("\(self.base)/projects?limit=1", bearer: adminKey) { projData, _ in
+                    guard let projData = projData,
+                          let projJSON = try? JSONSerialization.jsonObject(with: projData) as? [String: Any],
+                          let projects = projJSON["data"] as? [[String: Any]],
+                          let firstProject = projects.first,
+                          let projectId = firstProject["id"] as? String else {
+                        deliver(.success(base))
+                        return
+                    }
+                    self.get("\(self.base)/projects/\(projectId)/rate_limits", bearer: adminKey) { rlData, _ in
+                        let limits = rlData.flatMap { try? OpenAIUsageFetcher.parseRateLimits($0) } ?? []
+                        let full = OpenAIUsageSnapshot(
+                            tokensByModel: tokens,
+                            costMTDUSD: cost?.usd ?? 0,
+                            costCurrency: cost?.currency,
+                            rateLimits: limits
+                        )
+                        deliver(.success(full))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Start of the current month in UTC, as a Unix timestamp.
+    public static func startOfUTCMonth(_ date: Date) -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.year, .month], from: date)
+        let start = cal.date(from: comps) ?? date
+        return Int(start.timeIntervalSince1970)
+    }
+
+    private func get(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        guard let url = URL(string: urlString) else { done(nil, nil); return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("OpenAI org API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}

--- a/app/PerplexityUsageFetcher.swift
+++ b/app/PerplexityUsageFetcher.swift
@@ -1,0 +1,484 @@
+// PR 8-BE — Perplexity Pro/Max usage fetcher (session-cookie authenticated).
+//
+// Sixth non-Anthropic provider, first cookie-authenticated one. The user
+// pastes their perplexity.ai session cookie (a spending credential — it lets
+// the bearer make paid Sonar queries and can top up on-demand credits), so
+// the cookie lives in the Keychain, never in UserDefaults.
+//
+// Auth ingestion accepts all four NextAuth v4/Auth.js v5 session cookie
+// names ("__Secure-next-auth.session-token" (live default), "next-auth.
+// session-token", "__Secure-authjs.session-token", "authjs.session-token"),
+// plus the chunked variants (.0, .1, …) NextAuth splits large JWEs into.
+// Bare tokens are accepted verbatim and sent under the default name.
+//
+// The three endpoints (all undocumented — perplexity.ai's own web UI calls
+// them):
+//   GET /rest/billing/credits?version=2.18&source=default
+//        → balance_cents (float USD cents), renewal_date_ts (Unix seconds),
+//          current_period_purchased_cents (float), credit_grants[] (each
+//          { type: "recurring"|"promotional"|"purchased", amount_cents,
+//          expires_at_ts?: Unix seconds }), total_usage_cents (float).
+//   GET /rest/rate-limit/all
+//        → remaining_pro, remaining_research, remaining_labs,
+//          remaining_agentic_research (ints — REMAINING ONLY, no totals, no
+//          resets), model_specific_limits {}, sources.source_to_limit
+//          { source_id: { monthly_limit: int|nil, remaining: int|nil } }.
+//          Total caps must be inferred client-side (plan lookup); the
+//          endpoint reports no plan/tier field of its own.
+//   GET /rest/user/settings
+//        → subscription_status ("active"|"trialing"|"none"),
+//          subscription_source, subscription_tier ("free"|"pro"|"max"), plus
+//          pages/upload/create limits and query_count. Supplies the plan
+//          label the rate-limit endpoint lacks.
+//
+// Cloudflare bot protection fronts perplexity.ai/rest/*. A residential-IP
+// URLSession GET with a valid cookie + a browser-shaped User-Agent + Accept
+// + Origin/Referer headers passes challenge on Macs today (verified across
+// three independent OSS consumers). Data centre / VPS traffic gets 403-
+// challenged regardless of cookie validity. We ship the browser headers
+// and surface 401/403 as invalidToken, which is what the user actually
+// needs to act on.
+//
+// Credentials never enter a log line; only status codes go through
+// Log.info(.count). The CI credential-leak guard is extended in this PR to
+// cover the `sessionCookie` name already, and `perplexity` variable prefixes
+// where they exist.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// One entry from `credit_grants[]`. Type strings observed: "recurring"
+/// (the monthly plan allotment), "promotional" (bonus, may expire), and
+/// "purchased" (on-demand top-ups). Unknown types are preserved verbatim so
+/// a new tier introduced server-side is not silently dropped.
+public struct PerplexityCreditGrant: Equatable, Sendable {
+    public var type: String
+    public var amountCents: Double
+    /// Unix epoch seconds; nil for grants that never expire (e.g. purchased).
+    public var expiresAtEpoch: Double?
+
+    public init(type: String, amountCents: Double, expiresAtEpoch: Double? = nil) {
+        self.type = type
+        self.amountCents = amountCents
+        self.expiresAtEpoch = expiresAtEpoch
+    }
+}
+
+/// Parsed `/rest/billing/credits` body.
+public struct PerplexityCredits: Equatable, Sendable {
+    /// Live balance in USD cents (float on the wire; we preserve precision).
+    public var balanceCents: Double
+    /// Renewal (start of next billing cycle) as Unix epoch seconds.
+    public var renewalEpoch: Double
+    /// On-demand purchases in the current billing period. May be reported
+    /// both here and inside `credit_grants` as `purchased`; the store
+    /// deduplicates by taking the max, per CodexBar convention.
+    public var currentPeriodPurchasedCents: Double
+    /// One entry per grant.
+    public var grants: [PerplexityCreditGrant]
+    /// Spend so far in the current billing period.
+    public var totalUsageCents: Double
+
+    public init(
+        balanceCents: Double = 0,
+        renewalEpoch: Double = 0,
+        currentPeriodPurchasedCents: Double = 0,
+        grants: [PerplexityCreditGrant] = [],
+        totalUsageCents: Double = 0
+    ) {
+        self.balanceCents = balanceCents
+        self.renewalEpoch = renewalEpoch
+        self.currentPeriodPurchasedCents = currentPeriodPurchasedCents
+        self.grants = grants
+        self.totalUsageCents = totalUsageCents
+    }
+}
+
+/// One entry from `sources.source_to_limit`. Both fields are nullable in the
+/// wire shape; a null `monthlyLimit` means the source is unmetered.
+public struct PerplexitySourceLimit: Equatable, Sendable {
+    public var sourceId: String
+    public var monthlyLimit: Int?
+    public var remaining: Int?
+
+    public init(sourceId: String, monthlyLimit: Int? = nil, remaining: Int? = nil) {
+        self.sourceId = sourceId
+        self.monthlyLimit = monthlyLimit
+        self.remaining = remaining
+    }
+}
+
+/// Parsed `/rest/rate-limit/all` body. Only remaining counts are on the
+/// wire — no totals, no reset timestamps, no plan/tier field.
+public struct PerplexityRateLimits: Equatable, Sendable {
+    public var remainingPro: Int
+    public var remainingResearch: Int
+    public var remainingLabs: Int
+    public var remainingAgenticResearch: Int
+    public var sources: [PerplexitySourceLimit]
+
+    public init(
+        remainingPro: Int = 0,
+        remainingResearch: Int = 0,
+        remainingLabs: Int = 0,
+        remainingAgenticResearch: Int = 0,
+        sources: [PerplexitySourceLimit] = []
+    ) {
+        self.remainingPro = remainingPro
+        self.remainingResearch = remainingResearch
+        self.remainingLabs = remainingLabs
+        self.remainingAgenticResearch = remainingAgenticResearch
+        self.sources = sources
+    }
+}
+
+/// Parsed subset of `/rest/user/settings`. The response is large; we ingest
+/// only the fields that inform tiles. Everything else is deliberately
+/// ignored to avoid tying us to churn on unrelated flags.
+public struct PerplexityUserSettings: Equatable, Sendable {
+    /// "active" | "trialing" | "none" | (other, preserved verbatim).
+    public var subscriptionStatus: String?
+    /// "stripe" | "revenuecat" | "none" | (other).
+    public var subscriptionSource: String?
+    /// "free" | "pro" | "max" | (other). The plan label the rate-limit
+    /// endpoint lacks.
+    public var subscriptionTier: String?
+    /// Best-effort per-feature limits carried by the endpoint. Zero for
+    /// absent fields.
+    public var pagesLimit: Int
+    public var uploadLimit: Int
+    public var createLimit: Int
+    public var queryCount: Int
+
+    public init(
+        subscriptionStatus: String? = nil,
+        subscriptionSource: String? = nil,
+        subscriptionTier: String? = nil,
+        pagesLimit: Int = 0,
+        uploadLimit: Int = 0,
+        createLimit: Int = 0,
+        queryCount: Int = 0
+    ) {
+        self.subscriptionStatus = subscriptionStatus
+        self.subscriptionSource = subscriptionSource
+        self.subscriptionTier = subscriptionTier
+        self.pagesLimit = pagesLimit
+        self.uploadLimit = uploadLimit
+        self.createLimit = createLimit
+        self.queryCount = queryCount
+    }
+}
+
+/// Aggregate snapshot the store applies. Any subset may be nil when the
+/// corresponding endpoint failed; the transport reports partial success by
+/// filling only the pieces that came back OK. A hard 401/403 short-circuits
+/// to `unauthorized` instead of a `success` with everything nil.
+public struct PerplexityUsageSnapshot: Equatable, Sendable {
+    public var credits: PerplexityCredits?
+    public var rateLimits: PerplexityRateLimits?
+    public var settings: PerplexityUserSettings?
+
+    public init(
+        credits: PerplexityCredits? = nil,
+        rateLimits: PerplexityRateLimits? = nil,
+        settings: PerplexityUserSettings? = nil
+    ) {
+        self.credits = credits
+        self.rateLimits = rateLimits
+        self.settings = settings
+    }
+}
+
+public enum PerplexityUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Cookie normalisation
+
+/// Session cookie forms Perplexity/NextAuth may present. Ordered
+/// most-preferred first: the __Secure- prefixed pair takes priority since
+/// perplexity.ai serves HTTPS-only and the __Secure- variant is the one live
+/// consumers see today (July 2026).
+public enum PerplexityCookie {
+    /// The four accepted NextAuth session cookie names, in priority order.
+    /// Insensitive to case for the match; casing is preserved for the header.
+    public static let supportedSessionCookieNames: [String] = [
+        "__Secure-next-auth.session-token",
+        "__Secure-authjs.session-token",
+        "next-auth.session-token",
+        "authjs.session-token",
+    ]
+
+    /// Default cookie name to send when the user pasted only a bare token.
+    public static let defaultSessionCookieName: String = "__Secure-next-auth.session-token"
+
+    /// Extract a `(cookieName, token)` pair from whatever the user pasted:
+    ///   - a bare token (no `;` and no `=`) → wrapped under the default cookie
+    ///     name.
+    ///   - a `name=value` pair or full cookie header (`a=1; b=2; …`) → the
+    ///     highest-priority supported session cookie is picked.
+    ///   - a paste that contains `=` but yields no supported cookie AND has
+    ///     no `;` separators → treated as a bare token verbatim. This catches
+    ///     opaque tokens with base64 padding (`abc.def==`) that would
+    ///     otherwise be mis-parsed as `abc.def=` = empty (an unsupported cookie
+    ///     name).
+    ///   - NextAuth chunked variants (`__Secure-next-auth.session-token.0`,
+    ///     `.1`, …) → reassembled in index order under the base name; the
+    ///     chunk index is bounded to defeat overflow / mass-allocation
+    ///     attacks.
+    /// Returns nil when the input yields no usable cookie.
+    public static func extract(from rawInput: String) -> (name: String, token: String)? {
+        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Bare token — no `=`, no `;`. Send under the default name.
+        if !trimmed.contains("="), !trimmed.contains(";") {
+            return (defaultSessionCookieName, trimmed)
+        }
+
+        // Otherwise parse `k=v; k=v; …` pairs.
+        var pairs: [(String, String)] = []
+        for chunk in trimmed.split(separator: ";") {
+            let piece = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let eq = piece.firstIndex(of: "=") else { continue }
+            let key = String(piece[..<eq]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let val = String(piece[piece.index(after: eq)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !key.isEmpty, !val.isEmpty {
+                pairs.append((key, val))
+            }
+        }
+        if let picked = pickSessionCookie(from: pairs) {
+            return picked
+        }
+        // Fallback: the input contains an `=` but did NOT parse into a
+        // supported session cookie AND has no `;` separators, so it is most
+        // likely a bare opaque token whose payload happens to contain `=`
+        // (e.g. base64 padding). Send it verbatim under the default name.
+        //
+        // Exception: if the name-part LOOKS like a session-cookie form
+        // (starts with one of the supported base names, e.g. a chunked
+        // variant that failed the index-bound check), do NOT fall back —
+        // that would let a hostile chunked-index paste smuggle a bogus
+        // token through the overflow guard.
+        if !trimmed.contains(";"),
+           let firstEq = trimmed.firstIndex(of: "="),
+           !looksLikeSessionCookieName(String(trimmed[..<firstEq])) {
+            return (defaultSessionCookieName, trimmed)
+        }
+        return nil
+    }
+
+    /// True when `raw` starts with (or equals, case-insensitively) any of
+    /// the four supported session-cookie base names. Used to prevent the
+    /// bare-token fallback from swallowing a malformed session-cookie paste.
+    private static func looksLikeSessionCookieName(_ raw: String) -> Bool {
+        let lower = raw.lowercased().trimmingCharacters(in: .whitespaces)
+        for expected in supportedSessionCookieNames {
+            let base = expected.lowercased()
+            if lower == base { return true }
+            if lower.hasPrefix(base + ".") { return true }
+        }
+        return false
+    }
+
+    /// Pick the highest-priority supported session cookie from a name/value
+    /// list. Handles NextAuth chunked cookies by reassembling in index order.
+    static func pickSessionCookie(from pairs: [(String, String)]) -> (name: String, token: String)? {
+        // Build case-insensitive lookup by lowercased key.
+        var byLoweredName: [String: (String, String)] = [:]
+        var chunkedByBase: [String: [Int: String]] = [:]
+        for (k, v) in pairs {
+            let lower = k.lowercased()
+            byLoweredName[lower] = (k, v)
+            for expected in supportedSessionCookieNames {
+                let base = expected.lowercased() + "."
+                guard lower.hasPrefix(base) else { continue }
+                let suffix = String(lower.dropFirst(base.count))
+                // Bound the chunk index defensively: NextAuth's real chunk
+                // indexes are 0..~10 (each ~4 KB). Reject indexes outside
+                // [0, maxAllowedChunkIndex] so a hostile paste of
+                // `…session-token.9223372036854775807=x` cannot overflow the
+                // `maxIdx + 1` arithmetic in `reassemble`, nor force a
+                // ~2 GB reserveCapacity.
+                guard let idx = Int(suffix), idx >= 0, idx <= maxAllowedChunkIndex else { continue }
+                chunkedByBase[expected.lowercased(), default: [:]][idx] = v
+            }
+        }
+
+        // Prefer a whole cookie over its chunked variant when both are present.
+        for expected in supportedSessionCookieNames {
+            let lower = expected.lowercased()
+            if let (originalName, value) = byLoweredName[lower] {
+                return (originalName, value)
+            }
+            if let chunks = chunkedByBase[lower], let reassembled = reassemble(chunks: chunks) {
+                return (expected, reassembled)
+            }
+        }
+        return nil
+    }
+
+    /// Absolute cap on the NextAuth chunk index. Real deployments have never
+    /// been observed above single digits; 64 is a generous ceiling that
+    /// still prevents pathological allocation.
+    static let maxAllowedChunkIndex: Int = 64
+
+    private static func reassemble(chunks: [Int: String]) -> String? {
+        guard let maxIdx = chunks.keys.max() else { return nil }
+        // Redundant safety net — pickSessionCookie already caps at
+        // maxAllowedChunkIndex, but reassemble may be reached via a future
+        // caller. `maxIdx + 1` cannot overflow here because maxIdx is bounded.
+        guard maxIdx >= 0, maxIdx <= maxAllowedChunkIndex else { return nil }
+        var parts: [String] = []
+        parts.reserveCapacity(maxIdx + 1)
+        for i in 0 ... maxIdx {
+            guard let piece = chunks[i] else { return nil }  // gap → refuse
+            parts.append(piece)
+        }
+        return parts.joined()
+    }
+}
+
+// MARK: - Fetcher
+
+public struct PerplexityUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain key under which the pasted cookie is stored (raw input as
+    /// pasted; parsing runs at fetch time so a user can update the paste
+    /// format without needing to re-enter).
+    public static let cookieKeychainKey = "perplexity.session_cookie"
+
+    // MARK: Endpoint parsing
+
+    /// Parse the `/rest/billing/credits` body.
+    public static func parseCredits(_ data: Data) throws -> PerplexityCredits {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PerplexityUsageParseError.invalidJSON
+        }
+        var out = PerplexityCredits()
+        out.balanceCents = doubleOrZero(json["balance_cents"])
+        // Clamp Unix-second timestamps to a sane range. A wild value
+        // ("1e300") would create a pathological Date which then flows into
+        // DateFormatter downstream. saneEpochOrZero rejects anything outside
+        // [Jan 2000, Jan 2100] and returns 0 (treated by the store as "no
+        // renewal date"). Verified with round-2 Codex review #4.
+        out.renewalEpoch = saneEpochOrZero(json["renewal_date_ts"])
+        out.currentPeriodPurchasedCents = doubleOrZero(json["current_period_purchased_cents"])
+        out.totalUsageCents = doubleOrZero(json["total_usage_cents"])
+        if let grants = json["credit_grants"] as? [[String: Any]] {
+            out.grants = grants.compactMap { entry in
+                guard let type = entry["type"] as? String else { return nil }
+                return PerplexityCreditGrant(
+                    type: type,
+                    amountCents: doubleOrZero(entry["amount_cents"]),
+                    expiresAtEpoch: saneEpochOrNil(entry["expires_at_ts"])
+                )
+            }
+        }
+        return out
+    }
+
+    /// Sane bounds for a Unix-seconds timestamp coming off an untrusted API.
+    /// Jan 1 2000 UTC .. Jan 1 2100 UTC — anything outside is treated as
+    /// missing / garbage so a `Date` derived from it stays inside Foundation's
+    /// safe range.
+    static let minSaneEpoch: Double = 946684800   // 2000-01-01 UTC
+    static let maxSaneEpoch: Double = 4102444800  // 2100-01-01 UTC
+
+    /// Coerce to a Double epoch inside the sane range, else return 0.
+    static func saneEpochOrZero(_ value: Any?) -> Double {
+        saneEpochOrNil(value) ?? 0
+    }
+
+    /// Coerce to a Double epoch inside the sane range, else return nil.
+    static func saneEpochOrNil(_ value: Any?) -> Double? {
+        guard let d = doubleOrNil(value), d.isFinite,
+              d >= minSaneEpoch, d <= maxSaneEpoch else { return nil }
+        return d
+    }
+
+    /// Parse the `/rest/rate-limit/all` body.
+    public static func parseRateLimits(_ data: Data) throws -> PerplexityRateLimits {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PerplexityUsageParseError.invalidJSON
+        }
+        var out = PerplexityRateLimits()
+        out.remainingPro = max(0, intOrZero(json["remaining_pro"]))
+        out.remainingResearch = max(0, intOrZero(json["remaining_research"]))
+        out.remainingLabs = max(0, intOrZero(json["remaining_labs"]))
+        out.remainingAgenticResearch = max(0, intOrZero(json["remaining_agentic_research"]))
+
+        if let sources = json["sources"] as? [String: Any],
+           let map = sources["source_to_limit"] as? [String: Any] {
+            var parsed: [PerplexitySourceLimit] = []
+            parsed.reserveCapacity(map.count)
+            for (sourceId, raw) in map {
+                guard let entry = raw as? [String: Any] else { continue }
+                parsed.append(PerplexitySourceLimit(
+                    sourceId: sourceId,
+                    monthlyLimit: intOrNil(entry["monthly_limit"]),
+                    remaining: intOrNil(entry["remaining"])
+                ))
+            }
+            // Sort for deterministic tile ordering / test equality.
+            out.sources = parsed.sorted { $0.sourceId < $1.sourceId }
+        }
+        return out
+    }
+
+    /// Parse the `/rest/user/settings` body. Only fields that inform tiles
+    /// are extracted; everything else in the response is intentionally
+    /// ignored to keep the parser resilient to churn on unrelated flags.
+    public static func parseUserSettings(_ data: Data) throws -> PerplexityUserSettings {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PerplexityUsageParseError.invalidJSON
+        }
+        var out = PerplexityUserSettings()
+        out.subscriptionStatus = json["subscription_status"] as? String
+        out.subscriptionSource = json["subscription_source"] as? String
+        out.subscriptionTier = json["subscription_tier"] as? String
+        out.pagesLimit = max(0, intOrZero(json["pages_limit"]))
+        out.uploadLimit = max(0, intOrZero(json["upload_limit"]))
+        out.createLimit = max(0, intOrZero(json["create_limit"]))
+        out.queryCount = max(0, intOrZero(json["query_count"]))
+        return out
+    }
+
+    // MARK: Number coercion
+
+    /// Int coercion. Accepts Int, finite Double (rounded), or a numeric
+    /// string. Returns nil rather than trapping on a non-finite / oversize
+    /// Double (`Int(1e300)` traps; `Int(exactly:)` does not).
+    static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
+        if let s = value as? String {
+            return Int(s) ?? Double(s).flatMap { $0.isFinite ? Int(exactly: $0.rounded()) : nil }
+        }
+        return nil
+    }
+
+    static func intOrZero(_ value: Any?) -> Int {
+        intOrNil(value) ?? 0
+    }
+
+    /// Double coercion. Nil is returned only for a non-finite Double or a
+    /// truly missing field; strings are parsed defensively.
+    static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d.isFinite ? d : nil }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s).flatMap { $0.isFinite ? $0 : nil } }
+        return nil
+    }
+
+    static func doubleOrZero(_ value: Any?) -> Double {
+        doubleOrNil(value) ?? 0
+    }
+}

--- a/app/PerplexityUsageFetcher.swift
+++ b/app/PerplexityUsageFetcher.swift
@@ -230,7 +230,21 @@ public enum PerplexityCookie {
     ///     attacks.
     /// Returns nil when the input yields no usable cookie.
     public static func extract(from rawInput: String) -> (name: String, token: String)? {
-        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        var trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // Strip an optional leading "Cookie:" header prefix in any casing
+        // (Cookie:, cookie:, CoOkIe:, …). Some browsers' "Copy as HAR" /
+        // "Copy request headers" tools return the whole header line; the
+        // user should not have to hand-strip it. Truly ASCII case-insensitive
+        // so no spelling permutation falls through into the bare-token
+        // fallback and stores the header line as a token.
+        let prefixToken = "cookie:"
+        if trimmed.count >= prefixToken.count {
+            let head = trimmed.prefix(prefixToken.count)
+            if head.lowercased() == prefixToken {
+                trimmed = String(trimmed.dropFirst(prefixToken.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
         guard !trimmed.isEmpty else { return nil }
 
         // Bare token — no `=`, no `;`. Send under the default name.

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -515,8 +515,11 @@ private enum PerplexityEndpointKind {
 /// Thread-safe accumulator for the three concurrent GETs. A final call to
 /// `finalize()` collapses the state into a single snapshot + unauthorized
 /// flag. Lock-protected because `dataTask` completions can land on any
-/// queue.
-private final class PerplexityFetchAccumulator: @unchecked Sendable {
+/// queue. `public` (rather than `private`) so TestRunner can lock in the
+/// httpError priority ordering without going through a live URL session
+/// (chk1 Omission #1). The type is otherwise an internal implementation
+/// detail — not re-exported, not part of the store's public API surface.
+public final class PerplexityFetchAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var credits: PerplexityCredits?
     private var rateLimits: PerplexityRateLimits?
@@ -528,23 +531,25 @@ private final class PerplexityFetchAccumulator: @unchecked Sendable {
     /// failed.
     private var httpError: Int?
 
-    func setCredits(_ value: PerplexityCredits) {
+    public init() {}
+
+    public func setCredits(_ value: PerplexityCredits) {
         lock.lock(); defer { lock.unlock() }
         credits = value
     }
-    func setRateLimits(_ value: PerplexityRateLimits) {
+    public func setRateLimits(_ value: PerplexityRateLimits) {
         lock.lock(); defer { lock.unlock() }
         rateLimits = value
     }
-    func setSettings(_ value: PerplexityUserSettings) {
+    public func setSettings(_ value: PerplexityUserSettings) {
         lock.lock(); defer { lock.unlock() }
         settings = value
     }
-    func setUnauthorized() {
+    public func setUnauthorized() {
         lock.lock(); defer { lock.unlock() }
         unauthorized = true
     }
-    func recordHttpError(_ status: Int) {
+    public func recordHttpError(_ status: Int) {
         lock.lock(); defer { lock.unlock() }
         // Priority: 429 > 5xx > anything else. Only replace when the new
         // code carries strictly more signal.
@@ -561,7 +566,7 @@ private final class PerplexityFetchAccumulator: @unchecked Sendable {
             httpError = status
         }
     }
-    func finalize() -> (Bool, Int?, PerplexityUsageSnapshot) {
+    public func finalize() -> (Bool, Int?, PerplexityUsageSnapshot) {
         lock.lock(); defer { lock.unlock() }
         return (unauthorized, httpError, PerplexityUsageSnapshot(
             credits: credits,
@@ -569,4 +574,14 @@ private final class PerplexityFetchAccumulator: @unchecked Sendable {
             settings: settings
         ))
     }
+
+    #if DEBUG
+    /// Test-only accessor for the current httpError. Guarded behind DEBUG
+    /// so it cannot be reached from production paths and stays out of
+    /// release-binary symbol tables.
+    public var currentHttpError: Int? {
+        lock.lock(); defer { lock.unlock() }
+        return httpError
+    }
+    #endif
 }

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -116,9 +116,10 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
 
         var out: [UsageTile] = []
 
-        // Plan tile from user/settings. Fall back to a plain "Perplexity" label
-        // when settings is absent (Cloudflare-challenged that endpoint).
-        if let settings = snap.settings, let tier = normalisedTier(settings.subscriptionTier, source: settings.subscriptionSource) {
+        // Plan tile from user/settings. Only rendered when we can name a
+        // plan tier — the tile is omitted when the settings endpoint was
+        // Cloudflare-challenged or only reported a billing source.
+        if let settings = snap.settings, let tier = normalisedTier(settings.subscriptionTier) {
             let statusLine = settings.subscriptionStatus.map { "\(tier) (\($0))" } ?? tier
             out.append(UsageTile(
                 id: "perplexity-plan",
@@ -202,23 +203,24 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
         return out
     }
 
-    /// Normalise raw subscription strings into a human label. Preserves
+    /// Normalise a raw subscription-tier string into a human label. Preserves
     /// unknown values verbatim so a new tier introduced server-side is not
-    /// silently swallowed.
-    private func normalisedTier(_ rawTier: String?, source: String?) -> String? {
-        // Prefer subscription_tier when present; fall back to source name.
-        if let tier = rawTier?.trimmingCharacters(in: .whitespaces), !tier.isEmpty, tier.lowercased() != "none" {
-            switch tier.lowercased() {
-            case "free": return "Free"
-            case "pro": return "Pro"
-            case "max": return "Max"
-            default: return tier
-            }
+    /// silently swallowed. Returns nil when no tier is reported — the caller
+    /// omits the plan tile in that case rather than mislabelling it with a
+    /// billing-provider name (chk1 Bug #3: `subscription_source` values like
+    /// "stripe" / "revenuecat" are billing providers, NOT plans).
+    private func normalisedTier(_ rawTier: String?) -> String? {
+        guard let tier = rawTier?.trimmingCharacters(in: .whitespaces),
+              !tier.isEmpty,
+              tier.lowercased() != "none" else {
+            return nil
         }
-        if let src = source?.trimmingCharacters(in: .whitespaces), !src.isEmpty, src.lowercased() != "none" {
-            return src.capitalized
+        switch tier.lowercased() {
+        case "free": return "Free"
+        case "pro":  return "Pro"
+        case "max":  return "Max"
+        default:     return tier   // preserve an unknown tier verbatim
         }
-        return nil
     }
 
     // MARK: - Result application (testable seam)
@@ -261,13 +263,34 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
 
     public func fetch() {
         guard isEnabled else { return }
-        guard let data = credentials.read(PerplexityUsageFetcher.cookieKeychainKey),
-              !data.isEmpty,
-              let raw = String(data: data, encoding: .utf8) else {
-            // No credential in the store (or locked keychain returning nil
-            // read here). Onboarding card renders via isConfigured=false.
+        // Use readResult() rather than read() so a locked keychain
+        // (.unavailable) is distinguished from a truly-missing item. Round-2
+        // review addressed the malformed-cookie case; this closes the same
+        // silent-no-op gap for the locked-keychain scenario — isConfigured
+        // still returns true when the item exists but is unreadable, so
+        // without an explicit branch here the UI would report the provider
+        // as configured while fetch quietly did nothing (chk1 Bug #2).
+        let data: Data
+        switch credentials.readResult(PerplexityUsageFetcher.cookieKeychainKey) {
+        case .found(let value) where !value.isEmpty:
+            data = value
+        case .found, .missing:
+            // No credential stored (or empty item — treat as missing).
+            // Onboarding card renders via isConfigured=false.
             snapshot = nil
             lastError = nil
+            return
+        case .unavailable:
+            // Keychain present but temporarily unreadable (locked screen,
+            // access denied). Surface an actionable message so the tile
+            // does not silently blank while the user's Mac is locked.
+            snapshot = nil
+            lastError = "Keychain locked or unavailable. Unlock your Mac to refresh Perplexity usage."
+            return
+        }
+        guard let raw = String(data: data, encoding: .utf8) else {
+            snapshot = nil
+            lastError = "Could not decode the stored Perplexity cookie. Re-paste it in Settings."
             return
         }
         guard let cookie = PerplexityCookie.extract(from: raw) else {
@@ -335,6 +358,32 @@ public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
     /// it is the shape Perplexity's own web bundle sends.
     private let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+
+    /// Private URLSession, isolated from `URLSession.shared` (chk1 Risk #1
+    /// + #2). Two problems the shared session has for a cookie-authenticated
+    /// provider:
+    ///   1. The default `HTTPCookieStorage` is disk-backed under
+    ///      ~/Library/Cookies/. Perplexity sets several cookies on every
+    ///      response (`__cf_bm`, `cf_clearance`, session tokens); with the
+    ///      shared session those would silently persist across app launches
+    ///      in a store the user cannot see, and would leak onto every other
+    ///      request the app makes to perplexity.ai (including Anthropic's
+    ///      tracker if that ever traversed the domain).
+    ///   2. `URLSessionConfiguration.default.timeoutIntervalForResource` is
+    ///      604 800 seconds (7 days). A stalled Perplexity response would
+    ///      park its callback for a week.
+    /// Our explicit `Cookie:` header is the ONLY source of session state for
+    /// this transport; the response cookie jar is nulled so nothing sticks.
+    /// Timeouts are matched to the 60s poll cadence.
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
 
     public init() {}
 
@@ -443,7 +492,10 @@ public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
         request.setValue("https://www.perplexity.ai/account/usage", forHTTPHeaderField: "Referer")
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
 
-        URLSession.shared.dataTask(with: request) { data, response, error in
+        // Private session (see the `session` property comment) — critical
+        // that this is NOT URLSession.shared, so Perplexity's Set-Cookie
+        // responses cannot contaminate the process-wide cookie jar.
+        session.dataTask(with: request) { data, response, error in
             if error != nil { done(nil, nil); return }
             let status = (response as? HTTPURLResponse)?.statusCode
             Log.info("Perplexity API response", .count(status ?? -1))

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -2,9 +2,10 @@
 //
 // Sixth non-Anthropic provider; first cookie-authenticated one. The user's
 // perplexity.ai session cookie is stored in the Keychain (PasteKeyProvider
-// UX; the field ships in PR 8-UI). Three endpoints are polled every 5
-// minutes when enabled: credits, rate-limit/all, user/settings. Bodies are
-// never logged; only HTTP status codes go through Log.info(.count).
+// UX shipped in PR 8-UI). Three endpoints are polled every 60 seconds by
+// the shared AppDelegate timer when enabled: credits, rate-limit/all,
+// user/settings. Bodies are never logged; only HTTP status codes go
+// through Log.info(.count).
 //
 // Feature posture: features.perplexity.enabled defaults false. Nothing
 // registers a store into the live registry yet — the tile + Settings sheet
@@ -150,8 +151,13 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
             // published Pro/Max plan comparisons (CodexBar comment) —
             // NB: the initial draft used 5 000 which flipped Pro users to
             // "Max" one order of magnitude too early.
+            // Defensive lowercase compare: Perplexity has been observed
+            // returning "recurring" verbatim, but a future casing change
+            // ("Recurring") would silently drop the recurring total and
+            // blank out the plan hint. Match case-insensitively so a
+            // schema tweak does not cause a silent regression.
             let recurring = credits.grants
-                .filter { $0.type == "recurring" }
+                .filter { $0.type.lowercased() == "recurring" }
                 .reduce(0.0) { $0 + max(0, $1.amountCents) }
             let planHint: String? = recurring <= 0
                 ? nil

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -520,10 +520,17 @@ private enum PerplexityEndpointKind {
 /// Thread-safe accumulator for the three concurrent GETs. A final call to
 /// `finalize()` collapses the state into a single snapshot + unauthorized
 /// flag. Lock-protected because `dataTask` completions can land on any
-/// queue. `public` (rather than `private`) so TestRunner can lock in the
-/// httpError priority ordering without going through a live URL session
-/// (chk1 Omission #1). The type is otherwise an internal implementation
-/// detail — not re-exported, not part of the store's public API surface.
+/// queue.
+///
+/// `public` (rather than `private`) so TestRunner — a separate SwiftPM
+/// target — can lock in the httpError priority ordering and multi-endpoint
+/// partial-success shapes without going through a live URL session
+/// (chk1 Omission #1 + #2). Codex round-4 flagged this as a small API
+/// surface leak; we accept the leak because ClaudeUsageBar is an app-only
+/// module with no external library consumers, so no downstream code can
+/// depend on this shape. If the module ever gains an external API contract,
+/// switch TestRunner to `@testable import ClaudeUsageBar` and revert this
+/// to `internal`.
 public final class PerplexityFetchAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var credits: PerplexityCredits?

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -30,6 +30,10 @@ public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKey
     // or a full cookie header string (browser DevTools "Copy value" or
     // "Copy string"). Extraction runs at fetch time.
     public let keyPlaceholder: String = "__Secure-next-auth.session-token=… (or paste the cookie value)"
+    /// Override the default noun so the generic ProviderToggleRow renders
+    /// "Cookie saved in Keychain" rather than "Key saved in Keychain",
+    /// matching what the user actually pasted.
+    public var secretKindNoun: String { "Cookie" }
 
     // MARK: Observable state
 

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -1,0 +1,510 @@
+// PR 8-BE — Perplexity Pro/Max UsageProvider conformer (dark code, flag off).
+//
+// Sixth non-Anthropic provider; first cookie-authenticated one. The user's
+// perplexity.ai session cookie is stored in the Keychain (PasteKeyProvider
+// UX; the field ships in PR 8-UI). Three endpoints are polled every 5
+// minutes when enabled: credits, rate-limit/all, user/settings. Bodies are
+// never logged; only HTTP status codes go through Log.info(.count).
+//
+// Feature posture: features.perplexity.enabled defaults false. Nothing
+// registers a store into the live registry yet — the tile + Settings sheet
+// land in PR 8-UI.
+//
+// Polling etiquette: perplexity.ai's own internal endpoints ask consumers
+// to cache 60s+ to avoid a shadow-ban on the session cookie. The shared
+// AppDelegate timer fires providers at 60s; that meets the etiquette
+// without a per-provider override.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class PerplexityUsageStore: @preconcurrency UsageProvider, PasteKeyProvider {
+
+    public let id: String = "perplexity"
+    public let displayName: String = "Perplexity"
+    public let featureFlagKey: String = "features.perplexity.enabled"
+
+    // PasteKeyProvider — the input can be a bare token, a name=value pair,
+    // or a full cookie header string (browser DevTools "Copy value" or
+    // "Copy string"). Extraction runs at fetch time.
+    public let keyPlaceholder: String = "__Secure-next-auth.session-token=… (or paste the cookie value)"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: PerplexityUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: PerplexityUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: PerplexityUsageTransport = URLSessionPerplexityTransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// True when a session cookie is stored, treating a locked keychain as
+    /// "still configured" so a locked screen does not drop the provider back
+    /// to onboarding (parity with DeepSeek / xAI / OpenAI).
+    public var hasKey: Bool {
+        switch credentials.readResult(PerplexityUsageFetcher.cookieKeychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
+    }
+
+    /// Store the pasted cookie verbatim (whitespace-trimmed only). We do NOT
+    /// pre-parse: keeping the raw input lets the user amend a stray prefix
+    /// without re-pasting the whole thing, and extraction runs at fetch
+    /// time.
+    public func saveKey(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(PerplexityUsageFetcher.cookieKeychainKey)
+        } else {
+            credentials.write(PerplexityUsageFetcher.cookieKeychainKey, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    public var isConfigured: Bool {
+        hasKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "perplexity-needs-key",
+                title: "Perplexity",
+                kind: .needsAccess(
+                    path: "perplexity.ai",
+                    guidance: "Paste your Perplexity session cookie in Settings. Sign in on perplexity.ai, then copy the value of the __Secure-next-auth.session-token cookie."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan tile from user/settings. Fall back to a plain "Perplexity" label
+        // when settings is absent (Cloudflare-challenged that endpoint).
+        if let settings = snap.settings, let tier = normalisedTier(settings.subscriptionTier, source: settings.subscriptionSource) {
+            let statusLine = settings.subscriptionStatus.map { "\(tier) (\($0))" } ?? tier
+            out.append(UsageTile(
+                id: "perplexity-plan",
+                title: "Perplexity plan",
+                kind: .text(status: statusLine, subtitle: nil)
+            ))
+        }
+
+        // Credits balance tile. balance_cents is a live USD-cents number;
+        // the balance tile takes minor units directly. Renewal date drives
+        // the resetsAt hint.
+        if let credits = snap.credits {
+            // Crash-safety: balance_cents is a Double parsed from an
+            // untrusted server. `Int(Double)` traps on non-finite / oversize
+            // values (1e300 is a valid JSON number). Clamp with
+            // Int(exactly:) on the rounded Double, then max(0, …).
+            let cents: Int = {
+                let clamped = max(0.0, credits.balanceCents)
+                guard clamped.isFinite else { return 0 }
+                return Int(exactly: clamped.rounded()) ?? Int.max
+            }()
+            let renewsAt: Date? = credits.renewalEpoch > 0
+                ? Date(timeIntervalSince1970: credits.renewalEpoch)
+                : nil
+            // Plan hint on the balance tile comes from the recurring grant
+            // total. Perplexity's own plans put Pro's monthly credit
+            // allotment in the ~$5 range and Max's in the ~$100+ range; use
+            // 10 000 cents ($100) as the Pro/Max boundary so a $50 (5 000c)
+            // recurring grant is still labelled Pro. Verified against
+            // published Pro/Max plan comparisons (CodexBar comment) —
+            // NB: the initial draft used 5 000 which flipped Pro users to
+            // "Max" one order of magnitude too early.
+            let recurring = credits.grants
+                .filter { $0.type == "recurring" }
+                .reduce(0.0) { $0 + max(0, $1.amountCents) }
+            let planHint: String? = recurring <= 0
+                ? nil
+                : (recurring < 10000 ? "Pro" : "Max")
+            out.append(UsageTile(
+                id: "perplexity-credits",
+                title: "Perplexity credits",
+                kind: .balance(
+                    remainingMinorUnits: cents,
+                    currency: "USD",
+                    plan: planHint,
+                    resetsAt: renewsAt
+                )
+            ))
+        }
+
+        // Per-mode counters from /rest/rate-limit/all. Only remaining values
+        // are on the wire — no totals — so we cannot render a proper
+        // used/limit counter without inferring a plan cap client-side. That
+        // inference is brittle (Perplexity ships plan changes without
+        // notice), so surface the raw number as a `.text` tile ("42 left")
+        // rather than a `.counter` whose "limit" would be the same as
+        // "remaining" and read as unused. Only emit tiles for modes that
+        // report a positive number so a free-tier account isn't papered
+        // with four grey zeros.
+        if let limits = snap.rateLimits {
+            let modes: [(String, String, Int)] = [
+                ("perplexity-pro", "Pro Search", limits.remainingPro),
+                ("perplexity-research", "Deep Research", limits.remainingResearch),
+                ("perplexity-labs", "Labs", limits.remainingLabs),
+                ("perplexity-agentic", "Agentic Research", limits.remainingAgenticResearch),
+            ]
+            for (id, title, remaining) in modes where remaining > 0 {
+                out.append(UsageTile(
+                    id: id,
+                    title: title,
+                    kind: .text(status: "\(remaining) left", subtitle: nil)
+                ))
+            }
+        }
+
+        return out
+    }
+
+    /// Normalise raw subscription strings into a human label. Preserves
+    /// unknown values verbatim so a new tier introduced server-side is not
+    /// silently swallowed.
+    private func normalisedTier(_ rawTier: String?, source: String?) -> String? {
+        // Prefer subscription_tier when present; fall back to source name.
+        if let tier = rawTier?.trimmingCharacters(in: .whitespaces), !tier.isEmpty, tier.lowercased() != "none" {
+            switch tier.lowercased() {
+            case "free": return "Free"
+            case "pro": return "Pro"
+            case "max": return "Max"
+            default: return tier
+            }
+        }
+        if let src = source?.trimmingCharacters(in: .whitespaces), !src.isEmpty, src.lowercased() != "none" {
+            return src.capitalized
+        }
+        return nil
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// Apply a transport result. Extracted so the TestRunner can drive every
+    /// branch synchronously.
+    public func apply(_ result: PerplexityUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            // 401/403 — cookie expired, or Cloudflare bounced us. Both need
+            // the same user action (re-copy the cookie from a signed-in
+            // browser); the differentiation is hidden behind one message.
+            // Also drop the stale snapshot so the tile does not keep
+            // showing an obsolete balance / counters while the credential
+            // is known-bad (Codex adversarial review #6).
+            self.snapshot = nil
+            self.lastError = "Perplexity session cookie expired or blocked. Sign in on perplexity.ai and paste a fresh cookie."
+        case .httpError(let code):
+            // 429 is Perplexity's rate-limit / soft-shadow-ban signal;
+            // 5xx is a real server problem the user cannot fix. Give each
+            // a distinct message so the user knows whether to slow down or
+            // wait for Perplexity to recover.
+            if code == 429 {
+                self.lastError = "Perplexity is rate-limiting this session. Slow polling or wait a few minutes."
+            } else if (500 ..< 600).contains(code) {
+                self.lastError = "Perplexity server error (HTTP \(code)). Retry later."
+            } else {
+                self.lastError = "HTTP \(code)"
+            }
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let data = credentials.read(PerplexityUsageFetcher.cookieKeychainKey),
+              !data.isEmpty,
+              let raw = String(data: data, encoding: .utf8) else {
+            // No credential in the store (or locked keychain returning nil
+            // read here). Onboarding card renders via isConfigured=false.
+            snapshot = nil
+            lastError = nil
+            return
+        }
+        guard let cookie = PerplexityCookie.extract(from: raw) else {
+            // The stored blob exists but is not a usable cookie. Surface an
+            // actionable error rather than silently no-op'ing forever —
+            // isConfigured is still true (hasKey checks presence, not
+            // parseability), so without this message the user sees an
+            // empty section indefinitely.
+            snapshot = nil
+            lastError = "Could not parse the stored Perplexity cookie. Re-paste it in Settings."
+            return
+        }
+
+        transport.fetchAll(cookieName: cookie.name, cookieValue: cookie.token) { [weak self] result in
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
+        }
+    }
+
+    public func clear() {
+        // Clearing Perplexity DOES delete the cookie — the user pasted it
+        // here. Same pattern as DeepSeek's Clear Key.
+        credentials.delete(PerplexityUsageFetcher.cookieKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum PerplexityUsageResult: Sendable {
+    case success(PerplexityUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the multi-endpoint fetch. The completion MAY be delivered on
+/// any queue; the store hops to the main actor via a `Task { @MainActor }`
+/// before touching @Published state (see the Hardening pass in PR #60 for
+/// why `assumeIsolated` is banned).
+public protocol PerplexityUsageTransport: Sendable {
+    func fetchAll(
+        cookieName: String,
+        cookieValue: String,
+        completion: @escaping @Sendable (PerplexityUsageResult) -> Void
+    )
+}
+
+/// Production transport. Issues three GETs in parallel with the pasted
+/// cookie, browser-shaped headers, and no body. Bodies are never logged;
+/// only status codes go through Log.info(.count).
+public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
+
+    private let creditsURL = URL(string: "https://www.perplexity.ai/rest/billing/credits?version=2.18&source=default")!
+    private let rateLimitsURL = URL(string: "https://www.perplexity.ai/rest/rate-limit/all")!
+    private let settingsURL = URL(string: "https://www.perplexity.ai/rest/user/settings?version=2.18&source=default")!
+
+    /// Browser-shaped User-Agent. Cloudflare bot detection fingerprints on
+    /// TLS + IP; a plain URLSession UA is enough for residential Mac users
+    /// but the header still needs to smell like a browser to avoid the
+    /// challenge-page filter. This UA is not spoofing a specific browser —
+    /// it is the shape Perplexity's own web bundle sends.
+    private let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+
+    public init() {}
+
+    public func fetchAll(
+        cookieName: String,
+        cookieValue: String,
+        completion: @escaping @Sendable (PerplexityUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (PerplexityUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Cookie assembly. Both name and value pass through
+        // RequestSafety.headerValue to reject control chars (CR/LF/NUL) that
+        // could split the header. Additionally, `;`, `,`, `=` are rejected
+        // in the *value*, and the same set plus space is rejected in the
+        // *name*, to defeat a Cookie-splicing attack: a hostile string
+        // pasted (or Keychain-injected) as a value like "real; other=evil"
+        // would otherwise silently add a second cookie to the request, and
+        // a similarly hostile name like "session-token=real; other" would
+        // splice via the name half. NextAuth cookie names are letters,
+        // digits, `-`, `.`, `_`; JWEs are base64url with dot separators;
+        // neither ever legitimately contains these splitters.
+        guard let safeName = RequestSafety.headerValue(cookieName),
+              let safeValue = RequestSafety.headerValue(cookieValue),
+              !safeName.contains(";"),
+              !safeName.contains(","),
+              !safeName.contains("="),
+              !safeName.contains(" "),
+              !safeValue.contains(";"),
+              !safeValue.contains(",") else {
+            deliver(.unauthorized)
+            return
+        }
+        let cookieHeader = "\(safeName)=\(safeValue)"
+
+        let group = DispatchGroup()
+        // Atomic accumulator around a lock — three concurrent GETs feed it.
+        let acc = PerplexityFetchAccumulator()
+
+        for (url, kind) in [
+            (creditsURL, PerplexityEndpointKind.credits),
+            (rateLimitsURL, .rateLimits),
+            (settingsURL, .settings),
+        ] {
+            group.enter()
+            get(url, cookieHeader: cookieHeader) { data, status in
+                defer { group.leave() }
+                if let status = status, (status == 401 || status == 403) {
+                    acc.setUnauthorized()
+                    return
+                }
+                if status == 200, let data = data {
+                    switch kind {
+                    case .credits:
+                        if let parsed = try? PerplexityUsageFetcher.parseCredits(data) {
+                            acc.setCredits(parsed)
+                        }
+                    case .rateLimits:
+                        if let parsed = try? PerplexityUsageFetcher.parseRateLimits(data) {
+                            acc.setRateLimits(parsed)
+                        }
+                    case .settings:
+                        if let parsed = try? PerplexityUsageFetcher.parseUserSettings(data) {
+                            acc.setSettings(parsed)
+                        }
+                    }
+                } else if let status = status {
+                    // A non-success, non-auth status (429, 5xx, ...). Remember
+                    // the highest-signal code so a total failure can surface it
+                    // to the user rather than degrading to "Network error".
+                    // 429 is Perplexity's shadow-ban / rate-limit response
+                    // and is the most actionable — the user needs to slow
+                    // down or wait, not re-paste a cookie.
+                    acc.recordHttpError(status)
+                }
+            }
+        }
+
+        group.notify(queue: .global()) {
+            let (unauthorized, httpError, snap) = acc.finalize()
+            if unauthorized {
+                deliver(.unauthorized)
+            } else if snap.credits == nil && snap.rateLimits == nil && snap.settings == nil {
+                // Every endpoint failed. Prefer the HTTP status when one is
+                // remembered (429/5xx) — Codex round-3 review — else fall
+                // back to networkError for a genuine transport failure.
+                if let code = httpError {
+                    deliver(.httpError(code))
+                } else {
+                    deliver(.networkError)
+                }
+            } else {
+                deliver(.success(snap))
+            }
+        }
+    }
+
+    private func get(_ url: URL, cookieHeader: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("https://www.perplexity.ai", forHTTPHeaderField: "Origin")
+        request.setValue("https://www.perplexity.ai/account/usage", forHTTPHeaderField: "Referer")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("Perplexity API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}
+
+// MARK: - Endpoint kind + accumulator
+
+/// Which endpoint a completion is reporting for. Nested in the transport
+/// only (not part of the public surface).
+private enum PerplexityEndpointKind {
+    case credits, rateLimits, settings
+}
+
+/// Thread-safe accumulator for the three concurrent GETs. A final call to
+/// `finalize()` collapses the state into a single snapshot + unauthorized
+/// flag. Lock-protected because `dataTask` completions can land on any
+/// queue.
+private final class PerplexityFetchAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var credits: PerplexityCredits?
+    private var rateLimits: PerplexityRateLimits?
+    private var settings: PerplexityUserSettings?
+    private var unauthorized = false
+    /// Highest-priority non-2xx status seen. Prioritises 429 (shadow-ban
+    /// signal, most actionable), then 5xx, then anything else, so the
+    /// finalize step surfaces the most useful code when every endpoint
+    /// failed.
+    private var httpError: Int?
+
+    func setCredits(_ value: PerplexityCredits) {
+        lock.lock(); defer { lock.unlock() }
+        credits = value
+    }
+    func setRateLimits(_ value: PerplexityRateLimits) {
+        lock.lock(); defer { lock.unlock() }
+        rateLimits = value
+    }
+    func setSettings(_ value: PerplexityUserSettings) {
+        lock.lock(); defer { lock.unlock() }
+        settings = value
+    }
+    func setUnauthorized() {
+        lock.lock(); defer { lock.unlock() }
+        unauthorized = true
+    }
+    func recordHttpError(_ status: Int) {
+        lock.lock(); defer { lock.unlock() }
+        // Priority: 429 > 5xx > anything else. Only replace when the new
+        // code carries strictly more signal.
+        let priority: (Int) -> Int = { code in
+            if code == 429 { return 3 }
+            if code >= 500 && code < 600 { return 2 }
+            return 1
+        }
+        if let existing = httpError {
+            if priority(status) > priority(existing) {
+                httpError = status
+            }
+        } else {
+            httpError = status
+        }
+    }
+    func finalize() -> (Bool, Int?, PerplexityUsageSnapshot) {
+        lock.lock(); defer { lock.unlock() }
+        return (unauthorized, httpError, PerplexityUsageSnapshot(
+            credits: credits,
+            rateLimits: rateLimits,
+            settings: settings
+        ))
+    }
+}

--- a/app/PerplexityUsageStore.swift
+++ b/app/PerplexityUsageStore.swift
@@ -372,14 +372,19 @@ public struct URLSessionPerplexityTransport: PerplexityUsageTransport {
     ///   2. `URLSessionConfiguration.default.timeoutIntervalForResource` is
     ///      604 800 seconds (7 days). A stalled Perplexity response would
     ///      park its callback for a week.
-    /// Our explicit `Cookie:` header is the ONLY source of session state for
-    /// this transport; the response cookie jar is nulled so nothing sticks.
+    /// This session uses `.ephemeral` configuration — Apple's documented
+    /// pattern for a URLSession with in-memory-only cookie storage isolated
+    /// from `URLSession.shared`. `.ephemeral` gives us a per-session cookie
+    /// jar that:
+    ///   - Cloudflare's per-poll `__cf_bm` challenge cookies still work
+    ///     inside a single fetchAll() cycle (chk1-fix Codex round 4: nulling
+    ///     the store entirely could break Cloudflare challenge flows).
+    ///   - Nothing persists to disk (unlike the shared session's default
+    ///     store under ~/Library/Cookies/).
+    ///   - Nothing leaks into the shared jar or any other provider.
     /// Timeouts are matched to the 60s poll cadence.
     private let session: URLSession = {
-        let config = URLSessionConfiguration.default
-        config.httpShouldSetCookies = false
-        config.httpCookieAcceptPolicy = .never
-        config.httpCookieStorage = nil
+        let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 30
         return URLSession(configuration: config)

--- a/app/SQLiteReader.swift
+++ b/app/SQLiteReader.swift
@@ -1,0 +1,438 @@
+// PR 10a — SQLiteReader (shared local-provider infrastructure).
+//
+// Read-only SQLite reader used by every local-file provider that reads a
+// VS-Code-family SQLite database (Cursor, Windsurf, Cline via VS Code
+// globalStorage/state.vscdb). Never opens a database read-write, never
+// runs schema-mutating statements, and always emits `PRAGMA query_only=1`
+// before any user query.
+//
+// Design goals — every constraint here is defensive, not decorative:
+//
+//   1. Read-only file open. `sqlite3_open_v2(SQLITE_OPEN_READONLY |
+//      SQLITE_OPEN_NOMUTEX)`. NOMUTEX because every SQLiteReader instance
+//      is only ever touched from a single thread (the local-provider's
+//      polling closure); the app-wide serialisation is done at the store
+//      layer.
+//   2. `PRAGMA query_only=1`. Belt-and-braces against a future refactor
+//      that accidentally passes a non-SELECT statement. Even a read-only
+//      handle can be tricked into writing to a temp table without this.
+//   3. `PRAGMA busy_timeout=5000`. VS Code / Cursor / Windsurf hold write
+//      locks on their state.vscdb during startup and during editor state
+//      persistence. Without a busy timeout, a concurrent write locks our
+//      SELECTs with `SQLITE_BUSY` immediately. 5s is enough to survive
+//      the ~1s writes those apps do, without hanging our fetch cadence.
+//   4. Optional schema-version sentinel. Callers can register a
+//      `(table, versionColumn, expected)` tuple; the reader verifies it
+//      on open and refuses further queries if the schema has moved.
+//      Cursor's cursor-stats maintainer archived that project citing
+//      exactly this class of churn — we surface it as a distinct error.
+//   5. Prepared statements are finalised on scope exit; connection is
+//      closed on `deinit`. No SQL-injection concerns because every path
+//      uses `?` bind placeholders — but the API only accepts prepared
+//      SQL with typed binds anyway.
+//   6. No mutation is possible through the public surface — the API is
+//      shaped like `query(sql:binds:decoding:)` returning an array of
+//      the caller's decoded row type; there is no `execute` sibling.
+//
+// See `SQLiteReaderTests` in the TestRunner for the 7-scenario matrix
+// this file is verified against.
+
+import Foundation
+import SQLite3
+
+/// Errors surfaced by SQLiteReader. The categories are chosen so a local
+/// provider can render distinct UI states — an app that's "not opened yet"
+/// (no file at path) is different from "schema drifted" (needs an app
+/// update) is different from "locked by editor" (transient, retry).
+public enum SQLiteReaderError: Error, Equatable {
+    /// The database file does not exist at the given path. Common in
+    /// dev — the target app has never been launched.
+    case notFound(String)
+    /// The file exists but the process cannot open it. Almost always a
+    /// TCC / Full Disk Access denial; local providers should render a
+    /// `.needsAccess` tile in response.
+    case openFailed(rc: Int32, message: String)
+    /// The file opened but isn't SQLite (SQLITE_NOTADB). VS Code's state
+    /// files have been observed corrupted this way after abrupt shutdowns.
+    case notADatabase
+    /// The file opened but is encrypted (typical of SQLCipher databases).
+    /// We won't attempt a key — surface it and skip.
+    case encrypted
+    /// Statement prepare or step returned an error that isn't in the
+    /// known categories above.
+    case sqlError(rc: Int32, message: String)
+    /// The database schema doesn't match the version the caller expects.
+    /// Contains both the observed and expected sentinel values for the
+    /// diagnostic message.
+    case schemaMismatch(observed: String, expected: String)
+    /// A concurrent writer held the lock longer than the busy timeout.
+    /// The caller should retry on the next poll — this is not a bug.
+    case busy
+}
+
+/// A schema-version sentinel query the reader uses to detect a database
+/// whose schema has drifted beyond what the caller was written against.
+/// The reader runs `SELECT {valueColumn} FROM {table} WHERE {keyColumn}
+/// = {key}` and compares against `expected`. Absence of the row or a
+/// mismatch is reported as `.schemaMismatch`.
+public struct SQLiteSchemaSentinel: Sendable, Equatable {
+    public let table: String
+    public let keyColumn: String
+    public let key: String
+    public let valueColumn: String
+    public let expected: String
+
+    public init(table: String, keyColumn: String, key: String, valueColumn: String, expected: String) {
+        self.table = table
+        self.keyColumn = keyColumn
+        self.key = key
+        self.valueColumn = valueColumn
+        self.expected = expected
+    }
+}
+
+/// Bind values supported by the reader. Deliberately narrow — every local
+/// provider we ship needs only integers, doubles, strings, and NULL for
+/// `WHERE` clauses.
+public enum SQLiteBind: Sendable, Equatable {
+    case int(Int64)
+    case double(Double)
+    case text(String)
+    case null
+}
+
+/// One row produced by `query(sql:binds:)`. Columns are indexed by name;
+/// the caller decodes into its own strong type.
+public struct SQLiteRow: Sendable {
+    fileprivate let columns: [String: SQLiteValue]
+
+    public func int(_ column: String) -> Int64? {
+        if case let .int(v) = columns[column] { return v }
+        return nil
+    }
+    public func double(_ column: String) -> Double? {
+        if case let .double(v) = columns[column] { return v }
+        // Fall back to Int → Double promotion for schemas that store
+        // fractional counts as integers.
+        if case let .int(v) = columns[column] { return Double(v) }
+        return nil
+    }
+    public func string(_ column: String) -> String? {
+        if case let .text(v) = columns[column] { return v }
+        return nil
+    }
+    public func blob(_ column: String) -> Data? {
+        if case let .blob(v) = columns[column] { return v }
+        return nil
+    }
+    public func isNull(_ column: String) -> Bool {
+        if case .null = columns[column] { return true }
+        return columns[column] == nil
+    }
+}
+
+/// The internal column-value representation. Not exposed in the public
+/// API — `SQLiteRow` accessors coerce out of this.
+fileprivate enum SQLiteValue: Sendable {
+    case int(Int64)
+    case double(Double)
+    case text(String)
+    case blob(Data)
+    case null
+}
+
+/// A read-only, single-thread SQLite reader. See the file header for the
+/// full rationale on each constraint.
+///
+/// Marked `final class` (not a value type) because it owns a `sqlite3*`
+/// handle that must be closed exactly once on deallocation, and that
+/// lifecycle is not expressible as a Sendable value.
+public final class SQLiteReader {
+
+    private let db: OpaquePointer
+    private let path: String
+    /// True after `close()` — subsequent queries throw `sqlError` rather
+    /// than passing a nil handle to sqlite3.
+    private var closed = false
+
+    /// Open a database in strict read-only mode with a 5-second busy
+    /// timeout and `query_only` enforced. If a `sentinel` is supplied,
+    /// the reader validates it on open and throws `.schemaMismatch` if
+    /// the observed value differs.
+    ///
+    /// Throws:
+    ///   - `.notFound` if the file does not exist.
+    ///   - `.openFailed` if sqlite3 rejected the open call (typically TCC).
+    ///   - `.notADatabase` if the header check fails.
+    ///   - `.encrypted` if the header check reveals SQLCipher.
+    ///   - `.schemaMismatch` if the sentinel does not match.
+    ///   - `.sqlError` for other prepare/step failures during init.
+    public init(path: String, sentinel: SQLiteSchemaSentinel? = nil) throws {
+        // Existence pre-check — sqlite3_open_v2(READONLY) refuses to create
+        // a database, but its error code (SQLITE_CANTOPEN) collapses
+        // "not found" and "permission denied" into one signal. Split them
+        // here so a `.notFound` tile ("app not installed") is distinct
+        // from a `.needsAccess` tile ("Full Disk Access denied").
+        if !FileManager.default.fileExists(atPath: path) {
+            throw SQLiteReaderError.notFound(path)
+        }
+        // Encryption / not-a-DB pre-check via the first 16 bytes of the
+        // file. SQLite databases start with the literal 16-byte header
+        // "SQLite format 3\0"; SQLCipher databases have random-looking
+        // bytes because the header itself is encrypted. This gives us a
+        // clean, actionable error before sqlite3_open_v2 emits its more
+        // generic "file is not a database" message.
+        if let handle = FileHandle(forReadingAtPath: path) {
+            defer { try? handle.close() }
+            let head = handle.readData(ofLength: 16)
+            let expected = "SQLite format 3\u{0}".data(using: .ascii) ?? Data()
+            if head.count == 16 && head != expected {
+                // Not the SQLite magic. Distinguish encrypted (random-
+                // looking full 16 bytes) from an empty / truncated file.
+                if head.count == 16 {
+                    // If the whole 16-byte block is non-ASCII-printable
+                    // it's almost certainly an encrypted database. This
+                    // heuristic is intentionally loose — the tests
+                    // include an SQLCipher fixture that exercises it.
+                    let nonPrintable = head.filter { $0 < 0x20 || $0 > 0x7E }.count
+                    if nonPrintable >= 12 {
+                        throw SQLiteReaderError.encrypted
+                    }
+                }
+                throw SQLiteReaderError.notADatabase
+            }
+        }
+
+        var handle: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX
+        let rc = sqlite3_open_v2(path, &handle, flags, nil)
+        guard rc == SQLITE_OK, let db = handle else {
+            let msg = handle.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
+            if let db = handle { sqlite3_close(db) }
+            throw SQLiteReaderError.openFailed(rc: rc, message: msg)
+        }
+        self.db = db
+        self.path = path
+
+        // PRAGMA setup: enforce query-only, arm the busy timeout, and
+        // reject any pragma failure loudly rather than silently
+        // proceeding without the protections.
+        do {
+            try Self.pragma(db: db, "PRAGMA query_only=1")
+            try Self.pragma(db: db, "PRAGMA busy_timeout=5000")
+        } catch {
+            sqlite3_close(db)
+            throw error
+        }
+
+        // Schema sentinel validation — do this INSIDE init so the caller
+        // can't miss it. If the DB schema drifted, the reader is dead on
+        // arrival and no query() call needs to guard against it.
+        if let sentinel = sentinel {
+            do {
+                try validateSchemaSentinel(sentinel)
+            } catch {
+                sqlite3_close(db)
+                throw error
+            }
+        }
+    }
+
+    deinit {
+        if !closed {
+            sqlite3_close(db)
+        }
+    }
+
+    /// Close the database explicitly. Safe to call more than once. After
+    /// close(), further query() calls throw `.sqlError`. Callers usually
+    /// don't need to call this — deinit handles it — but it's exposed so
+    /// tests can deterministically release file handles before deleting
+    /// the fixture directory.
+    public func close() {
+        if closed { return }
+        sqlite3_close(db)
+        closed = true
+    }
+
+    /// Run a SELECT statement and decode every row via the caller's
+    /// closure. The statement is finalised on return. `binds` map to
+    /// numbered `?` placeholders 1-indexed on the wire (but here as
+    /// natural 0-indexed swift array positions).
+    public func query<T>(
+        _ sql: String,
+        binds: [SQLiteBind] = [],
+        decode: (SQLiteRow) -> T?
+    ) throws -> [T] {
+        if closed {
+            throw SQLiteReaderError.sqlError(rc: SQLITE_MISUSE, message: "reader is closed")
+        }
+        var stmt: OpaquePointer?
+        let prepareRc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard prepareRc == SQLITE_OK, let handle = stmt else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            if let s = stmt { sqlite3_finalize(s) }
+            throw SQLiteReaderError.sqlError(rc: prepareRc, message: msg)
+        }
+        defer { sqlite3_finalize(handle) }
+
+        for (idx, bind) in binds.enumerated() {
+            try Self.bind(stmt: handle, index: Int32(idx + 1), value: bind, db: db)
+        }
+
+        var out: [T] = []
+        while true {
+            let rc = sqlite3_step(handle)
+            if rc == SQLITE_DONE { break }
+            if rc == SQLITE_BUSY { throw SQLiteReaderError.busy }
+            if rc != SQLITE_ROW {
+                throw SQLiteReaderError.sqlError(rc: rc, message: String(cString: sqlite3_errmsg(db)))
+            }
+            let row = try Self.decodeRow(stmt: handle)
+            if let decoded = decode(row) {
+                out.append(decoded)
+            }
+        }
+        return out
+    }
+
+    // MARK: - Internals
+
+    private func validateSchemaSentinel(_ sentinel: SQLiteSchemaSentinel) throws {
+        // Codex round-1 finding #7: sentinel identifiers are interpolated
+        // into SQL, so we validate them strictly first. SQL identifiers
+        // in every schema we care about (VS Code state.vscdb, Cursor,
+        // Windsurf, Warp, Cline, JetBrains, Continue) are lowercase
+        // ASCII letters, digits, and underscores only — anything else
+        // is a config bug in the caller. Reject early so a maintainer
+        // typo cannot silently produce a corrupt SQL statement.
+        for identifier in [sentinel.table, sentinel.keyColumn, sentinel.valueColumn] {
+            try Self.assertIsValidIdentifier(identifier)
+        }
+        let sql = "SELECT \(sentinel.valueColumn) FROM \(sentinel.table) WHERE \(sentinel.keyColumn) = ?"
+        let rows = try query(sql, binds: [.text(sentinel.key)]) { row in
+            row.string(sentinel.valueColumn)
+        }
+        guard let observed = rows.first else {
+            throw SQLiteReaderError.schemaMismatch(observed: "<row missing>", expected: sentinel.expected)
+        }
+        if observed != sentinel.expected {
+            throw SQLiteReaderError.schemaMismatch(observed: observed, expected: sentinel.expected)
+        }
+    }
+
+    /// Reject identifiers that would produce hostile SQL when
+    /// interpolated. Strict ASCII contract per Codex round-2 nit:
+    /// `[A-Za-z_][A-Za-z0-9_]{0,63}`. Every schema we care about (VS
+    /// Code state.vscdb, Cursor, Windsurf, Warp, Cline, JetBrains,
+    /// Continue) uses ASCII-only identifiers; non-ASCII input is a
+    /// caller bug, not a supported edge case. Public so downstream
+    /// local-provider PRs can reuse it wherever they build SQL from
+    /// config or metadata.
+    public static func assertIsValidIdentifier(_ name: String) throws {
+        guard !name.isEmpty, name.count <= 64 else {
+            throw SQLiteReaderError.sqlError(rc: SQLITE_MISUSE, message: "invalid SQL identifier: \(name.prefix(32))")
+        }
+        let bytes = Array(name.utf8)
+        // First byte: strict ASCII letter or underscore.
+        let firstOK = Self.isAsciiLetter(bytes[0]) || bytes[0] == UInt8(ascii: "_")
+        if !firstOK {
+            throw SQLiteReaderError.sqlError(rc: SQLITE_MISUSE, message: "invalid SQL identifier: \(name.prefix(32))")
+        }
+        for i in 1 ..< bytes.count {
+            let b = bytes[i]
+            let ok = Self.isAsciiLetter(b) || Self.isAsciiDigit(b) || b == UInt8(ascii: "_")
+            if !ok {
+                throw SQLiteReaderError.sqlError(rc: SQLITE_MISUSE, message: "invalid SQL identifier: \(name.prefix(32))")
+            }
+        }
+    }
+
+    @inline(__always)
+    private static func isAsciiLetter(_ b: UInt8) -> Bool {
+        (b >= UInt8(ascii: "A") && b <= UInt8(ascii: "Z")) ||
+        (b >= UInt8(ascii: "a") && b <= UInt8(ascii: "z"))
+    }
+    @inline(__always)
+    private static func isAsciiDigit(_ b: UInt8) -> Bool {
+        b >= UInt8(ascii: "0") && b <= UInt8(ascii: "9")
+    }
+
+    private static func pragma(db: OpaquePointer, _ sql: String) throws {
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK, let handle = stmt else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            if let s = stmt { sqlite3_finalize(s) }
+            throw SQLiteReaderError.sqlError(rc: rc, message: msg)
+        }
+        defer { sqlite3_finalize(handle) }
+        let step = sqlite3_step(handle)
+        guard step == SQLITE_DONE || step == SQLITE_ROW else {
+            throw SQLiteReaderError.sqlError(rc: step, message: String(cString: sqlite3_errmsg(db)))
+        }
+    }
+
+    /// Sentinel object required by sqlite3 to mark a bind as a transient
+    /// pointer (i.e. sqlite must copy it) rather than a static pointer.
+    /// See sqlite.org/c3ref/c_static.html — using the wrong sentinel is
+    /// a classic use-after-free class of bug.
+    private static let SQLITE_TRANSIENT = unsafeBitCast(
+        OpaquePointer(bitPattern: -1),
+        to: sqlite3_destructor_type.self
+    )
+
+    private static func bind(stmt: OpaquePointer, index: Int32, value: SQLiteBind, db: OpaquePointer) throws {
+        let rc: Int32
+        switch value {
+        case .int(let v):
+            rc = sqlite3_bind_int64(stmt, index, v)
+        case .double(let v):
+            rc = sqlite3_bind_double(stmt, index, v)
+        case .text(let s):
+            rc = s.withCString { cstr in
+                sqlite3_bind_text(stmt, index, cstr, -1, SQLITE_TRANSIENT)
+            }
+        case .null:
+            rc = sqlite3_bind_null(stmt, index)
+        }
+        guard rc == SQLITE_OK else {
+            throw SQLiteReaderError.sqlError(rc: rc, message: String(cString: sqlite3_errmsg(db)))
+        }
+    }
+
+    private static func decodeRow(stmt: OpaquePointer) throws -> SQLiteRow {
+        let count = sqlite3_column_count(stmt)
+        var columns: [String: SQLiteValue] = [:]
+        columns.reserveCapacity(Int(count))
+        for i in 0 ..< count {
+            let name = String(cString: sqlite3_column_name(stmt, i))
+            let value: SQLiteValue
+            switch sqlite3_column_type(stmt, i) {
+            case SQLITE_INTEGER:
+                value = .int(sqlite3_column_int64(stmt, i))
+            case SQLITE_FLOAT:
+                value = .double(sqlite3_column_double(stmt, i))
+            case SQLITE_TEXT:
+                if let cstr = sqlite3_column_text(stmt, i) {
+                    value = .text(String(cString: cstr))
+                } else {
+                    value = .null
+                }
+            case SQLITE_BLOB:
+                let bytes = sqlite3_column_bytes(stmt, i)
+                if bytes > 0, let ptr = sqlite3_column_blob(stmt, i) {
+                    value = .blob(Data(bytes: ptr, count: Int(bytes)))
+                } else {
+                    value = .null
+                }
+            case SQLITE_NULL:
+                value = .null
+            default:
+                value = .null
+            }
+            columns[name] = value
+        }
+        return SQLiteRow(columns: columns)
+    }
+}

--- a/app/TCCState.swift
+++ b/app/TCCState.swift
@@ -1,0 +1,185 @@
+// PR 10a — TCCState + LocalProviderAccessGuide (shared local-provider
+// infrastructure).
+//
+// Local-file providers need to distinguish three failure modes so the
+// popover can render the right onboarding UI:
+//
+//   1. `.granted` — the process can read the target directory. Normal
+//      operation; render the usage tile.
+//   2. `.denied` — the process cannot read the target directory. Could
+//      be a TCC denial ("Full Disk Access" not granted), classic UNIX
+//      permission denial, or an ambiguous error. macOS's TCC API does
+//      not expose "was I denied vs never asked" — Codex round-1 finding
+//      #6. Rather than expose a `.needsRequest` state that is
+//      indistinguishable from `.denied` in every empirical test, we
+//      collapse both into `.denied` and let the tile copy point the
+//      user at System Settings regardless.
+//   3. `.pathMissing` — the target directory does not exist AND the
+//      process can prove it does not exist. Local providers surface
+//      this as a "not installed / never launched" state.
+//
+// Codex round-1 finding #5: `fileExists() == false` alone is not a
+// reliable "pathMissing" signal — a TCC-denied containing directory
+// causes stat to return false, and we'd send the user to a "not
+// installed" tile when the real problem is access. `probe()` cross-
+// checks the containing directory's readability before returning
+// pathMissing; if the containing directory itself is unreadable, we
+// surface `.denied` and let the user grant access first.
+
+import Foundation
+
+/// Outcome of a probe against a local-provider directory. Every local
+/// provider maps its target path through `TCCProbe.probe(path:)` on the
+/// first fetch and each time the flag toggles back on, then renders the
+/// resulting state as its tile.
+public enum TCCState: Equatable, Sendable {
+    /// Access confirmed — the store can read the target files.
+    case granted
+    /// The store cannot read the target files. Covers both TCC denial
+    /// and classic UNIX permission denial; we cannot reliably distinguish
+    /// them on macOS, so the tile treats them the same way (both send
+    /// the user to System Settings → Privacy & Security → Full Disk
+    /// Access).
+    case denied
+    /// The target path does not exist AND we can prove that from the
+    /// containing directory (which we CAN read). Distinct from `.denied`
+    /// so the user isn't sent to Settings for the wrong reason.
+    case pathMissing
+}
+
+/// Probe a local path and classify the outcome. Static, no state — the
+/// caller caches the result if it wants to avoid repeated probes.
+public enum TCCProbe {
+    /// Probe a single directory or file path.
+    ///
+    /// The macOS TCC API is deliberately opaque:
+    ///   - `fileExists` returns true even when we can't read the file.
+    ///   - `isReadableFile` returns false for both "denied" and "missing".
+    ///   - The only reliable way to distinguish "denied" from "missing"
+    ///     is to test the CONTAINING directory: if we can read the
+    ///     parent and the target isn't there, it's missing; if we can't
+    ///     read the parent, the target might exist but we can't tell.
+    public static func probe(path: String) -> TCCState {
+        let fm = FileManager.default
+
+        var isDir: ObjCBool = false
+        let exists = fm.fileExists(atPath: path, isDirectory: &isDir)
+
+        if !exists {
+            // Codex round-1 finding #5: cross-check the containing
+            // directory. If we cannot read it, "not found" might be a
+            // TCC lie — surface `.denied` and let the user grant access,
+            // rather than steering them to a "not installed" tile.
+            let parent = (path as NSString).deletingLastPathComponent
+            if !parent.isEmpty && parent != path {
+                do {
+                    _ = try fm.contentsOfDirectory(atPath: parent)
+                    // Parent readable AND target absent → really missing.
+                    return .pathMissing
+                } catch {
+                    // Parent unreadable → we can't distinguish. Assume
+                    // denial (the safer of the two — sends the user to
+                    // Settings, and a genuine missing case will surface
+                    // as .pathMissing on the next probe once access is
+                    // granted).
+                    return classify(error: error)
+                }
+            }
+            // No parent (e.g. path == "/"). Surface missing.
+            return .pathMissing
+        }
+
+        // Path exists. Attempt to read.
+        if isDir.boolValue {
+            do {
+                _ = try fm.contentsOfDirectory(atPath: path)
+                return .granted
+            } catch {
+                return classify(error: error)
+            }
+        } else {
+            if let handle = FileHandle(forReadingAtPath: path) {
+                try? handle.close()
+                return .granted
+            }
+            do {
+                _ = try Data(contentsOf: URL(fileURLWithPath: path), options: [.mappedIfSafe])
+                return .granted
+            } catch {
+                return classify(error: error)
+            }
+        }
+    }
+
+    /// Map a foundation error into a TCC classification. Every error we
+    /// don't recognise defaults to `.denied` on the "safer to prompt for
+    /// Settings than to silently fail" theory — a false `.denied` tile
+    /// is annoying, a false `.granted` tile makes the provider useless.
+    private static func classify(error: Error) -> TCCState {
+        let ns = error as NSError
+        // NSFileReadNoPermissionError = TCC denial or classic UNIX perms.
+        if ns.domain == NSCocoaErrorDomain && ns.code == NSFileReadNoPermissionError {
+            return .denied
+        }
+        // Various Cocoa read errors we should treat as denial rather than
+        // silently ignoring.
+        if ns.domain == NSCocoaErrorDomain {
+            switch ns.code {
+            case NSFileReadUnknownError,
+                 NSFileReadInapplicableStringEncodingError,
+                 NSFileReadCorruptFileError,
+                 NSFileReadInvalidFileNameError:
+                return .denied
+            case NSFileReadNoSuchFileError:
+                return .pathMissing
+            default:
+                break
+            }
+        }
+        // POSIX EACCES / EPERM through the Foundation bridge.
+        if ns.domain == NSPOSIXErrorDomain {
+            switch ns.code {
+            case Int(EACCES), Int(EPERM):
+                return .denied
+            case Int(ENOENT):
+                return .pathMissing
+            default:
+                break
+            }
+        }
+        return .denied
+    }
+}
+
+/// Localised guidance strings for the `.needsAccess` tile when a local
+/// provider requests Full Disk Access. Held in the library (not the app
+/// view file) so the strings are unit-testable — user-facing copy must
+/// not silently change.
+public enum LocalProviderAccessGuide {
+
+    /// Guidance for the `.needsAccess` tile keyed by the current TCC
+    /// state. Return value is the (title, guidance) pair the tile renders.
+    public static func copy(for state: TCCState, appName: String) -> (title: String, guidance: String) {
+        switch state {
+        case .granted:
+            // Should not be shown — callers guard with `if state != .granted`.
+            return (appName, "Access granted.")
+        case .denied:
+            return (
+                "\(appName) — needs Full Disk Access",
+                "\(appName) tracking reads a file managed by another app on your Mac. Grant ClaudeUsageBar Full Disk Access in System Settings → Privacy & Security → Full Disk Access. If you previously denied access, macOS will not prompt again — you must enable it manually here."
+            )
+        case .pathMissing:
+            return (
+                "\(appName) — not installed",
+                "No data found for \(appName) on this Mac. If you use \(appName), launch it once and then click Refresh."
+            )
+        }
+    }
+
+    /// Deep-link URL for System Settings → Privacy → Full Disk Access.
+    /// The pane identifier `Privacy_AllFiles` is stable across Ventura /
+    /// Sonoma / Sequoia. Callers open this via NSWorkspace when the user
+    /// clicks the tile's "Open Settings" button (added in PR 10b onward).
+    public static let fullDiskAccessURL = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles")!
+}

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -164,6 +164,25 @@ public protocol CredentialStore {
     func delete(_ key: String)
 }
 
+// MARK: - PasteKeyProvider
+
+/// Optional capability for providers configured by pasting a secret (an API
+/// key, a session cookie). The Settings toggle row shows a secure entry
+/// field for any provider that conforms. Providers configured another way
+/// (Codex reads a CLI file; Anthropic uses the cookie sheet) do not conform.
+///
+/// @MainActor because conformers are main-actor stores; the entry field is
+/// itself on the main actor.
+@MainActor
+public protocol PasteKeyProvider {
+    /// Placeholder shown in the entry field (e.g. "sk-…").
+    var keyPlaceholder: String { get }
+    /// True when a secret is currently stored.
+    var hasKey: Bool { get }
+    /// Store a pasted secret. Empty input clears it.
+    func saveKey(_ raw: String)
+}
+
 // MARK: - ProviderCopy
 
 /// Per-provider help and disclosure copy for the Settings toggles. Kept in
@@ -176,6 +195,8 @@ public enum ProviderCopy {
         switch id {
         case "codex":
             return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
+        case "deepseek":
+            return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -121,7 +121,13 @@ public protocol UsageProvider: AnyObject, ObservableObject {
 /// observation site did not. `ProviderBox` is the fix.
 @MainActor
 public final class ProviderBox: ObservableObject, Identifiable {
-    public let provider: any UsageProvider
+    // `nonisolated` so consumers that are not themselves main-actor-isolated
+    // (e.g. ProvidersModel.fetchEnabled, called from AppDelegate timer and
+    // lifecycle closures) can read it without an actor hop. It is an
+    // immutable `let` set once at init; the underlying provider's own methods
+    // remain main-actor-isolated, so this only exposes the reference, not
+    // unsynchronised mutable state.
+    public nonisolated let provider: any UsageProvider
     // Cached at construction rather than reaching through `provider.id` on
     // every access — keeps `id` a nonisolated stored property so the
     // Identifiable conformance is Swift-6-strict-concurrency clean.
@@ -156,6 +162,35 @@ public protocol CredentialStore {
     func read(_ key: String) -> Data?
     func write(_ key: String, _ value: Data)
     func delete(_ key: String)
+}
+
+// MARK: - ProviderCopy
+
+/// Per-provider help and disclosure copy for the Settings toggles. Kept in
+/// the library (not the app view file) so the strings are unit-testable —
+/// they are user-facing and must not silently change. Returns nil for a
+/// provider with no bespoke copy.
+public enum ProviderCopy {
+    /// Explanatory help shown under a provider's Settings toggle.
+    public static func help(for id: String) -> String? {
+        switch id {
+        case "codex":
+            return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
+        default:
+            return nil
+        }
+    }
+
+    /// A warning line shown for providers backed by a private/undocumented
+    /// API that may break without notice. Rendered in an accent colour.
+    public static func disclosure(for id: String) -> String? {
+        switch id {
+        case "codex":
+            return "Uses OpenAI's private Codex API. It may stop working without notice."
+        default:
+            return nil
+        }
+    }
 }
 
 /// UserDefaults-backed credential store. Used only for the legacy

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -247,6 +247,18 @@ public protocol PasteKeyProvider {
     var hasKey: Bool { get }
     /// Store a pasted secret. Empty input clears it.
     func saveKey(_ raw: String)
+    /// Human word for what the user pasted, used in status text like
+    /// "Key saved in Keychain" or "Cookie saved in Keychain". Defaults to
+    /// "Key" for API-key providers via the extension below; override on a
+    /// concrete conformer for cookie/session providers (e.g. Perplexity).
+    /// Declared as a protocol requirement — not just an extension — so
+    /// existential dispatch (`box.provider as PasteKeyProvider`) picks up
+    /// the concrete override rather than the default.
+    var secretKindNoun: String { get }
+}
+
+public extension PasteKeyProvider {
+    var secretKindNoun: String { "Key" }
 }
 
 // MARK: - SecondaryKeyProvider
@@ -292,6 +304,8 @@ public enum ProviderCopy {
             return "Shows your xAI (Grok) API key permissions. Paste an inference key (xai-…) below. Add a management key too to also see prepaid balance and daily usage. Both are stored in your Keychain."
         case "openai":
             return "Shows your OpenAI organisation's month-to-date spend, token usage by model, and configured rate limits. Paste an Organization Admin key (sk-admin-…); it is stored in your Keychain."
+        case "perplexity":
+            return "Can show your Perplexity plan, credit balance, and per-mode remaining queries (Pro Search, Deep Research, Labs, Agentic) when available. Sign in on perplexity.ai, open your browser's cookie inspector, and paste your __Secure-next-auth.session-token cookie below — the bare value, a name=value pair, or the full copied Cookie header all work. It is stored in your Keychain."
         default:
             return nil
         }
@@ -305,6 +319,8 @@ public enum ProviderCopy {
             return "Uses OpenAI's private Codex API. It may stop working without notice."
         case "openai":
             return "An Admin key can view billing and manage users in your OpenAI organisation. It cannot make inference calls. Store yours only if you are comfortable with this app holding it."
+        case "perplexity":
+            return "Uses Perplexity's private web-app endpoints. They may stop working without notice. The pasted value is a full Perplexity web session cookie — it can let this app act as your signed-in account, including spending or purchasing credits your plan allows, until it expires or is revoked (for example by signing out or clearing sessions on perplexity.ai)."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -310,6 +310,8 @@ public enum ProviderCopy {
             return "Shows your GitHub Copilot chargeable AI-Credit overage (net) month-to-date, plus the top SKU line items. Note: usage covered by your plan's included allowance shows as $0 — only overage is charged. Create a fine-grained PAT on github.com (Settings → Developer settings → Personal access tokens → Fine-grained tokens), set the resource owner to your own account, then under Account permissions grant 'Plan: Read-only'. Paste the github_pat_… token below; it is stored in your Keychain."
         case "claudeCode":
             return "Reads your local Claude Code session logs (`~/.claude/projects/**/*.jsonl`) to show tokens used today, cost today, and cost month-to-date, broken down by model. Nothing leaves your Mac; no key or sign-in is needed. Costs are calculated locally from a bundled snapshot of Anthropic's published rates."
+        case "cline":
+            return "Reads your local Cline session logs. In VS Code, VS Code Insiders, VSCodium, Cursor, or Windsurf: `<host>/User/globalStorage/saoudrizwan.claude-dev/tasks/{taskId}/ui_messages.json`. For the Cline CLI: `$CLINE_DATA_DIR/tasks/…`, `$CLINE_DIR/data/tasks/…`, or `~/.cline/data/tasks/…`. Shows tokens used today, cost today, and cost month-to-date, broken down by model. Nothing leaves your Mac; no key or sign-in is needed. Costs come from Cline's own precomputed per-turn total — the same number you see inside the extension or CLI."
         default:
             return nil
         }
@@ -329,6 +331,8 @@ public enum ProviderCopy {
             return "Use a fine-grained PAT (github_pat_…), NOT a classic token. Grant only 'Plan: Read' under Account permissions — nothing else. Set an expiry so an accidentally-leaked token becomes worthless. Classic PATs with broader scopes can spend money on your GitHub account; do not paste one here. Treat a PAT like a password — anyone with it can act as you without triggering your 2FA prompt. Clearing this key deletes it from your Mac's Keychain but does NOT revoke it on GitHub — to revoke, visit github.com Settings → Developer settings → Personal access tokens and delete it there."
         case "claudeCode":
             return "Costs are estimates based on Anthropic's published per-token rates at the time this build was released. They are not a receipt from Anthropic and may differ from your actual bill. When new Claude models ship, unpriced records show tokens but $0 cost until the next app update; a 'Pricing update available' tile appears when this happens."
+        case "cline":
+            return "Costs come from Cline itself — this app reads Cline's precomputed per-turn total and sums them. If Cline's rate table is out of date, or the API-request record was not fully written (a crash mid-turn), the numbers will not match your provider's bill exactly. If a Cline install exists on this Mac but its data cannot be read, a 'Partial access' tile appears; grant Full Disk Access in System Settings to include it."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -23,6 +23,47 @@ import Foundation
 import SwiftUI
 import Combine
 
+// MARK: - RequestSafety
+
+/// Small hardening helpers for building credentialed requests from values
+/// that originate in an API response (a team id, project id) or a keychain
+/// account attribute (a user id). Server-issued strings are only semi-trusted:
+/// a compromised or buggy endpoint could return an id containing "/", "?",
+/// "#", or control characters that would alter the request path or split an
+/// HTTP header. These helpers reject or encode such input.
+public enum RequestSafety {
+    /// Percent-encode a single URL PATH segment, rejecting characters that
+    /// would change the path structure. Returns nil if the input is empty or
+    /// contains characters not valid in a path segment even after encoding
+    /// (control characters). "/" and "?" and "#" are encoded, not passed
+    /// through, so an id like "../admin" cannot traverse the path.
+    public static func pathSegment(_ raw: String) -> String? {
+        guard !raw.isEmpty else { return nil }
+        // Reject control characters outright — they have no business in an id.
+        if raw.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F }) {
+            return nil
+        }
+        // Encode everything that is not an unreserved path character. This
+        // encodes "/", "?", "#", "%", etc., so the segment cannot escape its
+        // position in the path.
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")   // RFC 3986 unreserved
+        return raw.addingPercentEncoding(withAllowedCharacters: allowed)
+    }
+
+    /// Validate a value destined for an HTTP header (e.g. a user id in an
+    /// Authorization header). Rejects CR, LF, and other control characters
+    /// that could split or inject headers. Returns the value unchanged when
+    /// safe, or nil when it must not be sent.
+    public static func headerValue(_ raw: String) -> String? {
+        guard !raw.isEmpty else { return nil }
+        if raw.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F }) {
+            return nil
+        }
+        return raw
+    }
+}
+
 // MARK: - UsageTile
 
 /// One renderable tile in the popover. A provider may contribute zero or
@@ -162,6 +203,31 @@ public protocol CredentialStore {
     func read(_ key: String) -> Data?
     func write(_ key: String, _ value: Data)
     func delete(_ key: String)
+
+    /// Read that distinguishes a genuinely absent credential (`.missing`)
+    /// from a keychain that is present but unreadable (`.unavailable`, e.g.
+    /// locked or access-denied). Only `.missing` should drive a provider's
+    /// "not configured" onboarding state. The default implementation maps the
+    /// plain `read` (found → `.found`, nil → `.missing`); `KeychainStore`
+    /// overrides it to report the real status.
+    func readResult(_ key: String) -> CredentialReadResult
+}
+
+public extension CredentialStore {
+    func readResult(_ key: String) -> CredentialReadResult {
+        if let data = read(key) { return .found(data) }
+        return .missing
+    }
+}
+
+/// Outcome of a credential read that separates a genuinely absent credential
+/// (`.missing`) from a store that is present but unreadable (`.unavailable`,
+/// e.g. a locked keychain). Only `.missing` should drive a "not configured"
+/// onboarding state. `OSStatus` is Foundation's `Int32` security-result code.
+public enum CredentialReadResult: Equatable {
+    case found(Data)
+    case missing
+    case unavailable(OSStatus)
 }
 
 // MARK: - PasteKeyProvider

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -308,6 +308,8 @@ public enum ProviderCopy {
             return "Can show your Perplexity plan, credit balance, and per-mode remaining queries (Pro Search, Deep Research, Labs, Agentic) when available. Sign in on perplexity.ai, open your browser's cookie inspector, and paste your __Secure-next-auth.session-token cookie below — the bare value, a name=value pair, or the full copied Cookie header all work. It is stored in your Keychain."
         case "copilot":
             return "Shows your GitHub Copilot chargeable AI-Credit overage (net) month-to-date, plus the top SKU line items. Note: usage covered by your plan's included allowance shows as $0 — only overage is charged. Create a fine-grained PAT on github.com (Settings → Developer settings → Personal access tokens → Fine-grained tokens), set the resource owner to your own account, then under Account permissions grant 'Plan: Read-only'. Paste the github_pat_… token below; it is stored in your Keychain."
+        case "claudeCode":
+            return "Reads your local Claude Code session logs (`~/.claude/projects/**/*.jsonl`) to show tokens used today, cost today, and cost month-to-date, broken down by model. Nothing leaves your Mac; no key or sign-in is needed. Costs are calculated locally from a bundled snapshot of Anthropic's published rates."
         default:
             return nil
         }
@@ -325,6 +327,8 @@ public enum ProviderCopy {
             return "Uses Perplexity's private web-app endpoints. They may stop working without notice. The pasted value is a full Perplexity web session cookie — it can let this app act as your signed-in account, including spending or purchasing credits your plan allows, until it expires or is revoked (for example by signing out or clearing sessions on perplexity.ai)."
         case "copilot":
             return "Use a fine-grained PAT (github_pat_…), NOT a classic token. Grant only 'Plan: Read' under Account permissions — nothing else. Set an expiry so an accidentally-leaked token becomes worthless. Classic PATs with broader scopes can spend money on your GitHub account; do not paste one here. Treat a PAT like a password — anyone with it can act as you without triggering your 2FA prompt. Clearing this key deletes it from your Mac's Keychain but does NOT revoke it on GitHub — to revoke, visit github.com Settings → Developer settings → Personal access tokens and delete it there."
+        case "claudeCode":
+            return "Costs are estimates based on Anthropic's published per-token rates at the time this build was released. They are not a receipt from Anthropic and may differ from your actual bill. When new Claude models ship, unpriced records show tokens but $0 cost until the next app update; a 'Pricing update available' tile appears when this happens."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -224,6 +224,8 @@ public enum ProviderCopy {
             return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
         case "xai":
             return "Shows your xAI (Grok) API key permissions. Paste an inference key (xai-…) below. Add a management key too to also see prepaid balance and daily usage. Both are stored in your Keychain."
+        case "openai":
+            return "Shows your OpenAI organisation's month-to-date spend, token usage by model, and configured rate limits. Paste an Organization Admin key (sk-admin-…); it is stored in your Keychain."
         default:
             return nil
         }
@@ -235,6 +237,8 @@ public enum ProviderCopy {
         switch id {
         case "codex":
             return "Uses OpenAI's private Codex API. It may stop working without notice."
+        case "openai":
+            return "An Admin key can view billing and manage users in your OpenAI organisation. It cannot make inference calls. Store yours only if you are comfortable with this app holding it."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -183,6 +183,29 @@ public protocol PasteKeyProvider {
     func saveKey(_ raw: String)
 }
 
+// MARK: - SecondaryKeyProvider
+
+/// Optional capability for providers that accept a SECOND, higher-privilege
+/// secret gated behind a warning (e.g. xAI's management key, which can
+/// create/rotate/delete API keys). The Settings row renders a second, opt-in
+/// entry field with the warning text for any provider that conforms.
+///
+/// A provider adopting this must also adopt PasteKeyProvider for its primary
+/// (required) key.
+@MainActor
+public protocol SecondaryKeyProvider {
+    /// Placeholder for the secondary field.
+    var secondaryKeyPlaceholder: String { get }
+    /// Short label for the opt-in row (e.g. "Enable balance + history").
+    var secondaryKeyLabel: String { get }
+    /// Warning shown before the field (e.g. what the key can do).
+    var secondaryKeyWarning: String { get }
+    /// True when a secondary secret is stored.
+    var hasSecondaryKey: Bool { get }
+    /// Store a pasted secondary secret. Empty input clears it.
+    func saveSecondaryKey(_ raw: String)
+}
+
 // MARK: - ProviderCopy
 
 /// Per-provider help and disclosure copy for the Settings toggles. Kept in
@@ -199,6 +222,8 @@ public enum ProviderCopy {
             return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
         case "zed":
             return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
+        case "xai":
+            return "Shows your xAI (Grok) API key permissions. Paste an inference key (xai-…) below. Add a management key too to also see prepaid balance and daily usage. Both are stored in your Keychain."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -197,6 +197,8 @@ public enum ProviderCopy {
             return "Codex counters cover the Codex CLI, IDE extensions, Slack, and Cloud tasks — one shared 5-hour and weekly pool. General GPT chat is not counted. Reads your existing `codex auth login` session; run it in a terminal if prompted."
         case "deepseek":
             return "Shows your DeepSeek platform balance (granted + topped-up), per currency. Paste a DeepSeek API key below; it is stored in your macOS Keychain and used only to read the balance."
+        case "zed":
+            return "Shows your Zed plan and edit-prediction usage. Reads the login Zed already saved in your Keychain — macOS will ask once to allow it. Sign in to Zed first, then click Refresh."
         default:
             return nil
         }

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -1,0 +1,181 @@
+// PR 2c — UsageProvider protocol and supporting types.
+//
+// This PR introduces the multi-provider surface without adding any new
+// provider. It ships:
+//
+//   1. A `UsageProvider` protocol every provider will conform to.
+//   2. A `UsageTile` value type for popover rendering.
+//   3. A `ProviderBox` type-erasing wrapper so SwiftUI can observe a
+//      collection of heterogeneous providers via a single ObservableObject.
+//   4. `AnthropicUsageStore` — the first conformer, wrapping the existing
+//      UsageManager. Behaviour identical to v1.3.1.
+//
+// Everything is additive. UsageManager is not removed. The popover is not
+// yet driven by `[UsageProvider]` — that switch lands in a follow-up PR
+// once at least one non-Anthropic provider exists.
+//
+// The two-layer split (Fetcher value type + Store observable class) is
+// documented in EXPANSION_PLAN.md § 2. Fetchers are Sendable value types
+// with no observable state (see AnthropicUsageFetcher in PR 2b). Stores
+// hold @Published state on the main actor and are what SwiftUI observes.
+
+import Foundation
+import SwiftUI
+import Combine
+
+// MARK: - UsageTile
+
+/// One renderable tile in the popover. A provider may contribute zero or
+/// more tiles. The `Kind` enum encodes the presentation semantics without
+/// coupling to a specific SwiftUI view; downstream PRs render each kind
+/// with the appropriate component.
+public struct UsageTile: Identifiable, Equatable, Sendable {
+    public let id: String                   // "anthropic-5h", "codex-weekly"
+    public let title: String                // "Session (5 hour)"
+    public let kind: Kind
+
+    public enum Kind: Equatable, Sendable {
+        /// Progress-bar tile with a 0.0…1.0 fraction and optional reset time.
+        case bar(fraction: Double, resetsAt: Date?, badge: String?)
+
+        /// Balance tile — displayed as a monetary amount plus an optional
+        /// plan label and reset time.
+        case balance(remainingMinorUnits: Int, currency: String, plan: String?, resetsAt: Date?)
+
+        /// Counter tile — used / limit with optional reset time.
+        case counter(used: Int, limit: Int?, resetsAt: Date?)
+
+        /// Freeform text tile — plan info, status warnings, "needs access".
+        case text(status: String, subtitle: String?)
+
+        /// The provider needs a permission the user has not granted.
+        case needsAccess(path: String, guidance: String)
+    }
+
+    public init(id: String, title: String, kind: Kind) {
+        self.id = id
+        self.title = title
+        self.kind = kind
+    }
+}
+
+// MARK: - UsageProvider
+
+/// Every provider (Anthropic, Codex, DeepSeek, Zed, xAI, OpenAI Platform,
+/// Perplexity, Copilot, local-file readers) conforms to this protocol.
+/// Providers are held in `AppDelegate.providers` as a heterogeneous
+/// collection wrapped in `ProviderBox` for SwiftUI observation.
+public protocol UsageProvider: AnyObject, ObservableObject {
+    /// Stable identifier used for feature flags, notification-threshold
+    /// tracking, and log correlation. Examples: "anthropic", "codex",
+    /// "deepseek".
+    var id: String { get }
+
+    /// Display name in the popover section header and Settings toggle.
+    var displayName: String { get }
+
+    /// UserDefaults key that gates activation. Defaulted false. Reading and
+    /// writing this flag is the provider's responsibility.
+    var featureFlagKey: String { get }
+
+    /// True when the user has activated the provider via Settings.
+    var isEnabled: Bool { get }
+
+    /// True when the provider has valid credentials or file access to
+    /// operate. False means the tile should render a first-run onboarding
+    /// state (paste key, grant access, etc.).
+    var isConfigured: Bool { get }
+
+    /// Timestamp of the most recent successful fetch. Nil before the
+    /// first fetch.
+    var lastUpdated: Date? { get }
+
+    /// One-line human-readable error if the last fetch failed. Nil on
+    /// success or when idle.
+    var errorMessage: String? { get }
+
+    /// Tiles this provider currently renders in the popover. Empty when
+    /// the provider is disabled.
+    var tiles: [UsageTile] { get }
+
+    /// Kick off a fetch. Providers are responsible for their own cadence
+    /// (5-minute Anthropic, 60-second Codex, hourly OpenAI Platform,
+    /// etc.). This method is called by the shared timer in AppDelegate
+    /// and may be called manually via the popover's Refresh button.
+    func fetch()
+
+    /// Clear stored state and (optionally) credentials. Called by the
+    /// per-provider "Clear credentials" button in Settings.
+    func clear()
+}
+
+// MARK: - ProviderBox
+
+/// Type-erasing wrapper for SwiftUI. `@ObservedObject var: any UsageProvider`
+/// does not compile in Swift 6 mode (existential + associated type) — the
+/// box forwards `objectWillChange` from the underlying provider so views
+/// can observe it uniformly.
+///
+/// This is one of the load-bearing catches from the pre-PR adversarial
+/// review; the underlying protocol trial compiled fine, but the SwiftUI
+/// observation site did not. `ProviderBox` is the fix.
+@MainActor
+public final class ProviderBox: ObservableObject, Identifiable {
+    public let provider: any UsageProvider
+    // Cached at construction rather than reaching through `provider.id` on
+    // every access — keeps `id` a nonisolated stored property so the
+    // Identifiable conformance is Swift-6-strict-concurrency clean.
+    public nonisolated let id: String
+
+    private var cancellable: AnyCancellable?
+
+    public init<P: UsageProvider>(_ provider: P) {
+        self.provider = provider
+        self.id = provider.id
+        // Forward the underlying provider's change notifications so
+        // SwiftUI redraws views observing this box.
+        self.cancellable = provider.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+    }
+}
+
+// MARK: - CredentialStore
+
+/// Storage abstraction for provider credentials. Two backends:
+/// `DefaultsStore` (for the legacy Anthropic cookie, retained for
+/// backwards compatibility) and `KeychainStore` (for spending credentials
+/// and any new provider going forward).
+///
+/// Concrete Keychain implementation lands in a follow-up PR once at
+/// least one provider actually needs it. PR 2c ships the abstraction so
+/// downstream PRs have a stable target.
+public protocol CredentialStore {
+    func read(_ key: String) -> Data?
+    func write(_ key: String, _ value: Data)
+    func delete(_ key: String)
+}
+
+/// UserDefaults-backed credential store. Used only for the legacy
+/// Anthropic session cookie. New providers must use `KeychainStore`.
+public struct DefaultsStore: CredentialStore {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func read(_ key: String) -> Data? {
+        defaults.data(forKey: key)
+    }
+
+    public func write(_ key: String, _ value: Data) {
+        defaults.set(value, forKey: key)
+    }
+
+    public func delete(_ key: String) {
+        defaults.removeObject(forKey: key)
+    }
+}

--- a/app/UsageProvider.swift
+++ b/app/UsageProvider.swift
@@ -306,6 +306,8 @@ public enum ProviderCopy {
             return "Shows your OpenAI organisation's month-to-date spend, token usage by model, and configured rate limits. Paste an Organization Admin key (sk-admin-…); it is stored in your Keychain."
         case "perplexity":
             return "Can show your Perplexity plan, credit balance, and per-mode remaining queries (Pro Search, Deep Research, Labs, Agentic) when available. Sign in on perplexity.ai, open your browser's cookie inspector, and paste your __Secure-next-auth.session-token cookie below — the bare value, a name=value pair, or the full copied Cookie header all work. It is stored in your Keychain."
+        case "copilot":
+            return "Shows your GitHub Copilot chargeable AI-Credit overage (net) month-to-date, plus the top SKU line items. Note: usage covered by your plan's included allowance shows as $0 — only overage is charged. Create a fine-grained PAT on github.com (Settings → Developer settings → Personal access tokens → Fine-grained tokens), set the resource owner to your own account, then under Account permissions grant 'Plan: Read-only'. Paste the github_pat_… token below; it is stored in your Keychain."
         default:
             return nil
         }
@@ -321,6 +323,8 @@ public enum ProviderCopy {
             return "An Admin key can view billing and manage users in your OpenAI organisation. It cannot make inference calls. Store yours only if you are comfortable with this app holding it."
         case "perplexity":
             return "Uses Perplexity's private web-app endpoints. They may stop working without notice. The pasted value is a full Perplexity web session cookie — it can let this app act as your signed-in account, including spending or purchasing credits your plan allows, until it expires or is revoked (for example by signing out or clearing sessions on perplexity.ai)."
+        case "copilot":
+            return "Use a fine-grained PAT (github_pat_…), NOT a classic token. Grant only 'Plan: Read' under Account permissions — nothing else. Set an expiry so an accidentally-leaked token becomes worthless. Classic PATs with broader scopes can spend money on your GitHub account; do not paste one here. Treat a PAT like a password — anyone with it can act as you without triggering your 2FA prompt. Clearing this key deletes it from your Mac's Keychain but does NOT revoke it on GitHub — to revoke, visit github.com Settings → Developer settings → Personal access tokens and delete it there."
         default:
             return nil
         }

--- a/app/WindsurfUsageFetcher.swift
+++ b/app/WindsurfUsageFetcher.swift
@@ -1,0 +1,309 @@
+// PR 11-BE — Windsurf local usage fetcher (feature-flagged off).
+//
+// Third local-file provider (Milestone 6). Reads Windsurf's own
+// state.vscdb (a SQLite database) for the cached plan-usage record
+// Windsurf's Cascade chat writes there. Nothing leaves the machine.
+//
+// Data source
+// -----------
+// `~/Library/Application Support/Windsurf/User/globalStorage/state.vscdb`
+// is a standard VS Code-style key/value SQLite DB. The
+// `ItemTable(key, value)` schema holds a `windsurf.settings.cachedPlanInfo`
+// row whose `value` is a JSON string.
+//
+// Two shapes observed in the wild (Windsurf's plan-info payload has
+// evolved twice; both live installs today can produce either shape):
+//
+//   OLDER: `quotaUsage.{dailyRemainingPercent, weeklyRemainingPercent,
+//                       dailyResetAtUnix,       weeklyResetAtUnix}`
+//   NEWER: `usage.{usedMessages,       remainingMessages,
+//                   usedFlexCredits,   flexCredits,
+//                   usedFlowActions}`
+//   Both: `planName`, `startTimestamp`, `endTimestamp` (all optional).
+//
+// The parser reads BOTH and produces a tile-ready `WindsurfPlanUsage`
+// with best-effort projection: `quotaUsage.*` maps to explicit daily/
+// weekly windows with reset times; `usage.*` maps to a single "credits"
+// window using `usedMessages` / `messages` (or `usedFlexCredits` /
+// `flexCredits` when present).
+//
+// Live-endpoint (`windsurf.com/_backend/exa.seat_management_pb...`) is
+// intentionally deferred — it uses Connect-RPC protobuf and Chromium
+// leveldb cookies (requires Full Disk Access), which materially
+// increases attack surface and maintenance load for a nice-to-have.
+// Local-only ships first; live path can land in a follow-on PR.
+//
+// Feature posture
+// ---------------
+// `features.windsurf.enabled` defaults false. Nothing registers a
+// `WindsurfUsageStore` into the live registry yet (that lands in PR
+// 11-UI). This file compiles and unit-tests but is inert at runtime
+// until enabled.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// A single quota window Windsurf exposes. Windsurf's cached plan info
+/// mixes two representations: percent-remaining with reset times
+/// (older shape) and used/remaining message counts (newer shape). Both
+/// project to this record via `WindsurfUsageParser`.
+public struct WindsurfPlanUsageWindow: Equatable, Sendable {
+    public enum Kind: String, Sendable, Equatable {
+        case daily
+        case weekly
+        case credits          // catch-all for `usage.usedMessages` /
+                              // `usedFlexCredits` shape.
+    }
+    public var kind: Kind
+    /// Fraction of the window consumed in the range `[0, 1]`. Derived from
+    /// `100 - remainingPercent` (older) or `used / total` (newer).
+    public var fractionUsed: Double
+    /// Wall-clock reset time for this window, when the source data has it.
+    /// Nil when Windsurf did not persist a reset stamp.
+    public var resetsAt: Date?
+    /// Human label for the window ("Daily", "Weekly", "Credits"). Kept
+    /// separately from `Kind` because a future Windsurf plan tier may
+    /// expose a differently-named window we still want to render.
+    public var displayLabel: String
+
+    public init(kind: Kind, fractionUsed: Double, resetsAt: Date?, displayLabel: String) {
+        self.kind = kind
+        self.fractionUsed = fractionUsed
+        self.resetsAt = resetsAt
+        self.displayLabel = displayLabel
+    }
+}
+
+/// Aggregate parse result. `planName` is exposed for a diagnostic /
+/// header line in the popover; the windows drive the actual tiles.
+public struct WindsurfPlanUsage: Equatable, Sendable {
+    /// e.g. "Pro", "Free", "Enterprise". Nil when the JSON did not carry a
+    /// planName (older Windsurf builds).
+    public var planName: String?
+    /// Windows extracted from the payload. Empty when the JSON was well-
+    /// formed but had no usage numbers — the caller renders a diagnostic.
+    public var windows: [WindsurfPlanUsageWindow]
+
+    public init(planName: String? = nil, windows: [WindsurfPlanUsageWindow] = []) {
+        self.planName = planName
+        self.windows = windows
+    }
+}
+
+// MARK: - Path resolution
+
+public enum WindsurfPathResolver {
+
+    public struct Environment: Sendable {
+        public var homeDirectoryPath: String
+        public var applicationSupportPath: String
+        public init(homeDirectoryPath: String, applicationSupportPath: String) {
+            self.homeDirectoryPath = homeDirectoryPath
+            self.applicationSupportPath = applicationSupportPath
+        }
+
+        public static func current() -> Environment {
+            let home = NSHomeDirectory()
+            return Environment(
+                homeDirectoryPath: home,
+                applicationSupportPath: (home as NSString).appendingPathComponent("Library/Application Support")
+            )
+        }
+    }
+
+    /// Absolute path to `state.vscdb`. Nil when we have no
+    /// `applicationSupportPath` to build against (an empty environment
+    /// snapshot — never in practice on macOS).
+    public static func stateDbPath(_ env: Environment) -> String? {
+        guard !env.applicationSupportPath.isEmpty else { return nil }
+        return "\(env.applicationSupportPath)/Windsurf/User/globalStorage/state.vscdb"
+    }
+}
+
+// MARK: - JSON parsing
+
+public enum WindsurfUsageParser {
+
+    /// Parse a `windsurf.settings.cachedPlanInfo` value string into a
+    /// tile-ready plan-usage record. Returns nil when the string does
+    /// not decode as a JSON object; returns an empty-windows record when
+    /// the object is well-formed but has no quota fields.
+    public static func parse(cachedPlanInfoJSON raw: String) -> WindsurfPlanUsage? {
+        guard let data = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data),
+              let dict = obj as? [String: Any] else {
+            return nil
+        }
+        let planName = dict["planName"] as? String
+        var windows: [WindsurfPlanUsageWindow] = []
+
+        // Older shape — `quotaUsage.{daily,weekly}RemainingPercent`.
+        if let quota = dict["quotaUsage"] as? [String: Any] {
+            if let dailyRemaining = numeric(quota["dailyRemainingPercent"]) {
+                let used = max(0.0, min(1.0, (100.0 - dailyRemaining) / 100.0))
+                windows.append(WindsurfPlanUsageWindow(
+                    kind: .daily,
+                    fractionUsed: used,
+                    resetsAt: unixTimestampFlexibleSecondsOrMs(quota["dailyResetAtUnix"]),
+                    displayLabel: "Daily"
+                ))
+            }
+            if let weeklyRemaining = numeric(quota["weeklyRemainingPercent"]) {
+                let used = max(0.0, min(1.0, (100.0 - weeklyRemaining) / 100.0))
+                windows.append(WindsurfPlanUsageWindow(
+                    kind: .weekly,
+                    fractionUsed: used,
+                    resetsAt: unixTimestampFlexibleSecondsOrMs(quota["weeklyResetAtUnix"]),
+                    displayLabel: "Weekly"
+                ))
+            }
+        }
+
+        // Newer shape — `usage.{used,remaining}Messages` /
+        // `usage.{usedFlexCredits, flexCredits}`. Only surfaced when the
+        // older shape produced no windows so the tile does not double-
+        // count.
+        if windows.isEmpty, let usage = dict["usage"] as? [String: Any] {
+            // Prefer flex credits when Windsurf exposes them (Pro plan).
+            if let used = numeric(usage["usedFlexCredits"]),
+               let total = numeric(usage["flexCredits"]),
+               total > 0 {
+                windows.append(WindsurfPlanUsageWindow(
+                    kind: .credits,
+                    fractionUsed: max(0.0, min(1.0, used / total)),
+                    resetsAt: unixTimestampFlexibleSecondsOrMs(dict["endTimestamp"]),
+                    displayLabel: "Flex credits"
+                ))
+            } else if let used = numeric(usage["usedMessages"]),
+                      let remaining = numeric(usage["remainingMessages"]) {
+                let total = used + remaining
+                if total > 0 {
+                    windows.append(WindsurfPlanUsageWindow(
+                        kind: .credits,
+                        fractionUsed: max(0.0, min(1.0, used / total)),
+                        resetsAt: unixTimestampFlexibleSecondsOrMs(dict["endTimestamp"]),
+                        displayLabel: "Messages"
+                    ))
+                }
+            } else if let used = numeric(usage["usedMessages"]),
+                      let total = numeric(usage["messages"]),
+                      total > 0 {
+                // Third form observed in some plans: `usage.messages` is
+                // the total, `usedMessages` the consumed count. Kept as
+                // a distinct branch so a schema break narrows the
+                // failure mode.
+                windows.append(WindsurfPlanUsageWindow(
+                    kind: .credits,
+                    fractionUsed: max(0.0, min(1.0, used / total)),
+                    resetsAt: unixTimestampFlexibleSecondsOrMs(dict["endTimestamp"]),
+                    displayLabel: "Messages"
+                ))
+            }
+        }
+
+        return WindsurfPlanUsage(planName: planName, windows: windows)
+    }
+
+    // MARK: - Field helpers
+
+    /// Best-effort numeric extraction. Windsurf stores every quota field
+    /// as JSON Number, but a schema drift or hand-edit could produce a
+    /// stringified number. Returns nil for `null`, missing, NaN, or
+    /// infinity.
+    ///
+    /// Codex round-1 finding #2: JSON booleans MUST be rejected — an
+    /// `NSNumber` bridged from a JSON bool has `.doubleValue == 0` or
+    /// `1`, which would silently map `dailyRemainingPercent: false` to
+    /// 0% remaining (i.e. 100% used) instead of "no data".
+    public static func numeric(_ raw: Any?) -> Double? {
+        if let n = raw as? NSNumber, CFGetTypeID(n) == CFBooleanGetTypeID() {
+            return nil
+        }
+        if let d = raw as? Double, d.isFinite { return d }
+        if let i = raw as? Int { return Double(i) }
+        if let n = raw as? NSNumber { return n.doubleValue.isFinite ? n.doubleValue : nil }
+        if let s = raw as? String, let parsed = Double(s), parsed.isFinite { return parsed }
+        return nil
+    }
+
+    /// Interpret a Unix timestamp that may be seconds OR milliseconds
+    /// (Windsurf's schema is inconsistent across releases — the older
+    /// `quotaUsage.*ResetAtUnix` used seconds, but some newer builds emit
+    /// milliseconds). Heuristic: > 1e11 → treat as ms (would be year
+    /// 5138 as seconds); ≤ 1e11 → seconds. Rejects values outside
+    /// [2000-01-01, 2100-01-01] the same way Cline's parser does.
+    public static func unixTimestampFlexibleSecondsOrMs(_ raw: Any?) -> Date? {
+        guard let n = numeric(raw) else { return nil }
+        let seconds: Double = n > 1_000_000_000_00 /* 1e11 */ ? n / 1000.0 : n
+        let year2000: Double = 946_684_800
+        let year2100: Double = 4_102_444_800
+        guard seconds >= year2000 && seconds < year2100 else { return nil }
+        return Date(timeIntervalSince1970: seconds)
+    }
+}
+
+// MARK: - Fetcher
+
+/// Sendable value-type. All I/O is optional via injection.
+public struct WindsurfUsageFetcher: Sendable {
+
+    /// Read the `windsurf.settings.cachedPlanInfo` row from a Windsurf
+    /// state.vscdb and return the parsed usage record.
+    ///
+    /// Throws every error `SQLiteReader.init` can emit — `.notFound` and
+    /// `.openFailed` (TCC-denied) drive the store's onboarding tile;
+    /// `.notADatabase` / `.encrypted` / `.schemaMismatch` are hard
+    /// failures the store surfaces as an error tile.
+    ///
+    /// Returns nil ONLY when the file opened cleanly and the
+    /// cachedPlanInfo row is absent (fresh install; user has not
+    /// signed in yet).
+    ///
+    /// Codex round-1 finding #1: a row that exists but is malformed
+    /// (JSON parse fails, or the JSON is not a top-level object) must
+    /// NOT be indistinguishable from a missing row — otherwise the
+    /// store stays on "Loading…" forever. Signalled via the new
+    /// `.malformedPayload` case below; the store maps it to a
+    /// schema-mismatch tile.
+    public static func read(from stateDbPath: String) throws -> WindsurfReadOutcome {
+        let reader = try SQLiteReader(path: stateDbPath)
+        defer { reader.close() }
+        // Codex round-3 finding #1: differentiate row-absent from
+        // row-present-with-non-text-value. The decode closure returns
+        // an inner Optional<String> so a NULL / blob / integer value
+        // still counts as a row-present hit and maps to
+        // .malformedPayload instead of collapsing to .rowMissing.
+        let rows = try reader.query(
+            "SELECT value FROM ItemTable WHERE key = ? LIMIT 1",
+            binds: [.text("windsurf.settings.cachedPlanInfo")]
+        ) { row -> String? in
+            // Sentinel: return a marker for "present-but-not-text" by
+            // reading the value column as a blob first. If it's a
+            // string, decode it; if it's non-nil but not text, return
+            // an empty string (distinct from the "no row" case where
+            // the closure is not called at all).
+            if row.isNull("value") { return "" }
+            if let text = row.string("value") { return text }
+            // Row present with non-text value (blob / integer /
+            // double). Treat as malformed.
+            return ""
+        }
+        guard let value = rows.first ?? nil else { return .rowMissing }
+        if value.isEmpty { return .malformedPayload }
+        guard let parsed = WindsurfUsageParser.parse(cachedPlanInfoJSON: value) else {
+            return .malformedPayload
+        }
+        return .success(parsed)
+    }
+}
+
+/// Outcome of a Windsurf state.vscdb read. Differentiates a
+/// legitimately-missing cachedPlanInfo row (`.rowMissing` — fresh
+/// install) from a row that exists but contains junk (`.malformedPayload`
+/// — schema drift). Codex round-1 finding #1.
+public enum WindsurfReadOutcome: Equatable, Sendable {
+    case success(WindsurfPlanUsage)
+    case rowMissing
+    case malformedPayload
+}

--- a/app/WindsurfUsageStore.swift
+++ b/app/WindsurfUsageStore.swift
@@ -1,0 +1,321 @@
+// PR 11-BE — Windsurf UsageProvider store (feature-flag off).
+//
+// Third local-file reader. Reads Windsurf's own state.vscdb for the
+// `windsurf.settings.cachedPlanInfo` blob and renders per-window
+// quota tiles. Nothing leaves the machine.
+//
+// Concurrency model mirrors ClaudeCodeUsageStore / ClineUsageStore:
+// SQLite read + JSON parse run on a serial background queue; results
+// apply on the main actor via `Task { @MainActor [weak self] in ... }`;
+// `fetchGeneration` invalidates in-flight completions on clear(),
+// disable, or TCC transition.
+//
+// Feature posture: `features.windsurf.enabled` defaults false. Nothing
+// registers a WindsurfUsageStore into `AppDelegate.providers` yet —
+// that lands in PR 11-UI along with `ProviderCopy.help(for: "windsurf")`.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class WindsurfUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "windsurf"
+    public let displayName: String = "Windsurf"
+    public let featureFlagKey: String = "features.windsurf.enabled"
+
+    // MARK: - Observable state
+
+    @Published public private(set) var usage: WindsurfPlanUsage?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    @Published public private(set) var tccState: TCCState = .granted
+    /// True when the SQLite reader reported `.schemaMismatch` — the tile
+    /// tells the user to update the app rather than showing stale numbers
+    /// against a schema they no longer recognise. Modelled per the plan's
+    /// "ship a schema-version sentinel; refuse to render on mismatch"
+    /// directive (applied to Windsurf out of prudence; Windsurf's plan
+    /// info has evolved twice already).
+    @Published public private(set) var schemaMismatch: Bool = false
+    /// True after a fetch completed successfully but Windsurf had no
+    /// `cachedPlanInfo` row (fresh install, user has not signed in).
+    /// Codex round-3 finding #2: differentiated from the initial
+    /// "loading" state so the user gets an actionable "sign in"
+    /// tile rather than "Loading…" forever.
+    @Published public private(set) var rowMissing: Bool = false
+
+    // MARK: - Dependencies
+
+    private let defaults: UserDefaults
+    private let resolvePath: @Sendable () -> String?
+    private let tccProbe: @Sendable (String) -> TCCState
+    /// Reader hook — parses the file bytes on the background queue and
+    /// returns a discriminated outcome: success, row-missing, or
+    /// malformed-payload. Codex round-1 finding #1: differentiate
+    /// missing vs corrupt so the tile can render distinct states.
+    private let readUsage: @Sendable (String) throws -> WindsurfReadOutcome
+    private let workQueue: DispatchQueue
+    private let clock: @Sendable () -> Date
+
+    private var fetchGeneration: UInt64 = 0
+
+    public init(
+        defaults: UserDefaults = .standard,
+        resolvePath: @escaping @Sendable () -> String? = {
+            WindsurfPathResolver.stateDbPath(.current())
+        },
+        tccProbe: @escaping @Sendable (String) -> TCCState = { TCCProbe.probe(path: $0) },
+        readUsage: @escaping @Sendable (String) throws -> WindsurfReadOutcome = {
+            try WindsurfUsageFetcher.read(from: $0)
+        },
+        workQueue: DispatchQueue = DispatchQueue(
+            label: "com.claude.usagebar.windsurf.parse",
+            qos: .utility
+        ),
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.defaults = defaults
+        self.resolvePath = resolvePath
+        self.tccProbe = tccProbe
+        self.readUsage = readUsage
+        self.workQueue = workQueue
+        self.clock = clock
+    }
+
+    // MARK: - UsageProvider
+
+    public var isEnabled: Bool { defaults.bool(forKey: featureFlagKey) }
+    public var isConfigured: Bool { isEnabled }
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if schemaMismatch {
+            return [UsageTile(
+                id: "windsurf-schema-mismatch",
+                title: displayName,
+                kind: .text(
+                    status: "Windsurf plan-info format changed",
+                    subtitle: "The plan-info format on disk changed and this ClaudeUsageBar build cannot read it safely. Update ClaudeUsageBar to include the new format."
+                )
+            )]
+        }
+
+        switch tccState {
+        case .denied:
+            let copy = LocalProviderAccessGuide.copy(for: .denied, appName: displayName)
+            return [UsageTile(
+                id: "windsurf-needs-access",
+                title: copy.title,
+                kind: .needsAccess(
+                    path: "~/Library/Application Support/Windsurf/User/globalStorage/state.vscdb",
+                    guidance: copy.guidance
+                )
+            )]
+        case .pathMissing:
+            return [UsageTile(
+                id: "windsurf-not-installed",
+                title: displayName,
+                kind: .text(
+                    status: "No Windsurf install found",
+                    subtitle: "If Windsurf is installed, sign in and open a Cascade chat once. If Windsurf is not on this Mac, disable this provider in Settings."
+                )
+            )]
+        case .granted:
+            break
+        }
+
+        // Codex round-3 finding #2: distinguish "loading, no fetch
+        // completed yet" from "fetch completed, row absent" (fresh
+        // install with no sign-in). The former is transient; the
+        // latter is a durable state and needs an actionable tile.
+        if usage == nil && rowMissing {
+            return [UsageTile(
+                id: "windsurf-signin-needed",
+                title: displayName,
+                kind: .text(
+                    status: "No Windsurf session",
+                    subtitle: "Sign in to Windsurf and open a Cascade chat once, then click Refresh."
+                )
+            )]
+        }
+        guard let usage = usage else {
+            return [UsageTile(
+                id: "windsurf-loading",
+                title: displayName,
+                kind: .text(status: "Loading…", subtitle: nil)
+            )]
+        }
+
+        if usage.windows.isEmpty {
+            return [UsageTile(
+                id: "windsurf-no-quota",
+                title: displayName,
+                kind: .text(
+                    status: "No quota data found",
+                    subtitle: "Windsurf's plan info exists but has no quota fields. Sign in to Windsurf and open a Cascade chat, then click Refresh."
+                )
+            )]
+        }
+
+        var out: [UsageTile] = []
+        // Plan name tile — informational only. Only shown when the plan
+        // has a name; keeps the popover quiet on older Windsurf builds
+        // that omit `planName`.
+        if let name = usage.planName, !name.isEmpty {
+            out.append(UsageTile(
+                id: "windsurf-plan",
+                title: displayName,
+                kind: .text(status: name, subtitle: nil)
+            ))
+        }
+        // One bar tile per window.
+        for w in usage.windows {
+            out.append(UsageTile(
+                id: "windsurf-\(w.kind.rawValue)",
+                title: w.displayLabel,
+                kind: .bar(
+                    fraction: w.fractionUsed,
+                    resetsAt: w.resetsAt,
+                    badge: nil
+                )
+            ))
+        }
+        return out
+    }
+
+    public func fetch() {
+        fetchGeneration &+= 1
+        guard isEnabled else {
+            usage = nil
+            schemaMismatch = false
+            rowMissing = false
+            return
+        }
+        let launchGeneration = fetchGeneration
+
+        guard let path = resolvePath() else {
+            lastError = "Could not resolve Windsurf data path."
+            return
+        }
+
+        let probed = tccProbe(path)
+        self.tccState = probed
+        if probed != .granted {
+            self.usage = nil
+            self.lastError = nil
+            self.schemaMismatch = false
+            self.rowMissing = false
+            return
+        }
+
+        let read = self.readUsage
+        workQueue.async { [weak self] in
+            let outcome: FetchOutcome
+            do {
+                let readOutcome = try read(path)
+                switch readOutcome {
+                case .success(let usage):
+                    outcome = .success(usage)
+                case .rowMissing:
+                    outcome = .rowMissing
+                case .malformedPayload:
+                    // Codex round-1 finding #1: a payload that exists
+                    // but does not parse is a schema-mismatch signal,
+                    // NOT "no data yet". Surfaces the update-app tile.
+                    outcome = .schemaMismatch
+                }
+            } catch SQLiteReaderError.notFound {
+                outcome = .pathMissing
+            } catch SQLiteReaderError.openFailed {
+                outcome = .denied
+            } catch SQLiteReaderError.notADatabase, SQLiteReaderError.encrypted {
+                outcome = .schemaMismatch
+            } catch SQLiteReaderError.schemaMismatch {
+                outcome = .schemaMismatch
+            } catch SQLiteReaderError.busy {
+                outcome = .transientBusy
+            } catch {
+                outcome = .otherError("\(error)")
+            }
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                guard self.isEnabled else { return }
+                guard launchGeneration == self.fetchGeneration else { return }
+                self.applyOutcome(outcome)
+            }
+        }
+    }
+
+    public func clear() {
+        usage = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        schemaMismatch = false
+        rowMissing = false
+        fetchGeneration &+= 1
+    }
+
+    // MARK: - Outcome application
+
+    /// Internal outcome enum kept private so the store's public surface
+    /// only exposes @Published state. Every SQLiteReaderError variant
+    /// projects to exactly one outcome; the apply hop writes the
+    /// matching state and lets `tiles` compute the render.
+    private enum FetchOutcome: Sendable {
+        case success(WindsurfPlanUsage?)
+        case rowMissing
+        case pathMissing
+        case denied
+        case schemaMismatch
+        case transientBusy
+        case otherError(String)
+    }
+
+    private func applyOutcome(_ outcome: FetchOutcome) {
+        switch outcome {
+        case .success(let usage):
+            self.usage = usage
+            self.lastUpdatedAt = clock()
+            self.lastError = nil
+            self.schemaMismatch = false
+            self.rowMissing = false
+            Log.info("Windsurf plan-info parsed", .count(usage?.windows.count ?? 0))
+        case .rowMissing:
+            // Fresh install / not signed in. Distinct from "still
+            // loading" so the tile can show an actionable prompt.
+            self.usage = nil
+            self.rowMissing = true
+            self.lastUpdatedAt = clock()
+            self.lastError = nil
+            self.schemaMismatch = false
+        case .pathMissing:
+            self.tccState = .pathMissing
+            self.usage = nil
+            self.rowMissing = false
+            self.lastError = nil
+            self.schemaMismatch = false
+        case .denied:
+            self.tccState = .denied
+            self.usage = nil
+            self.rowMissing = false
+            self.lastError = nil
+            self.schemaMismatch = false
+        case .schemaMismatch:
+            self.schemaMismatch = true
+            self.usage = nil
+            self.rowMissing = false
+            self.lastError = nil
+        case .transientBusy:
+            // Editor holding the lock. Do not clear existing usage; next
+            // tick will retry.
+            self.lastError = "Windsurf editor is holding the database — retry on next tick."
+        case .otherError(let msg):
+            self.lastError = "Windsurf read failed: \(msg)"
+            self.schemaMismatch = false
+        }
+    }
+}

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -107,11 +107,16 @@ public struct XAIBalance: Equatable, Sendable {
 /// One day's usage from the management usage endpoint.
 public struct XAIDailyUsage: Equatable, Sendable {
     public var date: String   // ISO date (YYYY-MM-DD) as returned
-    public var usdSpent: Double
+    public var amountSpent: Double
+    /// Currency code if the response carries one (e.g. "USD", "CNY"). Nil
+    /// when the endpoint does not report a currency — the tile then shows a
+    /// neutral amount rather than assuming a "$" symbol.
+    public var currency: String?
 
-    public init(date: String, usdSpent: Double) {
+    public init(date: String, amountSpent: Double, currency: String? = nil) {
         self.date = date
-        self.usdSpent = usdSpent
+        self.amountSpent = amountSpent
+        self.currency = currency
     }
 }
 
@@ -218,19 +223,22 @@ public struct XAIUsageFetcher: Sendable {
             ?? []
         return buckets.compactMap { bucket in
             guard let date = (bucket["date"] as? String) ?? (bucket["day"] as? String) else { return nil }
-            // USD may be a dollar Double, or a cents Int (same unit as the
-            // balance total). Prefer an explicit dollar field; fall back to a
-            // cents field divided by 100. The exact daily-usage field names
-            // are not documented, so this stays tolerant.
-            let usd: Double
-            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"]) {
-                usd = d
+            // The amount may be a dollar Double, or a cents Int (same unit as
+            // the balance total). Prefer an explicit dollar field; fall back
+            // to a cents field divided by 100. The exact daily-usage field
+            // names are undocumented, so this stays tolerant — and it reads a
+            // currency when one is present rather than assuming USD.
+            let amount: Double
+            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"] ?? bucket["amount"]) {
+                amount = d
             } else if let cents = intOrNil(bucket["cents"] ?? bucket["usd_cents"] ?? bucket["amount_cents"]) {
-                usd = Double(cents) / 100.0
+                amount = Double(cents) / 100.0
             } else {
-                usd = 0
+                amount = 0
             }
-            return XAIDailyUsage(date: date, usdSpent: usd)
+            let currency = (bucket["currency"] as? String)
+                ?? ((bucket["amount"] as? [String: Any])?["currency"] as? String)
+            return XAIDailyUsage(date: date, amountSpent: amount, currency: currency)
         }
     }
 

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -1,0 +1,252 @@
+// PR 6-BE — xAI Developer usage fetcher (two-key, two-host).
+//
+// xAI is the first two-credential provider:
+//   - Tier 1 (mandatory): an INFERENCE key (xai-...). Bootstraps team_id and
+//     the model catalogue from api.x.ai. Gives plan info but no spend.
+//   - Tier 2 (optional): a MANAGEMENT key. Reads the prepaid balance and
+//     daily usage from management-api.x.ai. NB the management key also carries
+//     the `xai-` prefix (it is NOT literally `xai-mgmt-`); it is a distinct
+//     key issued from the console's Management Keys section, not
+//     interchangeable with the inference key. Management keys can create /
+//     rotate / delete API keys, so Tier 2 is gated behind an explicit warning
+//     in the UI (PR 6-UI). Both keys live in the Keychain.
+//
+// Feature posture: features.xai.enabled defaults false; nothing registers a
+// store into the live registry yet (tile + two-key sheet land in PR 6-UI).
+//
+// Hosts and auth (both Bearer):
+//   api.x.ai            — inference key: GET /v1/api-key, GET /v1/language-models
+//   management-api.x.ai — management key: GET  /v1/billing/teams/{team}/prepaid/balance
+//                                          POST /v1/billing/teams/{team}/usage
+//
+// The prepaid-balance `total.val` unit and sign convention are the single
+// riskiest interpretation here (the plan flags a live curl check before
+// ship). To keep that correction cheap, ALL unit/sign logic lives in one
+// documented function, `XAIBalance.remainingUSD`, and the parser stores the
+// raw integer verbatim. See the note there.
+
+import Foundation
+
+// MARK: - Snapshot pieces
+
+/// Result of GET /v1/api-key. Bootstraps the team id used for the management
+/// endpoints, and carries the ACL list used to describe the plan/permissions.
+public struct XAIApiKeyInfo: Equatable, Sendable {
+    public var teamId: String?
+    public var acls: [String]
+    /// Redacted key label for display (never the raw key).
+    public var redactedKey: String?
+    public var name: String?
+
+    public init(teamId: String? = nil, acls: [String] = [], redactedKey: String? = nil, name: String? = nil) {
+        self.teamId = teamId
+        self.acls = acls
+        self.redactedKey = redactedKey
+        self.name = name
+    }
+}
+
+/// One model from GET /v1/language-models.
+public struct XAIModel: Equatable, Sendable {
+    public var id: String
+    /// Prompt (input) price per token, in the unit the endpoint returns
+    /// (xAI uses 1e-10 USD ticks per token for completion pricing). Stored
+    /// verbatim; conversion is the tile's concern, not the fetcher's.
+    public var promptTokenPrice: Int?
+    public var completionTokenPrice: Int?
+
+    public init(id: String, promptTokenPrice: Int? = nil, completionTokenPrice: Int? = nil) {
+        self.id = id
+        self.promptTokenPrice = promptTokenPrice
+        self.completionTokenPrice = completionTokenPrice
+    }
+}
+
+/// Prepaid balance from the management API.
+public struct XAIBalance: Equatable, Sendable {
+    /// The raw `total.val` integer, stored verbatim. Interpretation (unit +
+    /// sign) is deliberately isolated in `remainingUSD` so it can be
+    /// corrected after a live account check without touching the parser.
+    public var totalValRaw: Int
+    /// Currency code if the endpoint returns one (e.g. "USD").
+    public var currency: String?
+
+    public init(totalValRaw: Int, currency: String? = nil) {
+        self.totalValRaw = totalValRaw
+        self.currency = currency
+    }
+
+    /// Convert the raw `total.val` into remaining USD.
+    ///
+    /// UNIT + SIGN — the one place this interpretation lives, verified against
+    /// xAI's management-API OpenAPI schema (the `total` object is documented
+    /// as "Representation of USD Cents"):
+    ///   - Unit: `total.val` is USD CENTS (1/100 USD). Divide by 100 for
+    ///     dollars. NOTE: this is NOT the 1e-10 "tick" unit — that unit
+    ///     applies to per-token MODEL PRICING (lineItem.unitPrice, documented
+    ///     as 1/1_000_000 USD cents), not to the balance total. Getting this
+    ///     wrong is an 8-order-of-magnitude error, so it is isolated here.
+    ///   - Sign: the ledger convention makes credit-adding events negative and
+    ///     spend positive, so `total.val` is NEGATIVE when prepaid credit
+    ///     remains. Remaining credit in cents is `-val`; a zero or positive
+    ///     value means no prepaid credit left (clamp to 0).
+    /// `val` arrives as a string-encoded int64 on the wire; the parser stores
+    /// it as an Int. A live curl check against a paid account can still
+    /// correct this single function if the account data contradicts the docs.
+
+    /// Per-token model pricing is expressed in 1/1_000_000 USD cents
+    /// (micro-cents). Distinct from the balance unit above.
+    public static let modelPriceMicroCentsPerCent = 1_000_000.0
+
+    public var remainingUSD: Double {
+        // Negative val = remaining credit; clamp non-negative val to 0.
+        max(-Double(totalValRaw), 0) / 100.0
+    }
+}
+
+/// One day's usage from the management usage endpoint.
+public struct XAIDailyUsage: Equatable, Sendable {
+    public var date: String   // ISO date (YYYY-MM-DD) as returned
+    public var usdSpent: Double
+
+    public init(date: String, usdSpent: Double) {
+        self.date = date
+        self.usdSpent = usdSpent
+    }
+}
+
+/// Aggregate snapshot. Tier-1 fields are always present when configured;
+/// Tier-2 fields (balance, daily) are nil until a management key is added.
+public struct XAIUsageSnapshot: Equatable, Sendable {
+    public var apiKeyInfo: XAIApiKeyInfo?
+    public var models: [XAIModel]
+    public var balance: XAIBalance?
+    public var daily: [XAIDailyUsage]
+
+    public init(
+        apiKeyInfo: XAIApiKeyInfo? = nil,
+        models: [XAIModel] = [],
+        balance: XAIBalance? = nil,
+        daily: [XAIDailyUsage] = []
+    ) {
+        self.apiKeyInfo = apiKeyInfo
+        self.models = models
+        self.balance = balance
+        self.daily = daily
+    }
+}
+
+public enum XAIUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+// MARK: - Fetcher
+
+public struct XAIUsageFetcher: Sendable {
+
+    public init() {}
+
+    /// Keychain keys for the two credentials.
+    public static let inferenceKeyKeychainKey = "xai.inference_key"
+    public static let managementKeyKeychainKey = "xai.management_key"
+
+    // MARK: Tier 1 parsing
+
+    /// Parse GET /v1/api-key. Tolerant of absent fields; the team_id is the
+    /// one field the management endpoints depend on.
+    public static func parseApiKey(_ data: Data) throws -> XAIApiKeyInfo {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        var info = XAIApiKeyInfo()
+        // xAI has used both "team_id" and "teamId"; accept either.
+        info.teamId = (json["team_id"] as? String) ?? (json["teamId"] as? String)
+        if let acls = json["acls"] as? [String] {
+            info.acls = acls
+        }
+        info.redactedKey = (json["redacted_api_key"] as? String) ?? (json["redactedApiKey"] as? String)
+        info.name = json["name"] as? String
+        return info
+    }
+
+    /// Parse GET /v1/language-models. The models live under a top-level
+    /// "models" or "data" array depending on API version.
+    public static func parseLanguageModels(_ data: Data) throws -> [XAIModel] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        let arr = (json["models"] as? [[String: Any]]) ?? (json["data"] as? [[String: Any]]) ?? []
+        return arr.compactMap { entry in
+            guard let id = entry["id"] as? String else { return nil }
+            return XAIModel(
+                id: id,
+                promptTokenPrice: intOrNil(entry["prompt_text_token_price"] ?? entry["prompt_token_price"]),
+                completionTokenPrice: intOrNil(entry["completion_text_token_price"] ?? entry["completion_token_price"])
+            )
+        }
+    }
+
+    // MARK: Tier 2 parsing
+
+    /// Parse the prepaid balance. Stores `total.val` verbatim; the unit/sign
+    /// interpretation is in XAIBalance.remainingUSD.
+    public static func parseBalance(_ data: Data) throws -> XAIBalance {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        // Balance may be under "total" or at the top level.
+        let total = (json["total"] as? [String: Any]) ?? json
+        guard let val = intOrNil(total["val"]) else {
+            throw XAIUsageParseError.unexpectedShape("balance total.val missing")
+        }
+        let currency = (total["currency"] as? String) ?? (json["currency"] as? String)
+        return XAIBalance(totalValRaw: val, currency: currency)
+    }
+
+    /// Parse the daily-usage response into date/USD points. Tolerant of the
+    /// exact bucket shape: looks for a list of records each carrying a date
+    /// and a USD amount (in ticks or dollars — see note).
+    public static func parseUsage(_ data: Data) throws -> [XAIDailyUsage] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw XAIUsageParseError.invalidJSON
+        }
+        // The daily buckets live under "usage", "data", or "daily".
+        let buckets = (json["usage"] as? [[String: Any]])
+            ?? (json["data"] as? [[String: Any]])
+            ?? (json["daily"] as? [[String: Any]])
+            ?? []
+        return buckets.compactMap { bucket in
+            guard let date = (bucket["date"] as? String) ?? (bucket["day"] as? String) else { return nil }
+            // USD may be a dollar Double, or a cents Int (same unit as the
+            // balance total). Prefer an explicit dollar field; fall back to a
+            // cents field divided by 100. The exact daily-usage field names
+            // are not documented, so this stays tolerant.
+            let usd: Double
+            if let d = doubleOrNil(bucket["usd"] ?? bucket["total_usd"] ?? bucket["amount_usd"]) {
+                usd = d
+            } else if let cents = intOrNil(bucket["cents"] ?? bucket["usd_cents"] ?? bucket["amount_cents"]) {
+                usd = Double(cents) / 100.0
+            } else {
+                usd = 0
+            }
+            return XAIDailyUsage(date: date, usdSpent: usd)
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func intOrNil(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double { return Int(d) }
+        if let s = value as? String { return Int(s) }
+        return nil
+    }
+
+    private static func doubleOrNil(_ value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        if let s = value as? String { return Double(s) }
+        return nil
+    }
+}

--- a/app/XAIUsageFetcher.swift
+++ b/app/XAIUsageFetcher.swift
@@ -246,13 +246,19 @@ public struct XAIUsageFetcher: Sendable {
 
     private static func intOrNil(_ value: Any?) -> Int? {
         if let i = value as? Int { return i }
-        if let d = value as? Double { return Int(d) }
+        // Int(Double) TRAPS on a non-finite or out-of-range value (a hostile
+        // API can send 1e300 as a valid JSON number). Int(exactly:) on the
+        // rounded value is crash-safe: it returns nil rather than trapping.
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
         if let s = value as? String { return Int(s) }
         return nil
     }
 
     private static func doubleOrNil(_ value: Any?) -> Double? {
-        if let d = value as? Double { return d }
+        if let d = value as? Double { return d.isFinite ? d : nil }
         if let i = value as? Int { return Double(i) }
         if let s = value as? String { return Double(s) }
         return nil

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -148,13 +148,20 @@ public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvide
         }
 
         // Tier 2: rolled-up recent spend as a text tile (the small chart is a
-        // UI concern for PR 6-UI; the backend surfaces the total here).
+        // UI concern for PR 6-UI; the backend surfaces the total here). The
+        // amount is shown with its reported currency code rather than a bare
+        // "$" — the daily-usage shape is undocumented and may bill in CNY, so
+        // we do not assume USD. When no currency is reported, show a neutral
+        // amount with no symbol.
         if !snap.daily.isEmpty {
-            let total = snap.daily.reduce(0.0) { $0 + $1.usdSpent }
+            let total = snap.daily.reduce(0.0) { $0 + $1.amountSpent }
+            let currency = snap.daily.compactMap { $0.currency }.first
+            let status = currency.map { String(format: "%@ %.2f", $0, total) }
+                ?? String(format: "%.2f", total)
             out.append(UsageTile(
                 id: "xai-daily-usd",
                 title: "xAI usage (recent)",
-                kind: .text(status: String(format: "$%.2f", total), subtitle: "\(snap.daily.count) days")
+                kind: .text(status: status, subtitle: "\(snap.daily.count) days")
             ))
         }
 

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -1,0 +1,299 @@
+// PR 6-BE — xAI Developer UsageProvider conformer (dark code, flag off).
+//
+// Fifth provider, and the first two-credential one. Tier 1 (inference key)
+// is required and yields plan info; Tier 2 (management key) is optional and
+// yields the prepaid balance + daily usage. Both keys live in the Keychain.
+//
+// Feature posture: features.xai.enabled defaults false; nothing registers a
+// store into the live registry yet (two-key sheet + tiles land in PR 6-UI).
+//
+// Credentials never reach a log line; only HTTP status codes are logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class XAIUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "xai"
+    public let displayName: String = "xAI (Grok)"
+    public let featureFlagKey: String = "features.xai.enabled"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: XAIUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+
+    private let credentials: CredentialStore
+    private let transport: XAIUsageTransport
+    private let defaults: UserDefaults
+
+    public init(
+        credentials: CredentialStore = KeychainStore(),
+        transport: XAIUsageTransport = URLSessionXAITransport(),
+        defaults: UserDefaults = .standard
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.defaults = defaults
+    }
+
+    // MARK: - Credential management
+
+    /// Tier 1 — the inference key (required).
+    public var hasInferenceKey: Bool {
+        !(credentials.read(XAIUsageFetcher.inferenceKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    /// Tier 2 — the management key (optional; unlocks balance + history).
+    public var hasManagementKey: Bool {
+        !(credentials.read(XAIUsageFetcher.managementKeyKeychainKey)?.isEmpty ?? true)
+    }
+
+    public func saveInferenceKey(_ raw: String) {
+        saveOrClear(raw, key: XAIUsageFetcher.inferenceKeyKeychainKey)
+    }
+
+    public func saveManagementKey(_ raw: String) {
+        saveOrClear(raw, key: XAIUsageFetcher.managementKeyKeychainKey)
+    }
+
+    private func saveOrClear(_ raw: String, key: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            credentials.delete(key)
+        } else {
+            credentials.write(key, Data(trimmed.utf8))
+        }
+        objectWillChange.send()
+    }
+
+    private func readKey(_ key: String) -> String? {
+        guard let data = credentials.read(key), !data.isEmpty else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured once the required Tier-1 inference key is present.
+    public var isConfigured: Bool {
+        hasInferenceKey
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        if !isConfigured {
+            return [UsageTile(
+                id: "xai-needs-key",
+                title: "xAI (Grok)",
+                kind: .needsAccess(
+                    path: "api.x.ai",
+                    guidance: "Paste an xAI API key (xai-…) in Settings. Add a management key too for balance and usage history."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan / permissions tile from the ACLs.
+        if let info = snap.apiKeyInfo {
+            let acls = info.acls.isEmpty ? "API access" : info.acls.joined(separator: ", ")
+            out.append(UsageTile(
+                id: "xai-plan",
+                title: "xAI API key",
+                kind: .text(status: info.redactedKey ?? "Configured", subtitle: acls)
+            ))
+        }
+
+        // Tier 2: prepaid balance. Only when a management key produced one.
+        if let balance = snap.balance {
+            let currency = balance.currency ?? "USD"
+            // remainingUSD encapsulates the tick unit + credit sign; convert
+            // to minor units for the balance tile.
+            let minorUnits = Int((balance.remainingUSD * 100).rounded())
+            out.append(UsageTile(
+                id: "xai-balance",
+                title: "xAI prepaid balance",
+                kind: .balance(remainingMinorUnits: minorUnits, currency: currency, plan: nil, resetsAt: nil)
+            ))
+        }
+
+        // Tier 2: rolled-up recent spend as a text tile (the small chart is a
+        // UI concern for PR 6-UI; the backend surfaces the total here).
+        if !snap.daily.isEmpty {
+            let total = snap.daily.reduce(0.0) { $0 + $1.usdSpent }
+            out.append(UsageTile(
+                id: "xai-daily-usd",
+                title: "xAI usage (recent)",
+                kind: .text(status: String(format: "$%.2f", total), subtitle: "\(snap.daily.count) days")
+            ))
+        }
+
+        return out
+    }
+
+    // MARK: - Result application (testable seam)
+
+    /// The transport gathers all endpoints and hands back a combined result
+    /// so the store applies one snapshot. Extracted for synchronous testing.
+    public func apply(_ result: XAIUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let snap):
+            self.snapshot = snap
+            self.lastUpdatedAt = now
+            self.lastError = nil
+        case .unauthorized:
+            self.lastError = "Invalid xAI API key"
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+        guard let inference = readKey(XAIUsageFetcher.inferenceKeyKeychainKey) else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+        // Tier 2 is optional — pass the management key only if present.
+        let management = readKey(XAIUsageFetcher.managementKeyKeychainKey)
+
+        transport.fetchAll(inferenceKey: inference, managementKey: management) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Clears BOTH keys (the user pasted them here) and the state.
+        credentials.delete(XAIUsageFetcher.inferenceKeyKeychainKey)
+        credentials.delete(XAIUsageFetcher.managementKeyKeychainKey)
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum XAIUsageResult: Sendable {
+    case success(XAIUsageSnapshot)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+/// Seam over the multi-endpoint fetch. The completion MUST be on the main
+/// queue.
+public protocol XAIUsageTransport: Sendable {
+    func fetchAll(
+        inferenceKey: String,
+        managementKey: String?,
+        completion: @escaping @Sendable (XAIUsageResult) -> Void
+    )
+}
+
+/// Production transport. Chains: api-key -> language-models (Tier 1), then if
+/// a management key + team id are present, prepaid/balance + usage (Tier 2).
+/// Response bodies are never logged; only status codes.
+public struct URLSessionXAITransport: XAIUsageTransport {
+    private let apiHost = "https://api.x.ai"
+    private let mgmtHost = "https://management-api.x.ai"
+
+    public init() {}
+
+    public func fetchAll(
+        inferenceKey: String,
+        managementKey: String?,
+        completion: @escaping @Sendable (XAIUsageResult) -> Void
+    ) {
+        let deliver: @Sendable (XAIUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Tier 1: GET /v1/api-key
+        get("\(apiHost)/v1/api-key", bearer: inferenceKey) { data, status in
+            guard status == 200, let data = data,
+                  let info = try? XAIUsageFetcher.parseApiKey(data) else {
+                deliver(status == 401 || status == 403 ? .unauthorized
+                        : (status == nil ? .networkError : .httpError(status!)))
+                return
+            }
+
+            // Tier 1: GET /v1/language-models. Build the snapshot immutably,
+            // passing accumulated pieces forward into each nested closure
+            // rather than mutating a captured var (which would not be
+            // Sendable-safe across the async completion boundaries).
+            self.get("\(self.apiHost)/v1/language-models", bearer: inferenceKey) { modelData, _ in
+                let models: [XAIModel] = modelData.flatMap { try? XAIUsageFetcher.parseLanguageModels($0) } ?? []
+                let tier1 = XAIUsageSnapshot(apiKeyInfo: info, models: models)
+
+                // Tier 2 (optional): balance + usage, only with a management
+                // key and a bootstrapped team id.
+                guard let mgmt = managementKey, let team = info.teamId else {
+                    deliver(.success(tier1))
+                    return
+                }
+
+                self.get("\(self.mgmtHost)/v1/billing/teams/\(team)/prepaid/balance", bearer: mgmt) { balData, _ in
+                    let balance: XAIBalance? = balData.flatMap { try? XAIUsageFetcher.parseBalance($0) }
+                    self.post("\(self.mgmtHost)/v1/billing/teams/\(team)/usage", bearer: mgmt) { usageData, _ in
+                        let daily: [XAIDailyUsage] = usageData.flatMap { try? XAIUsageFetcher.parseUsage($0) } ?? []
+                        let full = XAIUsageSnapshot(apiKeyInfo: info, models: models, balance: balance, daily: daily)
+                        deliver(.success(full))
+                    }
+                }
+            }
+        }
+    }
+
+    private func get(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        request(urlString, method: "GET", bearer: bearer, body: nil, done: done)
+    }
+
+    private func post(_ urlString: String, bearer: String, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        // Empty JSON body; the usage endpoint accepts a default date range.
+        request(urlString, method: "POST", bearer: bearer, body: Data("{}".utf8), done: done)
+    }
+
+    private func request(_ urlString: String, method: String, bearer: String, body: Data?, done: @escaping @Sendable (Data?, Int?) -> Void) {
+        guard let url = URL(string: urlString) else { done(nil, nil); return }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+        if let body = body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if error != nil { done(nil, nil); return }
+            let status = (response as? HTTPURLResponse)?.statusCode
+            Log.info("xAI API response", .count(status ?? -1))
+            done(data, status)
+        }.resume()
+    }
+}

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -49,14 +49,25 @@ public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvide
 
     // MARK: - Credential management
 
+    /// True when a credential is stored, treating an unreadable (locked)
+    /// keychain as "still configured" so a locked screen does not drop the
+    /// provider back to onboarding.
+    private func hasStoredKey(_ keychainKey: String) -> Bool {
+        switch credentials.readResult(keychainKey) {
+        case .found(let data): return !data.isEmpty
+        case .unavailable:     return true
+        case .missing:         return false
+        }
+    }
+
     /// Tier 1 — the inference key (required).
     public var hasInferenceKey: Bool {
-        !(credentials.read(XAIUsageFetcher.inferenceKeyKeychainKey)?.isEmpty ?? true)
+        hasStoredKey(XAIUsageFetcher.inferenceKeyKeychainKey)
     }
 
     /// Tier 2 — the management key (optional; unlocks balance + history).
     public var hasManagementKey: Bool {
-        !(credentials.read(XAIUsageFetcher.managementKeyKeychainKey)?.isEmpty ?? true)
+        hasStoredKey(XAIUsageFetcher.managementKeyKeychainKey)
     }
 
     public func saveInferenceKey(_ raw: String) {
@@ -200,10 +211,9 @@ public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvide
         let management = readKey(XAIUsageFetcher.managementKeyKeychainKey)
 
         transport.fetchAll(inferenceKey: inference, managementKey: management) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 
@@ -272,8 +282,12 @@ public struct URLSessionXAITransport: XAIUsageTransport {
                 let tier1 = XAIUsageSnapshot(apiKeyInfo: info, models: models)
 
                 // Tier 2 (optional): balance + usage, only with a management
-                // key and a bootstrapped team id.
-                guard let mgmt = managementKey, let team = info.teamId else {
+                // key and a bootstrapped team id. The team id comes from the
+                // api-key response (semi-trusted), so it is percent-encoded as
+                // a single path segment — an id containing "/" or "?" cannot
+                // alter the request path.
+                guard let mgmt = managementKey, let rawTeam = info.teamId,
+                      let team = RequestSafety.pathSegment(rawTeam) else {
                     deliver(.success(tier1))
                     return
                 }

--- a/app/XAIUsageStore.swift
+++ b/app/XAIUsageStore.swift
@@ -14,11 +14,18 @@ import SwiftUI
 import Combine
 
 @MainActor
-public final class XAIUsageStore: @preconcurrency UsageProvider {
+public final class XAIUsageStore: @preconcurrency UsageProvider, PasteKeyProvider, SecondaryKeyProvider {
 
     public let id: String = "xai"
     public let displayName: String = "xAI (Grok)"
     public let featureFlagKey: String = "features.xai.enabled"
+
+    // PasteKeyProvider — the required Tier-1 inference key.
+    public let keyPlaceholder: String = "xai-… (inference key)"
+    // SecondaryKeyProvider — the optional, spending-capable management key.
+    public let secondaryKeyPlaceholder: String = "xai-… (management key)"
+    public let secondaryKeyLabel: String = "Enable balance + usage history (needs a management key)"
+    public let secondaryKeyWarning: String = "A management key can create, rotate, and delete your xAI API keys. Only paste one if you understand that. It is stored in your Keychain and used only to read billing."
 
     // MARK: Observable state
 
@@ -59,6 +66,14 @@ public final class XAIUsageStore: @preconcurrency UsageProvider {
     public func saveManagementKey(_ raw: String) {
         saveOrClear(raw, key: XAIUsageFetcher.managementKeyKeychainKey)
     }
+
+    // PasteKeyProvider conformance (primary = inference key).
+    public var hasKey: Bool { hasInferenceKey }
+    public func saveKey(_ raw: String) { saveInferenceKey(raw) }
+
+    // SecondaryKeyProvider conformance (secondary = management key).
+    public var hasSecondaryKey: Bool { hasManagementKey }
+    public func saveSecondaryKey(_ raw: String) { saveManagementKey(raw) }
 
     private func saveOrClear(_ raw: String, key: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/app/ZedUsageFetcher.swift
+++ b/app/ZedUsageFetcher.swift
@@ -79,9 +79,16 @@ public struct ZedCredentials: Equatable, Sendable {
     }
 
     /// The Authorization header value Zed's client uses: user id and token
-    /// separated by a single space (not the Bearer scheme).
-    public var authorizationHeaderValue: String {
-        "\(userId) \(accessToken)"
+    /// separated by a single space (not the Bearer scheme). Returns nil if
+    /// either component contains a control character (CR/LF/etc.) that could
+    /// split or inject an HTTP header — the values come from Zed's Keychain
+    /// item, which we do not control, so they are validated before use.
+    public var authorizationHeaderValue: String? {
+        guard let uid = RequestSafety.headerValue(userId),
+              let tok = RequestSafety.headerValue(accessToken) else {
+            return nil
+        }
+        return "\(uid) \(tok)"
     }
 }
 
@@ -161,8 +168,8 @@ public struct ZedUsageFetcher: Sendable {
             var ep = ZedEditPredictionUsage()
             if let used = edit["used"] as? Int {
                 ep.used = used
-            } else if let used = edit["used"] as? Double {
-                ep.used = Int(used)
+            } else if let used = safeInt(edit["used"]) {
+                ep.used = used
             }
             // limit is Zed's UsageLimit enum, whose wire encoding is
             // non-obvious: Limited(N) serializes as the OBJECT {"limited": N},
@@ -190,7 +197,7 @@ public struct ZedUsageFetcher: Sendable {
     public static func parseUsageLimit(_ value: Any?) -> Int? {
         if let obj = value as? [String: Any] {
             if let n = obj["limited"] as? Int { return n }
-            if let n = obj["limited"] as? Double { return Int(n) }
+            if let n = safeInt(obj["limited"]) { return n }
             return nil
         }
         if let s = value as? String {
@@ -199,7 +206,18 @@ public struct ZedUsageFetcher: Sendable {
             return Int(s)
         }
         if let n = value as? Int { return n }
-        if let n = value as? Double { return Int(n) }
+        return safeInt(value)
+    }
+
+    /// Convert a value that may be a Double to Int WITHOUT trapping. Int(d)
+    /// crashes on a non-finite or out-of-range Double, which a hostile API
+    /// could send (e.g. 1e300 as valid JSON); Int(exactly:) returns nil.
+    static func safeInt(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let d = value as? Double {
+            guard d.isFinite else { return nil }
+            return Int(exactly: d.rounded())
+        }
         return nil
     }
 
@@ -214,7 +232,10 @@ public struct ZedUsageFetcher: Sendable {
             return iso.date(from: s)
         }
         if let epoch = value as? Int { return Date(timeIntervalSince1970: TimeInterval(epoch)) }
-        if let epoch = value as? Double { return Date(timeIntervalSince1970: epoch) }
+        // A non-finite epoch Double would produce an invalid Date; guard it.
+        if let epoch = value as? Double, epoch.isFinite {
+            return Date(timeIntervalSince1970: epoch)
+        }
         return nil
     }
 }

--- a/app/ZedUsageFetcher.swift
+++ b/app/ZedUsageFetcher.swift
@@ -1,0 +1,220 @@
+// PR 5-BE — Zed usage fetcher + reader for Zed's own Keychain credential.
+//
+// Zed differs from every prior provider: it holds no credential of its own.
+// It reads the access token Zed itself already stored in the login Keychain
+// (an internet-password item for server "zed.dev"), then calls Zed's client
+// API for the current user's plan and edit-prediction usage.
+//
+// The first Keychain read triggers a macOS SecurityAgent prompt ("ClaudeUsage
+// Bar wants to use the zed.dev password"); the user must allow it once. We
+// never write to Zed's Keychain item.
+//
+// Auth is unusual: the Authorization header value is "{user_id} {access_token}"
+// — the user id and token separated by a SPACE, NOT the "Bearer" scheme.
+//
+// Data source: GET https://cloud.zed.dev/client/users/me
+//
+// Response shape (the plan object the tiles consume) is built against Zed's
+// open-source client structs. Fields the parser reads:
+//   plan.plan_v3                              String enum (zed_free, zed_pro, …)
+//   plan.usage.edit_predictions.used / .limit Int
+//   plan.subscription_period.ended_at         reset time
+//   plan.has_overdue_invoices                 Bool
+//   plan.is_account_too_young                 Bool
+// Every field is treated as optional and tolerated when absent — this is an
+// undocumented internal API and the shape can drift.
+
+import Foundation
+import Security
+
+// MARK: - Snapshot
+
+/// Edit-prediction usage from `plan.usage.edit_predictions`.
+public struct ZedEditPredictionUsage: Equatable, Sendable {
+    public var used: Int
+    /// Nil means unlimited (Pro plans have no edit-prediction cap).
+    public var limit: Int?
+
+    public init(used: Int = 0, limit: Int? = nil) {
+        self.used = used
+        self.limit = limit
+    }
+}
+
+/// A parsed snapshot of the Zed `users/me` plan block.
+public struct ZedUsageSnapshot: Equatable, Sendable {
+    /// Raw plan identifier, e.g. "zed_free", "zed_pro". Rendered via a
+    /// friendly label in the tile.
+    public var planV3: String?
+    public var editPredictions: ZedEditPredictionUsage?
+    /// End of the current subscription/usage period — the edit-prediction
+    /// reset time.
+    public var periodEndsAt: Date?
+    public var hasOverdueInvoices: Bool
+    public var isAccountTooYoung: Bool
+
+    public init(
+        planV3: String? = nil,
+        editPredictions: ZedEditPredictionUsage? = nil,
+        periodEndsAt: Date? = nil,
+        hasOverdueInvoices: Bool = false,
+        isAccountTooYoung: Bool = false
+    ) {
+        self.planV3 = planV3
+        self.editPredictions = editPredictions
+        self.periodEndsAt = periodEndsAt
+        self.hasOverdueInvoices = hasOverdueInvoices
+        self.isAccountTooYoung = isAccountTooYoung
+    }
+}
+
+/// Credentials read from Zed's own Keychain item.
+public struct ZedCredentials: Equatable, Sendable {
+    public let userId: String
+    public let accessToken: String
+
+    public init(userId: String, accessToken: String) {
+        self.userId = userId
+        self.accessToken = accessToken
+    }
+
+    /// The Authorization header value Zed's client uses: user id and token
+    /// separated by a single space (not the Bearer scheme).
+    public var authorizationHeaderValue: String {
+        "\(userId) \(accessToken)"
+    }
+}
+
+public enum ZedUsageParseError: Error, Equatable {
+    case invalidJSON
+    case unexpectedShape(String)
+}
+
+public enum ZedAuthError: Error, Equatable {
+    /// No zed.dev item in the Keychain (Zed not logged in, or the user
+    /// denied the SecurityAgent prompt).
+    case keychainItemMissing
+    /// The item exists but lacks a usable account (user id) or token.
+    case keychainItemIncomplete
+}
+
+// MARK: - Fetcher
+
+public struct ZedUsageFetcher: Sendable {
+
+    public init() {}
+
+    // MARK: Keychain read (Zed's own internet-password item)
+
+    /// Read Zed's access token from the login Keychain. Zed stores it as an
+    /// internet-password item for server "zed.dev"; the item's account is the
+    /// user id and its data is the access token. We match by server only
+    /// (the user id is not known in advance) and read both attributes back.
+    ///
+    /// The `server` is injectable so tests do not touch the real Keychain.
+    public static func readCredentials(server: String = "zed.dev") throws -> ZedCredentials {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassInternetPassword,
+            kSecAttrServer as String: server,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess else {
+            throw ZedAuthError.keychainItemMissing
+        }
+        guard let dict = item as? [String: Any],
+              let account = dict[kSecAttrAccount as String] as? String, !account.isEmpty,
+              let data = dict[kSecValueData as String] as? Data,
+              let token = String(data: data, encoding: .utf8), !token.isEmpty
+        else {
+            throw ZedAuthError.keychainItemIncomplete
+        }
+        return ZedCredentials(userId: account, accessToken: token)
+    }
+
+    // MARK: Pure parsing (this is what the fixtures hit)
+
+    /// Parse the JSON body of `users/me`. The plan block may be nested under
+    /// a top-level "plan" key, or the whole response may itself be the plan
+    /// block depending on Zed's version — accept both by preferring a "plan"
+    /// object when present and falling back to the top level.
+    public static func parse(_ data: Data) throws -> ZedUsageSnapshot {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ZedUsageParseError.invalidJSON
+        }
+
+        // Prefer an explicit "plan" object; otherwise treat the root as the
+        // plan block (tolerant of both documented layouts).
+        let plan = (root["plan"] as? [String: Any]) ?? root
+
+        var snap = ZedUsageSnapshot()
+        snap.planV3 = plan["plan_v3"] as? String
+        snap.hasOverdueInvoices = (plan["has_overdue_invoices"] as? Bool) ?? false
+        snap.isAccountTooYoung = (plan["is_account_too_young"] as? Bool) ?? false
+
+        if let usage = plan["usage"] as? [String: Any],
+           let edit = usage["edit_predictions"] as? [String: Any] {
+            var ep = ZedEditPredictionUsage()
+            if let used = edit["used"] as? Int {
+                ep.used = used
+            } else if let used = edit["used"] as? Double {
+                ep.used = Int(used)
+            }
+            // limit is Zed's UsageLimit enum, whose wire encoding is
+            // non-obvious: Limited(N) serializes as the OBJECT {"limited": N},
+            // and Unlimited serializes as the bare STRING "unlimited". A plain
+            // integer is NOT what this endpoint returns. Map both: an object
+            // with "limited" -> that number; "unlimited" (or absent) -> nil
+            // (unlimited). Accept a bare number too, defensively.
+            ep.limit = Self.parseUsageLimit(edit["limit"])
+            snap.editPredictions = ep
+        }
+
+        if let period = plan["subscription_period"] as? [String: Any] {
+            snap.periodEndsAt = parseDate(period["ended_at"])
+        }
+
+        return snap
+    }
+
+    /// Parse Zed's `UsageLimit` from `usage.edit_predictions.limit`. The wire
+    /// encoding is a serde externally-tagged enum:
+    ///   Limited(i32) -> {"limited": N}   (an OBJECT)
+    ///   Unlimited    -> "unlimited"       (a bare STRING)
+    /// Returns the numeric cap for Limited, or nil for Unlimited / absent /
+    /// unrecognised. Also accepts a bare number defensively.
+    public static func parseUsageLimit(_ value: Any?) -> Int? {
+        if let obj = value as? [String: Any] {
+            if let n = obj["limited"] as? Int { return n }
+            if let n = obj["limited"] as? Double { return Int(n) }
+            return nil
+        }
+        if let s = value as? String {
+            // "unlimited" -> nil. A numeric string (header-style) -> its value.
+            if s == "unlimited" { return nil }
+            return Int(s)
+        }
+        if let n = value as? Int { return n }
+        if let n = value as? Double { return Int(n) }
+        return nil
+    }
+
+    /// Parse a reset timestamp that may be an ISO-8601 string or a Unix epoch
+    /// integer, tolerating both since the wire format is not guaranteed.
+    private static func parseDate(_ value: Any?) -> Date? {
+        if let s = value as? String {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            return iso.date(from: s)
+        }
+        if let epoch = value as? Int { return Date(timeIntervalSince1970: TimeInterval(epoch)) }
+        if let epoch = value as? Double { return Date(timeIntervalSince1970: epoch) }
+        return nil
+    }
+}

--- a/app/ZedUsageStore.swift
+++ b/app/ZedUsageStore.swift
@@ -184,10 +184,9 @@ public final class ZedUsageStore: @preconcurrency UsageProvider {
         }
 
         transport.fetchUser(credentials: creds) { [weak self] result in
-            guard let self else { return }
-            MainActor.assumeIsolated {
-                self.apply(result)
-            }
+            // Task { @MainActor } is safe on any delivery queue (cannot trap
+            // like assumeIsolated if a transport calls back off-main).
+            Task { @MainActor [weak self] in self?.apply(result) }
         }
     }
 
@@ -227,17 +226,26 @@ public struct URLSessionZedTransport: ZedUsageTransport {
         credentials: ZedCredentials,
         completion: @escaping @Sendable (ZedUsageResult) -> Void
     ) {
+        let deliver: @Sendable (ZedUsageResult) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        // Zed's client auth: "{user_id} {access_token}", NOT Bearer. The value
+        // is validated (no control chars) before use; if the Keychain item is
+        // malformed, treat it as unauthorized rather than sending a header
+        // that could be split/injected.
+        guard let authValue = credentials.authorizationHeaderValue else {
+            deliver(.unauthorized)
+            return
+        }
+
         var request = URLRequest(url: usersMeURL)
         request.httpMethod = "GET"
-        // Zed's client auth: "{user_id} {access_token}", NOT Bearer.
-        request.setValue(credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+        request.setValue(authValue, forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
 
         URLSession.shared.dataTask(with: request) { data, response, error in
-            let deliver: (ZedUsageResult) -> Void = { result in
-                DispatchQueue.main.async { completion(result) }
-            }
 
             if error != nil {
                 deliver(.networkError)

--- a/app/ZedUsageStore.swift
+++ b/app/ZedUsageStore.swift
@@ -1,0 +1,267 @@
+// PR 5-BE — Zed UsageProvider conformer (dark code, feature-flag off).
+//
+// Fourth provider. Zed is the read-from-the-app's-own-Keychain template: it
+// holds no credential of its own, reading the token Zed itself stored. The
+// first read triggers a macOS SecurityAgent prompt the user must allow once.
+//
+// Feature posture: features.zed.enabled defaults false; nothing registers a
+// ZedUsageStore into the live registry yet (tile + toggle land in PR 5-UI).
+//
+// Auth: the Authorization header is "{user_id} {access_token}" — space
+// delimited, NOT Bearer. Credentials never reach a log line; only the HTTP
+// status code is logged.
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+public final class ZedUsageStore: @preconcurrency UsageProvider {
+
+    public let id: String = "zed"
+    public let displayName: String = "Zed"
+    public let featureFlagKey: String = "features.zed.enabled"
+
+    // MARK: Observable state
+
+    @Published public private(set) var snapshot: ZedUsageSnapshot?
+    @Published public private(set) var lastUpdatedAt: Date?
+    @Published public private(set) var lastError: String?
+    /// True when Zed's Keychain item was readable on the last attempt.
+    @Published public private(set) var hasKeychainAccess: Bool = false
+
+    private let transport: ZedUsageTransport
+    private let defaults: UserDefaults
+    // Injected so tests can supply credentials without touching the real
+    // Keychain. Production reads Zed's own item.
+    private let credentialReader: @Sendable () -> Result<ZedCredentials, Error>
+
+    public init(
+        transport: ZedUsageTransport = URLSessionZedTransport(),
+        defaults: UserDefaults = .standard,
+        credentialReader: @escaping @Sendable () -> Result<ZedCredentials, Error> = {
+            Result { try ZedUsageFetcher.readCredentials() }
+        }
+    ) {
+        self.transport = transport
+        self.defaults = defaults
+        self.credentialReader = credentialReader
+    }
+
+    // MARK: - UsageProvider: feature flag
+
+    public var isEnabled: Bool {
+        defaults.bool(forKey: featureFlagKey)
+    }
+
+    /// Configured means Zed's Keychain item is readable. Probing it here
+    /// would trigger the SecurityAgent prompt on every access, so we report
+    /// the result of the last fetch attempt instead of probing eagerly.
+    public var isConfigured: Bool {
+        hasKeychainAccess
+    }
+
+    public var lastUpdated: Date? { lastUpdatedAt }
+
+    public var errorMessage: String? { lastError }
+
+    // MARK: - UsageProvider: tiles
+
+    public var tiles: [UsageTile] {
+        guard isEnabled else { return [] }
+
+        // Before the first successful Keychain read, show an onboarding card
+        // explaining the one-time prompt.
+        if !hasKeychainAccess && snapshot == nil {
+            return [UsageTile(
+                id: "zed-needs-access",
+                title: "Zed",
+                kind: .needsAccess(
+                    path: "zed.dev (Keychain)",
+                    guidance: "Sign in to Zed, then click Refresh. macOS will ask once to let this app read Zed's saved login."
+                )
+            )]
+        }
+
+        guard let snap = snapshot else { return [] }
+
+        var out: [UsageTile] = []
+
+        // Plan tile — friendly label for the raw plan_v3 identifier.
+        out.append(UsageTile(
+            id: "zed-plan",
+            title: "Zed plan",
+            kind: .text(status: Self.planLabel(snap.planV3), subtitle: nil)
+        ))
+
+        // Edit-predictions counter. Shown when the plan reports the bucket.
+        if let ep = snap.editPredictions {
+            out.append(UsageTile(
+                id: "zed-edit-predictions",
+                title: "Edit predictions",
+                kind: .counter(
+                    used: ep.used,
+                    limit: ep.limit,          // nil renders as unlimited
+                    resetsAt: snap.periodEndsAt
+                )
+            ))
+        }
+
+        // Billing warning — only when there is a problem, so healthy accounts
+        // stay uncluttered.
+        if snap.hasOverdueInvoices || snap.isAccountTooYoung {
+            let reason = snap.hasOverdueInvoices
+                ? "You have overdue invoices on your Zed account."
+                : "Your Zed account is too new for this feature yet."
+            out.append(UsageTile(
+                id: "zed-billing",
+                title: "Zed billing",
+                kind: .text(status: "Attention needed", subtitle: reason)
+            ))
+        }
+
+        return out
+    }
+
+    /// Map Zed's raw plan_v3 identifier to a human label. Unknown values are
+    /// shown verbatim so a new plan tier is never hidden.
+    public static func planLabel(_ planV3: String?) -> String {
+        // plan_v3 values from Zed source (cloud_api_types Plan enum):
+        // zed_free, zed_pro, zed_pro_trial, zed_business, zed_vip, zed_student.
+        switch planV3 {
+        case "zed_free":       return "Free"
+        case "zed_pro":        return "Pro"
+        case "zed_pro_trial":  return "Pro (trial)"
+        case "zed_business":   return "Business"
+        case "zed_vip":        return "VIP"
+        case "zed_student":    return "Student"
+        case .some(let other): return other
+        case .none:            return "Unknown"
+        }
+    }
+
+    // MARK: - Result application (testable seam)
+
+    public func apply(_ result: ZedUsageResult, now: Date = Date()) {
+        switch result {
+        case .success(let data):
+            do {
+                let snap = try ZedUsageFetcher.parse(data)
+                self.snapshot = snap
+                self.lastUpdatedAt = now
+                self.lastError = nil
+            } catch {
+                self.lastError = "Could not parse Zed usage"
+            }
+        case .unauthorized:
+            // Zed's stored token was rejected — the user must re-sign-in to
+            // Zed itself; we cannot refresh it.
+            self.lastError = "Zed session expired — sign in again in Zed."
+        case .httpError(let code):
+            self.lastError = "HTTP \(code)"
+        case .networkError:
+            self.lastError = "Network error"
+        }
+    }
+
+    // MARK: - UsageProvider: actions
+
+    public func fetch() {
+        guard isEnabled else { return }
+
+        let creds: ZedCredentials
+        switch credentialReader() {
+        case .success(let c):
+            creds = c
+            hasKeychainAccess = true
+        case .failure:
+            // Keychain item missing or the prompt was denied. Leave the
+            // onboarding card up; not an error state.
+            hasKeychainAccess = false
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        transport.fetchUser(credentials: creds) { [weak self] result in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.apply(result)
+            }
+        }
+    }
+
+    public func clear() {
+        // Zed's Keychain item belongs to Zed, not to us — never delete it.
+        // Clearing only drops our in-memory state and the access flag.
+        snapshot = nil
+        lastUpdatedAt = nil
+        lastError = nil
+        hasKeychainAccess = false
+    }
+}
+
+// MARK: - Transport abstraction
+
+public enum ZedUsageResult: Sendable {
+    case success(Data)
+    case unauthorized
+    case httpError(Int)
+    case networkError
+}
+
+public protocol ZedUsageTransport: Sendable {
+    func fetchUser(
+        credentials: ZedCredentials,
+        completion: @escaping @Sendable (ZedUsageResult) -> Void
+    )
+}
+
+/// Production transport. Note the space-delimited Authorization value.
+public struct URLSessionZedTransport: ZedUsageTransport {
+    private let usersMeURL = URL(string: "https://cloud.zed.dev/client/users/me")!
+
+    public init() {}
+
+    public func fetchUser(
+        credentials: ZedCredentials,
+        completion: @escaping @Sendable (ZedUsageResult) -> Void
+    ) {
+        var request = URLRequest(url: usersMeURL)
+        request.httpMethod = "GET"
+        // Zed's client auth: "{user_id} {access_token}", NOT Bearer.
+        request.setValue(credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeUsageBar", forHTTPHeaderField: "User-Agent")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let deliver: (ZedUsageResult) -> Void = { result in
+                DispatchQueue.main.async { completion(result) }
+            }
+
+            if error != nil {
+                deliver(.networkError)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                deliver(.networkError)
+                return
+            }
+
+            Log.info("Zed users/me API response", .count(http.statusCode))
+
+            switch http.statusCode {
+            case 200:
+                if let data = data {
+                    deliver(.success(data))
+                } else {
+                    deliver(.networkError)
+                }
+            case 401, 403:
+                deliver(.unauthorized)
+            default:
+                deliver(.httpError(http.statusCode))
+            }
+        }.resume()
+    }
+}

--- a/app/build.sh
+++ b/app/build.sh
@@ -57,6 +57,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     OpenAIUsageStore.swift \
     PerplexityUsageFetcher.swift \
     PerplexityUsageStore.swift \
+    CopilotUsageFetcher.swift \
+    CopilotUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -81,6 +83,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     OpenAIUsageStore.swift \
     PerplexityUsageFetcher.swift \
     PerplexityUsageStore.swift \
+    CopilotUsageFetcher.swift \
+    CopilotUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -51,6 +51,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     DeepSeekUsageStore.swift \
     ZedUsageFetcher.swift \
     ZedUsageStore.swift \
+    XAIUsageFetcher.swift \
+    XAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -69,6 +71,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     DeepSeekUsageStore.swift \
     ZedUsageFetcher.swift \
     ZedUsageStore.swift \
+    XAIUsageFetcher.swift \
+    XAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -47,6 +47,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     AnthropicUsageStore.swift \
     CodexUsageFetcher.swift \
     CodexUsageStore.swift \
+    DeepSeekUsageFetcher.swift \
+    DeepSeekUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -61,6 +63,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     AnthropicUsageStore.swift \
     CodexUsageFetcher.swift \
     CodexUsageStore.swift \
+    DeepSeekUsageFetcher.swift \
+    DeepSeekUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -59,6 +59,9 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     PerplexityUsageStore.swift \
     CopilotUsageFetcher.swift \
     CopilotUsageStore.swift \
+    FileWatcher.swift \
+    SQLiteReader.swift \
+    TCCState.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -85,6 +88,9 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     PerplexityUsageStore.swift \
     CopilotUsageFetcher.swift \
     CopilotUsageStore.swift \
+    FileWatcher.swift \
+    SQLiteReader.swift \
+    TCCState.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -53,6 +53,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ZedUsageStore.swift \
     XAIUsageFetcher.swift \
     XAIUsageStore.swift \
+    OpenAIUsageFetcher.swift \
+    OpenAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -73,6 +75,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ZedUsageStore.swift \
     XAIUsageFetcher.swift \
     XAIUsageStore.swift \
+    OpenAIUsageFetcher.swift \
+    OpenAIUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -34,15 +34,19 @@ if [ -f "ClaudeUsageBar.icns" ]; then
 fi
 
 # Compile the Swift app for arm64.
-# Log.swift and AnthropicUsageFetcher.swift are compiled alongside
-# ClaudeUsageBar.swift; see the header comments in those files for why
-# the SwiftPM library boundary is drawn where it is.
+# Log.swift, AnthropicUsageFetcher.swift, UsageProvider.swift, and the
+# Codex provider files are compiled alongside ClaudeUsageBar.swift; see the
+# header comments in those files for why the SwiftPM library boundary is
+# drawn where it is. AnthropicUsageStore stays app-only (needs UsageManager);
+# the Codex files are also in the SwiftPM library for unit testing.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
     UsageProvider.swift \
     AnthropicUsageStore.swift \
+    CodexUsageFetcher.swift \
+    CodexUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -55,6 +59,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     AnthropicUsageFetcher.swift \
     UsageProvider.swift \
     AnthropicUsageStore.swift \
+    CodexUsageFetcher.swift \
+    CodexUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -34,11 +34,13 @@ if [ -f "ClaudeUsageBar.icns" ]; then
 fi
 
 # Compile the Swift app for arm64.
-# Log.swift is compiled alongside ClaudeUsageBar.swift; see the header
-# comment in Log.swift for why the split exists.
+# Log.swift and AnthropicUsageFetcher.swift are compiled alongside
+# ClaudeUsageBar.swift; see the header comments in those files for why
+# the SwiftPM library boundary is drawn where it is.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
+    AnthropicUsageFetcher.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -48,6 +50,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
     Log.swift \
+    AnthropicUsageFetcher.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -49,6 +49,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     CodexUsageStore.swift \
     DeepSeekUsageFetcher.swift \
     DeepSeekUsageStore.swift \
+    ZedUsageFetcher.swift \
+    ZedUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -65,6 +67,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     CodexUsageStore.swift \
     DeepSeekUsageFetcher.swift \
     DeepSeekUsageStore.swift \
+    ZedUsageFetcher.swift \
+    ZedUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -33,9 +33,12 @@ if [ -f "ClaudeUsageBar.icns" ]; then
     /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile ClaudeUsageBar" "$APP_PATH/Contents/Info.plist"
 fi
 
-# Compile the Swift app for arm64
+# Compile the Swift app for arm64.
+# Log.swift is compiled alongside ClaudeUsageBar.swift; see the header
+# comment in Log.swift for why the split exists.
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
+    Log.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -44,6 +47,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 # Compile for x86_64 (Intel)
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
+    Log.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -41,6 +41,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
+    UsageProvider.swift \
+    AnthropicUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -51,6 +53,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeUsageBar.swift \
     Log.swift \
     AnthropicUsageFetcher.swift \
+    UsageProvider.swift \
+    AnthropicUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -62,6 +62,9 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     FileWatcher.swift \
     SQLiteReader.swift \
     TCCState.swift \
+    ClaudeCodePricing.swift \
+    ClaudeCodeUsageFetcher.swift \
+    ClaudeCodeUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -91,6 +94,9 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     FileWatcher.swift \
     SQLiteReader.swift \
     TCCState.swift \
+    ClaudeCodePricing.swift \
+    ClaudeCodeUsageFetcher.swift \
+    ClaudeCodeUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -67,6 +67,10 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeCodeUsageStore.swift \
     ClineUsageFetcher.swift \
     ClineUsageStore.swift \
+    WindsurfUsageFetcher.swift \
+    WindsurfUsageStore.swift \
+    CursorUsageFetcher.swift \
+    CursorUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -101,6 +105,10 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeCodeUsageStore.swift \
     ClineUsageFetcher.swift \
     ClineUsageStore.swift \
+    WindsurfUsageFetcher.swift \
+    WindsurfUsageStore.swift \
+    CursorUsageFetcher.swift \
+    CursorUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -65,6 +65,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     ClaudeCodePricing.swift \
     ClaudeCodeUsageFetcher.swift \
     ClaudeCodeUsageStore.swift \
+    ClineUsageFetcher.swift \
+    ClineUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -97,6 +99,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     ClaudeCodePricing.swift \
     ClaudeCodeUsageFetcher.swift \
     ClaudeCodeUsageStore.swift \
+    ClineUsageFetcher.swift \
+    ClineUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/build.sh
+++ b/app/build.sh
@@ -55,6 +55,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
     XAIUsageStore.swift \
     OpenAIUsageFetcher.swift \
     OpenAIUsageStore.swift \
+    PerplexityUsageFetcher.swift \
+    PerplexityUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \
@@ -77,6 +79,8 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
     XAIUsageStore.swift \
     OpenAIUsageFetcher.swift \
     OpenAIUsageStore.swift \
+    PerplexityUsageFetcher.swift \
+    PerplexityUsageStore.swift \
     -framework SwiftUI \
     -framework AppKit \
     -framework WebKit \

--- a/app/create_dmg.sh
+++ b/app/create_dmg.sh
@@ -70,13 +70,18 @@ echo "✅ DMG created: ${DMG_NAME}.dmg"
 DEVELOPER_ID="Developer ID Application: Linkko Technology Pte Ltd (Q467HQ5432)"
 NOTARY_PROFILE="claudeusagebar-notary"
 
-# Sign the DMG itself (the .app inside was already signed in build.sh)
+# Sign the DMG itself (the .app inside was already signed in build.sh).
+# Fail-fast on sign failure: an unsigned DMG will be rejected by notarytool
+# anyway, and the 5–15 min wait for that rejection is worse than aborting
+# here with a clear error. Matches the fail-fast policy in build.sh.
 echo ""
 echo "🔏 Signing DMG with Developer ID..."
 if codesign --force --sign "$DEVELOPER_ID" "${DMG_NAME}.dmg" 2>/dev/null; then
     echo "✅ DMG signed"
 else
-    echo "⚠️  DMG signing failed (continuing — Gatekeeper may reject)"
+    echo "❌ DMG signing failed — aborting before notarization." >&2
+    echo "   Fix the underlying cause (often: cert missing / expired, or stale xattrs on the DMG) and re-run." >&2
+    exit 1
 fi
 
 # Notarize


### PR DESCRIPTION
# PR 11-BE — Windsurf + Cursor backends (feature-flagged off)

Milestone 6 (v1.8.0), two providers landing together per EXPANSION_PLAN.md § Phase 8c/8d. Both reuse PR #66's `SQLiteReader` to parse a VS Code-style `state.vscdb`. Windsurf is pure-local; Cursor adds a live HTTP layer against Cursor's dashboard API with a full OAuth refresh state machine.

## What ships

### Windsurf (`app/WindsurfUsageFetcher.swift`, `app/WindsurfUsageStore.swift`)

Reads `~/Library/Application Support/Windsurf/User/globalStorage/state.vscdb` for the `windsurf.settings.cachedPlanInfo` row. Windsurf's plan-info payload has evolved twice — the fetcher handles BOTH shapes:

- **Older**: `quotaUsage.{daily,weekly}RemainingPercent` + `quotaUsage.{daily,weekly}ResetAtUnix`. Maps to explicit daily/weekly quota windows with reset times.
- **Newer**: `usage.{usedFlexCredits, flexCredits}` OR `usage.{usedMessages, remainingMessages}` OR `usage.{usedMessages, messages}`. Maps to a single "credits"/"messages" window with `endTimestamp` as reset.

Schema verified against `agentsystemlabs/mission-control` and `himanshu-nakrani/agent-tracker` (both ship-today OSS trackers reading the exact same file). Timestamps accept either seconds OR milliseconds (Windsurf's payloads mix them across releases).

Tiles: `windsurf-plan`, `windsurf-daily`/`windsurf-weekly`/`windsurf-credits` (bar), plus diagnostic tiles for `.needsAccess`, `.pathMissing`, `windsurf-schema-mismatch`, `windsurf-no-quota`, `windsurf-signin-needed`.

Live-endpoint (`windsurf.com/_backend/exa.seat_management_pb...`) intentionally deferred — protobuf Connect-RPC + Chromium leveldb cookies materially increase attack surface for a nice-to-have.

### Cursor (`app/CursorUsageFetcher.swift`, `app/CursorUsageStore.swift`)

Reads `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` for three rows (`cursorAuth/accessToken`, `cursorAuth/refreshToken`, `cursorAuth/stripeMembershipType`), then fetches live from Cursor's own dashboard API:

- **`GET https://cursor.com/api/usage-summary`** with `Cookie: WorkosCursorSessionToken=<accessToken value>`. Response shape verified against Raycast's `cursor-costs` extension (`extensions/cursor-costs/src/types.ts`): billing cycle bounds, `membershipType`, `individualUsage.plan.{used, limit, remaining, breakdown.{included, bonus, total}}` — every cents field is CENTS not dollars (`1207` = `$12.07`) — plus `individualUsage.onDemand.{enabled, used, limit?, remaining?}`.
- **`POST https://cursor.com/api/dashboard/get-aggregated-usage-events`** with `{teamId: -1, startDate: <ms>, endDate: <ms>}`. Response: `aggregations[].{modelIntent, inputTokens?, outputTokens?, cacheWriteTokens?, cacheReadTokens?, totalCents}`. Token counts are STRINGIFIED (Cursor sends them as strings to avoid JavaScript-Number precision loss on ≥ 2^53).
- **`POST https://api2.cursor.sh/oauth/token`** for refresh — client_id `KbZUR41cY7W6zRSdpSUJ7I7mLYBKOCmB` (Cursor's own OAuth client ID, in every OSS tracker; not a secret). Returns `{access_token, id_token, shouldLogout}`. CRITICAL: `shouldLogout: true` with empty tokens is HTTP 200 but the "your refresh token is dead, tell the user to log in again" signal — verified against a live probe of my own Cursor install.

State machine (per fetch tick): read credentials → GET summary → 2xx: chain aggregation → 401: refresh flow → refresh success: retry summary (`isRetry=true` so a second 401 goes straight to session-expired). Refresh token failures write to an in-memory access token (Cursor itself writes back to state.vscdb; a third-party writing there would race Cursor's own writes) with source-token tracking so a DB re-login invalidates the override.

Tiles: `cursor-plan`, `cursor-usage-mtd` (bar or text), `cursor-on-demand`, `cursor-per-model` (top-3 by cost). Diagnostic tiles for `.needsAccess`, `.pathMissing`, `cursor-session-expired`.

## Adversarial review

Three rounds of Codex `gpt-5.5` adversarial review addressed **13 findings** in total.

### Round 1 (6 findings)
1. **Windsurf** — malformed cachedPlanInfo blob was indistinguishable from a missing row; store stayed on "Loading…" forever. Fixed via new `WindsurfReadOutcome` enum (`success` / `rowMissing` / `malformedPayload`).
2. **Windsurf** — `WindsurfUsageParser.numeric` accepted JSON booleans (bridged NSNumber → `.doubleValue == 0/1`). `dailyRemainingPercent: false` silently mapped to 0% remaining (100% used). Fixed by rejecting `CFBoolean` before any numeric bridge.
3. **Cursor** — `parseUsageSummary` accepted `plan: null`/`plan: []`/`plan: 42` as valid, producing zero-cent snapshots rendered as success. Fixed by requiring `individualUsage.plan` to be an object; response fails to parse otherwise.
4. **Cursor** — `RequestSafety.headerValue` only rejects control chars; a token like `abc; WorkosCursorSessionToken=other` would splice a second cookie. Added new `CursorTokenSafety.isValidCookieValue` implementing RFC 6265 §4.1.1 cookie-octet validation.
5. **Cursor** — refreshed access token in-memory override persisted indefinitely even after Cursor wrote a fresh DB token (real re-login, account swap). Fixed by tracking `refreshedFromDbToken`; a mismatch drops the override.
6. **Cursor** — `sessionExpired` was sticky after re-sign-in if the next summary call hit 429/500/network. Fixed by tracking `sessionExpiredForDbToken`; a DB accessToken change clears the flag.

### Round 2 (3 findings)
1. **Cursor** — `formatTokens` used wrapping `&+` on Int64 aggregation totals; `Int64.max + 1` wrapped to `Int64.min` and then tripped `abs(Int.min)` in the formatter. Fixed via `saturatingAddInt64`.
2. **Cursor** — sticky `sessionExpired` was UI-only, not state-machine-aware; the timer kept sending the known-expired refresh token to Cursor every 60 seconds. Fixed by short-circuiting `fetch()` when `sessionExpired && DB token unchanged`.
3. **Cursor** — `safeInt`/`safeInt64`/`safeIntOptional` still accepted JSON booleans (same bug as round-1 #2 but on the Cursor helpers). Fixed by adding `CFBoolean` rejection to all three.

### Round 3 (4 findings)
1. **Windsurf** — row present with non-text value (NULL / blob / integer) collapsed to `.rowMissing` (permanent "Loading…") instead of `.malformedPayload`. Fixed by splitting row-present detection from value-decode in the fetcher.
2. **Windsurf** — `.rowMissing` still fell through to a "Loading…" tile forever. Added a distinct `rowMissing` observable state and a `windsurf-signin-needed` tile.
3. **Common** — `ClaudeCodeUsageStore.formatUSD` (shared by Windsurf + Cursor) trapped on `Int((amount * 100.0).rounded())` when the input was `1e300` / hostile huge Double. Fixed with `Int(exactly:)` guard + clamp to `Int.max`/`Int.min+1`.
4. **Cursor** — `Int64("9223372036854775808")` returns nil (Int64.max + 1). An oversized stringified token count silently disappeared. Fixed by clamping numeric-only positive strings to `Int64.max`.

Every finding has at least one matching regression test.

Total: **1302/1302 assertion checks pass** (baseline 1086 + 216 new). Both arches compile clean via `app/build.sh`. All six CI static-grep guards clean.

## Non-breaking guarantee

- [x] `features.windsurf.enabled` and `features.cursor.enabled` both default false; no `AppDelegate.providers.append(ProviderBox(…))` yet (that lands in PR 11-UI).
- [x] No existing provider touched.
- [x] `Package.swift` sources allow-list and `app/build.sh` compile lists updated to include the four new files.
- [x] All 6 CI static-grep guards pass locally — no credential (accessToken, refreshToken, cookie value) or response body ever reaches a log sink; only status codes go through `Log.info(.count)`.
- [x] Baseline 1086/1086 tests still pass; +216 new tests all pass (1302/1302 total).
- [x] Both arches (arm64 + x86_64) compile clean via `app/build.sh`.

## Reuses from prior PRs

- **PR #66**: `SQLiteReader` (both providers), `TCCProbe`, `LocalProviderAccessGuide`.
- **PR #67**: `ClaudeCodeUsageStore.formatUSD/formatTokens/todayRange/monthToDateRange`.
- **PR #70 (Cline audit cleanup)**: shared `formatUSD` overflow guard.

Co-Authored-By: Claude <noreply@anthropic.com>
