### PR TITLE
Popover header clipped in v1.3.2 — bug report + attempted light/dark fix (needs maintainer review)

### DIFF
--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -15,9 +15,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var hotKeyRef: EventHotKeyRef?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // The UI is designed for dark; force dark appearance regardless of the
-        // system light/dark setting (light mode had poor contrast).
-        NSApp.appearance = NSAppearance(named: .darkAqua)
+        // Follow the system light/dark setting. Contrast is kept consistent by the
+        // opaque, appearance-adaptive popover background (see UsageView.body),
+        // so there's no need to force a single appearance on every user.
 
         // NSUserNotification (deprecated but works without permissions for unsigned apps)
         NSLog("✅ App launched, notifications ready")
@@ -1444,9 +1444,10 @@ struct UsageView: View {
                     )
             }
             .frame(width: 360, height: min(max(measuredHeight, 100), maxPopupHeight))
-            // Darken the translucent popover material so contrast stays consistent
-            // no matter how light the content behind the popover is.
-            .background(Color(red: 0.07, green: 0.07, blue: 0.08).opacity(0.62))
+            // Opaque, appearance-adaptive backdrop so text contrast stays consistent
+            // no matter how light the content behind the popover is — and so the
+            // popover matches the user's light/dark system setting.
+            .background(Color(nsColor: .windowBackgroundColor))
             .onPreferenceChange(ContentHeightKey.self) { value in
                 guard value > 0 else { return }
                 measuredHeight = value


### PR DESCRIPTION
> **Please read this as a bug report + request, not a ready-to-merge PR.** We started out fixing one thing, hit a second (bigger) problem while testing, and couldn't fully root-cause it. Marking as draft. Details below in the spirit of full transparency.

## 1. What this started as (the diff)

Since **v1.3.2** the popover renders **dark text on a dark background** for users whose Mac is in **Light** mode — low contrast and muddy. `a9b0c3a` ("forced dark UI") added:

- `NSApp.appearance = NSAppearance(named: .darkAqua)` — forces dark globally, and
- `.background(Color(red: 0.07, green: 0.07, blue: 0.08).opacity(0.62))` — a hardcoded dark backdrop.

Setting `NSApp.appearance` doesn't reliably reach the `NSPopover`'s SwiftUI content, so on Light mode the adaptive text stays dark → dark-on-dark.

The 2-line diff here follows the system appearance again and uses the opaque, adaptive `windowBackgroundColor`. It builds clean via `app/build.sh`.

## 2. ⚠️ The new problem we ran into (the real reason this is a draft)

While testing a build with this change, we found the popover's **top gets cut off**: the **"Claude Usage" header and the Session (5-hour) bar render above the top of the screen** — you only see from the Weekly bar downward. Reproduced repeatedly (screenshotted).

What we were able to rule out through local testing:

- **Not a scroll-position issue** — forcing the scroll view to the top on appear had **zero effect**.
- **Not the `maxPopupHeight = 600` cap** — raising it to the screen height had **zero effect**.

So it appears the **popover window itself is being positioned with its top above the screen**, not the content scrolling within it.

## 3. What we could NOT determine

Whether this clipping is **caused by this appearance change** or is a **pre-existing v1.3.2 issue** (the taller content added in 1.3.2). Reasoning says a background color + an appearance flag can't move a window, but we couldn't get a clean A/B comparison: building an unsigned/ad-hoc copy of the *official* 1.3.2 kept triggering the Accessibility permission prompt (different code signature), which blocked the popover during the comparison run.

## 4. The ask

You can build and debug this interactively — we can't from the outside with confidence. Could you:

1. Confirm the header-clipping in v1.3.2, and
2. Fix the popover positioning properly?

Feel free to **close or hold this PR** — the appearance/contrast change is secondary to the clipping bug, and we'd rather flag what we observed honestly than merge something unverified. Thanks for keeping the app open source. 🙏