### PR TITLE
Add live reset countdown and usage pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A lightweight, open-source macOS menu bar application that displays your Claude.
 ## ✨ Features
 
 - 🟢 **Real-time usage tracking** - Monitor session (5-hour) and weekly (7-day) limits
+- ⏱️ **Live reset pacing** - See time remaining and compare usage with elapsed reset-window time
 - 🎨 **Color-coded menu bar icon** - Visual spark icon that changes color (green/yellow/red)
 - 🔔 **Smart notifications** - Alerts at 25%, 50%, 75%, 90% usage thresholds
 - ⌨️ **Keyboard shortcut** - Toggle popup with Cmd+U from anywhere
@@ -51,8 +52,8 @@ A lightweight, open-source macOS menu bar application that displays your Claude.
 ```
 
 **Popup Interface:**
-- Session (5-hour) usage with progress bar
-- Weekly (7-day) usage with progress bar
+- Session (5-hour) usage with a live reset countdown and proportional time marker
+- Weekly (7-day) usage with a live reset countdown and proportional time marker
 - Weekly Sonnet usage (Pro plan only)
 - Settings for notifications and shortcuts
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A lightweight, open-source macOS menu bar application that displays your Claude.
 ## ✨ Features
 
 - 🟢 **Real-time usage tracking** - Monitor session (5-hour) and weekly (7-day) limits
-- ⏱️ **Live reset pacing** - See time remaining and compare usage with elapsed reset-window time
+- ⏱️ **Live reset pacing** - See time remaining in the popup and menu bar, and compare usage with elapsed reset-window time
 - 🎨 **Color-coded menu bar icon** - Visual spark icon that changes color (green/yellow/red)
 - 🔔 **Smart notifications** - Alerts at 25%, 50%, 75%, 90% usage thresholds
 - ⌨️ **Keyboard shortcut** - Toggle popup with Cmd+U from anywhere

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -44,8 +44,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Create popover
         popover = NSPopover()
-        // Initial guess; SwiftUI's intrinsic size (capped at 600) will drive the actual size.
-        popover.contentSize = NSSize(width: 360, height: 320)
+        popover.contentSize = NSSize(width: 360, height: activeScreenPopupHeightLimit())
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(rootView: UsageView(
             usageManager: usageManager,
@@ -62,6 +61,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
             self.usageManager.fetchUsage()
             self.statusManager.fetch()
+        }
+
+        // Keep the status-bar countdown current without making extra API requests.
+        Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in
+            self.usageManager.refreshStatusDisplay()
         }
 
         // App updates are infrequent (new release at most weekly) — poll every 3 hours.
@@ -209,6 +213,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func openPopover() {
         if let button = statusItem.button {
+            // Size the viewport for the screen containing the status item before
+            // anchoring it, so the popover never grows beyond the visible area.
+            popover.contentSize = NSSize(width: 360, height: activeScreenPopupHeightLimit())
+
             // Force UI refresh by updating percentages
             DispatchQueue.main.async {
                 self.usageManager.updatePercentages()
@@ -235,7 +243,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func updateStatusIcon(percentage: Int) {
+    func updateStatusIcon(percentage: Int, resetDate: Date? = nil, now: Date = Date()) {
         guard let button = statusItem.button else { return }
 
         // Determine color based on percentage
@@ -253,7 +261,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Set image and title
         button.image = sparkIcon
-        button.title = " \(percentage)%"
+        if let resetDate {
+            button.title = " \(percentage)% · \(UsagePace.compactRemainingText(until: resetDate, now: now))"
+        } else {
+            button.title = " \(percentage)%"
+        }
     }
 
     func createSparkIcon(color: NSColor) -> NSImage {
@@ -795,11 +807,19 @@ class UsageManager: ObservableObject {
     func updateStatusBar() {
         let sessionPercent = Int((Double(sessionUsage) / Double(sessionLimit)) * 100)
 
-        // Update the icon color
-        delegate?.updateStatusIcon(percentage: sessionPercent)
+        refreshStatusDisplay()
 
         // Check for notification thresholds
         checkNotificationThresholds(percentage: sessionPercent)
+    }
+
+    func refreshStatusDisplay(now: Date = Date()) {
+        let sessionPercent = Int((Double(sessionUsage) / Double(sessionLimit)) * 100)
+        delegate?.updateStatusIcon(
+            percentage: sessionPercent,
+            resetDate: sessionResetsAt,
+            now: now
+        )
     }
 
     func checkNotificationThresholds(percentage: Int) {
@@ -1413,11 +1433,11 @@ struct PasteableTextField: NSViewRepresentable {
     }
 }
 
-private struct ContentHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
+private func activeScreenPopupHeightLimit() -> CGFloat {
+    let pointer = NSEvent.mouseLocation
+    let screen = NSScreen.screens.first { NSMouseInRect(pointer, $0.frame, false) } ?? NSScreen.main
+    let visibleHeight = screen?.visibleFrame.height ?? 600
+    return min(520, max(260, visibleHeight - 32))
 }
 
 private struct UsagePaceBar: View {
@@ -1540,40 +1560,37 @@ struct UsageView: View {
     @State private var showingCookieInput: Bool = false
     @State private var showingSettings: Bool = false
     @State private var showingStatusDetails: Bool = false
-    @State private var measuredHeight: CGFloat = 250
-
-    private let maxPopupHeight: CGFloat = 600
 
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 content
                     .padding()
-                    .background(
-                        GeometryReader { geo in
-                            Color.clear.preference(key: ContentHeightKey.self, value: geo.size.height)
-                        }
-                    )
             }
-            .frame(width: 360, height: min(max(measuredHeight, 100), maxPopupHeight))
+            .frame(width: 360, height: activeScreenPopupHeightLimit())
             // Darken the translucent popover material so contrast stays consistent
             // no matter how light the content behind the popover is.
             .background(Color(red: 0.07, green: 0.07, blue: 0.08).opacity(0.62))
-            .onPreferenceChange(ContentHeightKey.self) { value in
-                guard value > 0 else { return }
-                measuredHeight = value
-            }
             .onAppear {
                 if let savedCookie = UserDefaults.standard.string(forKey: "claude_session_cookie") {
                     sessionCookieInput = String(savedCookie.prefix(20)) + "..."
                 }
                 usageManager.updatePercentages()
+                DispatchQueue.main.async {
+                    proxy.scrollTo("usage-top", anchor: .top)
+                }
             }
             .onChange(of: showingSettings) { isOpen in
                 if isOpen {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                         withAnimation(.easeInOut(duration: 0.35)) {
                             proxy.scrollTo("settings-anchor", anchor: .bottom)
+                        }
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            proxy.scrollTo("usage-top", anchor: .top)
                         }
                     }
                 }
@@ -1586,6 +1603,7 @@ struct UsageView: View {
             Text("Claude Usage")
                 .font(.headline)
                 .padding(.bottom, 4)
+                .id("usage-top")
 
             // Free-form message banner (author-controlled). Takes priority over
             // the version-update banner when both are present.

--- a/app/ClaudeUsageBar.swift
+++ b/app/ClaudeUsageBar.swift
@@ -1420,6 +1420,118 @@ private struct ContentHeightKey: PreferenceKey {
     }
 }
 
+private struct UsagePaceBar: View {
+    let usageFraction: Double
+    let elapsedFraction: Double
+    let usageColor: Color
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let clampedUsage = min(max(usageFraction, 0), 1)
+            let clampedElapsed = min(max(elapsedFraction, 0), 1)
+            let markerOffset = min(max((width * clampedElapsed) - 1, 0), max(width - 2, 0))
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.secondary.opacity(0.22))
+                Capsule()
+                    .fill(usageColor)
+                    .frame(width: width * clampedUsage)
+                Rectangle()
+                    .fill(Color.white.opacity(0.95))
+                    .frame(width: 2, height: 10)
+                    .offset(x: markerOffset)
+            }
+        }
+        .frame(height: 8)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "Usage \(Int((usageFraction * 100).rounded())) percent, " +
+            "time marker \(Int((elapsedFraction * 100).rounded())) percent"
+        )
+    }
+}
+
+private struct UsageLimitRow: View {
+    let title: String
+    let usageFraction: Double
+    let resetDate: Date?
+    let window: TimeInterval
+
+    private var usageColor: Color {
+        if usageFraction < 0.7 { return .green }
+        if usageFraction < 0.9 { return .orange }
+        return .red
+    }
+
+    private func paceLabel(_ status: UsagePaceStatus) -> String {
+        switch status {
+        case .underPace: return "Under pace"
+        case .onPace: return "On pace"
+        case .overPace: return "Over pace"
+        }
+    }
+
+    private func paceColor(_ status: UsagePaceStatus) -> Color {
+        switch status {
+        case .underPace: return .green
+        case .onPace: return .blue
+        case .overPace: return .orange
+        }
+    }
+
+    var body: some View {
+        TimelineView(.periodic(from: Date(), by: 60)) { context in
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(title)
+                        .font(.subheadline)
+                    Spacer()
+                    if let resetDate {
+                        Text(UsagePace.remainingText(until: resetDate, now: context.date))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                if let resetDate {
+                    let elapsedFraction = UsagePace.elapsedFraction(
+                        until: resetDate,
+                        window: window,
+                        now: context.date
+                    )
+                    let status = UsagePace.status(
+                        usageFraction: usageFraction,
+                        elapsedFraction: elapsedFraction
+                    )
+
+                    UsagePaceBar(
+                        usageFraction: usageFraction,
+                        elapsedFraction: elapsedFraction,
+                        usageColor: usageColor
+                    )
+
+                    HStack {
+                        Text("\(Int((usageFraction * 100).rounded()))% used")
+                        Spacer()
+                        Text("Time \(Int((elapsedFraction * 100).rounded()))% · \(paceLabel(status))")
+                            .foregroundColor(paceColor(status))
+                    }
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                } else {
+                    ProgressView(value: usageFraction)
+                        .tint(usageColor)
+                    Text("\(Int((usageFraction * 100).rounded()))% used")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+}
+
 struct UsageView: View {
     @ObservedObject var usageManager: UsageManager
     @ObservedObject var statusManager: StatusManager
@@ -1569,92 +1681,40 @@ struct UsageView: View {
 
             // Session Usage
             if usageManager.hasFetchedData {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text("Session (5 hour)")
-                        .font(.subheadline)
-                    Spacer()
-                    if let resetTime = usageManager.sessionResetsAt {
-                        Text("Resets \(formatResetTime(resetTime))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                ProgressView(value: usageManager.sessionPercentage)
-                    .tint(colorForPercentage(usageManager.sessionPercentage))
-
-                Text("\(Int(usageManager.sessionPercentage * 100))% used")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+            UsageLimitRow(
+                title: "Session (5 hour)",
+                usageFraction: usageManager.sessionPercentage,
+                resetDate: usageManager.sessionResetsAt,
+                window: 5 * 60 * 60
+            )
 
             // Weekly Usage
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text("Weekly (7 day)")
-                        .font(.subheadline)
-                    Spacer()
-                    if let resetTime = usageManager.weeklyResetsAt {
-                        Text("Resets \(formatResetTime(resetTime, includeDate: true))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                ProgressView(value: usageManager.weeklyPercentage)
-                    .tint(colorForPercentage(usageManager.weeklyPercentage))
-
-                Text("\(Int(usageManager.weeklyPercentage * 100))% used")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+            UsageLimitRow(
+                title: "Weekly (7 day)",
+                usageFraction: usageManager.weeklyPercentage,
+                resetDate: usageManager.weeklyResetsAt,
+                window: 7 * 24 * 60 * 60
+            )
 
             // Weekly Sonnet Usage (only show if available)
             if usageManager.hasWeeklySonnet && usageManager.hasFetchedData {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("Weekly Sonnet (7 day)")
-                            .font(.subheadline)
-                        Spacer()
-                        if let resetTime = usageManager.weeklySonnetResetsAt {
-                            Text("Resets \(formatResetTime(resetTime, includeDate: true))")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-
-                    ProgressView(value: usageManager.weeklySonnetPercentage)
-                        .tint(colorForPercentage(usageManager.weeklySonnetPercentage))
-
-                    Text("\(Int(usageManager.weeklySonnetPercentage * 100))% used")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                UsageLimitRow(
+                    title: "Weekly Sonnet (7 day)",
+                    usageFraction: usageManager.weeklySonnetPercentage,
+                    resetDate: usageManager.weeklySonnetResetsAt,
+                    window: 7 * 24 * 60 * 60
+                )
             }
 
             // Weekly Fable Usage — only surfaced once usage is above 1%
             // (new model, counted separately; hidden while idle to avoid clutter).
             if usageManager.hasWeeklyFable && usageManager.hasFetchedData && usageManager.weeklyFableUsage >= 1 {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text("Weekly Fable (7 day)")
-                            .font(.subheadline)
-                        Spacer()
-                        if let resetTime = usageManager.weeklyFableResetsAt {
-                            Text("Resets \(formatResetTime(resetTime, includeDate: true))")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-
-                    ProgressView(value: usageManager.weeklyFablePercentage)
-                        .tint(colorForPercentage(usageManager.weeklyFablePercentage))
-
-                    Text("\(Int(usageManager.weeklyFablePercentage * 100))% used")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                UsageLimitRow(
+                    title: "Weekly Fable (7 day)",
+                    usageFraction: usageManager.weeklyFablePercentage,
+                    resetDate: usageManager.weeklyFableResetsAt,
+                    window: 7 * 24 * 60 * 60
+                )
             }
 
             // Usage credits (pay-as-you-go). Only shown once credits are actually
@@ -2131,20 +2191,6 @@ struct UsageView: View {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         return formatter.string(from: date)
-    }
-
-    func formatResetTime(_ date: Date, includeDate: Bool = false) -> String {
-        let formatter = DateFormatter()
-
-        if includeDate {
-            // Format: "on 31 Jan 2026 at 7:59 AM"
-            formatter.dateFormat = "d MMM yyyy 'at' h:mm a"
-            return "on \(formatter.string(from: date))"
-        } else {
-            formatter.timeStyle = .short
-            formatter.dateStyle = .none
-            return "at \(formatter.string(from: date))"
-        }
     }
 
     func colorForPercentage(_ percentage: Double) -> Color {

--- a/app/README.md
+++ b/app/README.md
@@ -7,6 +7,7 @@ A lightweight macOS menu bar app that displays your Claude.ai session and weekly
 ## ✨ Features
 
 - 🟢 **Real-time Usage Tracking**: Monitor session (5-hour) and weekly (7-day) usage
+- ⏱️ **Live Reset Pacing**: See time remaining and whether usage is under, on, or over pace
 - 🎨 **Color-Coded Menu Bar Icon**: Visual indication of usage levels (green/yellow/red)
 - 🔔 **Smart Notifications**: Alerts at 25%, 50%, 75%, and 90% usage thresholds
 - ⚡ **Auto-Refresh**: Updates every 5 minutes automatically
@@ -22,8 +23,8 @@ A lightweight macOS menu bar app that displays your Claude.ai session and weekly
 - Example: `🟢 45%` (green < 70%, yellow 70-90%, red > 90%)
 
 **Popup Interface:**
-- Session (5-hour) usage with progress bar and reset time
-- Weekly (7-day) usage with progress bar and reset date
+- Session (5-hour) usage with a live countdown and elapsed-time marker
+- Weekly (7-day) usage with a live countdown and elapsed-time marker
 - Weekly Sonnet usage (Pro plan only)
 - Settings for notifications and keyboard shortcuts
 
@@ -118,6 +119,12 @@ Access settings by clicking the gear icon in the popup:
 ### Build the App
 ```bash
 ./build.sh
+```
+
+### Run Pace Logic Tests
+```bash
+swiftc -parse-as-library ResetPace.swift ResetPaceTests.swift -o /tmp/claudeusagebar-reset-pace-tests
+/tmp/claudeusagebar-reset-pace-tests
 ```
 
 ### Create DMG Installer

--- a/app/README.md
+++ b/app/README.md
@@ -7,7 +7,7 @@ A lightweight macOS menu bar app that displays your Claude.ai session and weekly
 ## ✨ Features
 
 - 🟢 **Real-time Usage Tracking**: Monitor session (5-hour) and weekly (7-day) usage
-- ⏱️ **Live Reset Pacing**: See time remaining and whether usage is under, on, or over pace
+- ⏱️ **Live Reset Pacing**: See time remaining in the popup and menu bar, plus whether usage is under, on, or over pace
 - 🎨 **Color-Coded Menu Bar Icon**: Visual indication of usage levels (green/yellow/red)
 - 🔔 **Smart Notifications**: Alerts at 25%, 50%, 75%, and 90% usage thresholds
 - ⚡ **Auto-Refresh**: Updates every 5 minutes automatically

--- a/app/ResetPace.swift
+++ b/app/ResetPace.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum UsagePaceStatus: Equatable {
+    case underPace
+    case onPace
+    case overPace
+}
+
+enum UsagePace {
+    static func remainingText(until resetDate: Date, now: Date = Date()) -> String {
+        guard resetDate > now else { return "Resetting now" }
+        let totalMinutes = max(0, Int(ceil(resetDate.timeIntervalSince(now) / 60)))
+        if totalMinutes >= 24 * 60 {
+            let days = totalMinutes / (24 * 60)
+            let hours = (totalMinutes % (24 * 60)) / 60
+            return "\(days)d \(hours)h remaining"
+        }
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        return "\(hours)h \(minutes)m remaining"
+    }
+
+    static func elapsedFraction(
+        until resetDate: Date,
+        window: TimeInterval,
+        now: Date = Date()
+    ) -> Double {
+        min(max(1 - (resetDate.timeIntervalSince(now) / window), 0), 1)
+    }
+
+    static func status(usageFraction: Double, elapsedFraction: Double) -> UsagePaceStatus {
+        if usageFraction > elapsedFraction + 0.05 { return .overPace }
+        if usageFraction < elapsedFraction - 0.05 { return .underPace }
+        return .onPace
+    }
+}

--- a/app/ResetPace.swift
+++ b/app/ResetPace.swift
@@ -20,6 +20,14 @@ enum UsagePace {
         return "\(hours)h \(minutes)m remaining"
     }
 
+    static func compactRemainingText(until resetDate: Date, now: Date = Date()) -> String {
+        guard resetDate > now else { return "now" }
+        let totalMinutes = max(1, Int(ceil(resetDate.timeIntervalSince(now) / 60)))
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        return "\(hours)h\(minutes)m"
+    }
+
     static func elapsedFraction(
         until resetDate: Date,
         window: TimeInterval,

--- a/app/ResetPaceTests.swift
+++ b/app/ResetPaceTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+private func expectEqual<T: Equatable>(_ actual: T, _ expected: T, _ message: String) {
+    guard actual == expected else {
+        fputs("FAIL: \(message) — expected \(expected), got \(actual)\n", stderr)
+        exit(1)
+    }
+}
+
+@main
+struct ResetPaceTests {
+    static func main() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval((3 * 60 * 60) + (12 * 60))
+
+        expectEqual(
+            UsagePace.remainingText(until: reset, now: now),
+            "3h 12m remaining",
+            "session countdown includes hours and minutes"
+        )
+
+        let weeklyReset = now.addingTimeInterval((2 * 24 * 60 * 60) + (4 * 60 * 60))
+        expectEqual(
+            UsagePace.remainingText(until: weeklyReset, now: now),
+            "2d 4h remaining",
+            "weekly countdown uses compact days and hours"
+        )
+
+        expectEqual(
+            UsagePace.remainingText(until: now.addingTimeInterval(-1), now: now),
+            "Resetting now",
+            "elapsed reset dates never show a negative countdown"
+        )
+
+        let fiveHours = TimeInterval(5 * 60 * 60)
+        expectEqual(
+            UsagePace.elapsedFraction(
+                until: now.addingTimeInterval(fiveHours / 2),
+                window: fiveHours,
+                now: now
+            ),
+            0.5,
+            "half of a reset window is represented proportionally"
+        )
+
+        expectEqual(
+            UsagePace.elapsedFraction(
+                until: now.addingTimeInterval(fiveHours * 2),
+                window: fiveHours,
+                now: now
+            ),
+            0,
+            "elapsed proportion is clamped before the window begins"
+        )
+        expectEqual(
+            UsagePace.elapsedFraction(
+                until: now.addingTimeInterval(-60),
+                window: fiveHours,
+                now: now
+            ),
+            1,
+            "elapsed proportion is clamped after the window ends"
+        )
+
+        expectEqual(
+            UsagePace.status(usageFraction: 0.70, elapsedFraction: 0.50),
+            .overPace,
+            "usage materially ahead of elapsed time is over pace"
+        )
+        expectEqual(
+            UsagePace.status(usageFraction: 0.30, elapsedFraction: 0.50),
+            .underPace,
+            "usage materially behind elapsed time is under pace"
+        )
+        expectEqual(
+            UsagePace.status(usageFraction: 0.52, elapsedFraction: 0.50),
+            .onPace,
+            "small usage and time differences remain on pace"
+        )
+    }
+}

--- a/app/ResetPaceTests.swift
+++ b/app/ResetPaceTests.swift
@@ -19,6 +19,12 @@ struct ResetPaceTests {
             "session countdown includes hours and minutes"
         )
 
+        expectEqual(
+            UsagePace.compactRemainingText(until: reset, now: now),
+            "3h12m",
+            "menu bar countdown stays compact"
+        )
+
         let weeklyReset = now.addingTimeInterval((2 * 24 * 60 * 60) + (4 * 60 * 60))
         expectEqual(
             UsagePace.remainingText(until: weeklyReset, now: now),

--- a/app/build.sh
+++ b/app/build.sh
@@ -35,6 +35,7 @@ fi
 
 # Compile the Swift app for arm64
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
+    ResetPace.swift \
     ClaudeUsageBar.swift \
     -framework SwiftUI \
     -framework AppKit \
@@ -43,6 +44,7 @@ swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_arm64" \
 
 # Compile for x86_64 (Intel)
 swiftc -parse-as-library -o "$APP_PATH/Contents/MacOS/ClaudeUsageBar_x86_64" \
+    ResetPace.swift \
     ClaudeUsageBar.swift \
     -framework SwiftUI \
     -framework AppKit \


### PR DESCRIPTION
## What changed

- replace static reset timestamps with compact live countdowns that update every minute
- show the session reset countdown beside the menu-bar usage percentage while the popup is idle
- overlay an elapsed-time marker on each usage bar so usage can be compared proportionally with the reset window
- label each limit as under, on, or over pace with a five-percentage-point tolerance
- apply the indicator to session, weekly, weekly Sonnet, and weekly Fable limits
- constrain the popup to the active screen and restore its top scroll position after Settings closes
- extract deterministic reset and pace calculations into a small tested Swift module
- update build inputs and documentation for the new behavior

## Why

An absolute reset timestamp shows when a limit resets, but it does not make it easy to judge whether current usage is sustainable. The time marker and pace label make that comparison visible without additional Claude API requests. A fixed, screen-aware viewport also prevents the dynamically growing popup from extending beyond the display edge.

## Validation

- pace-logic executable tests pass
- app compiles for `arm64-apple-macos12.0`
- app compiles for `x86_64-apple-macos12.0`

The compiler still reports the repository's existing `NSUserNotification` deprecation warnings; this change introduces no new warnings.
